### PR TITLE
Align GitHub issue labels and templates with GitLab triage

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,18 +1,33 @@
 name: Bug report
 description: Report a defect or broken behavior
 title: "[Bug]: "
-labels: ["bug"]
 body:
+  - type: dropdown
+    id: issue_type
+    attributes:
+      label: Issue type (label)
+      description: These values match the GitLab label set used for Horizon Suite triage.
+      options:
+        - "[Enhancement] Improvement"
+        - "[Enhancement] Feature"
+        - "[Enhancement] Localization"
+    validations:
+      required: true
+
   - type: dropdown
     id: module
     attributes:
-      label: Module
-      description: Which part of Horizon Suite is affected?
+      label: Module (label)
+      description: Pick the closest module label.
       options:
-        - Focus (quest/objective tracker)
-        - Presence (notifications, zone text)
-        - Core (options, general)
-        - Unknown
+        - "[Module] Focus"
+        - "[Module] Presence"
+        - "[Module] Vista"
+        - "[Module] Cache"
+        - "[Module] Essence"
+        - "[Module] Insight"
+        - "[Module] Flow"
+        - "[Module] Axis"
     validations:
       required: true
 

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,17 +1,33 @@
 name: Feature request
 description: Suggest a new capability
 title: "[Feature]: "
-labels: ["feature"]
 body:
+  - type: dropdown
+    id: issue_type
+    attributes:
+      label: Issue type (label)
+      description: These values match the GitLab label set used for Horizon Suite triage.
+      options:
+        - "[Enhancement] Feature"
+        - "[Enhancement] Improvement"
+        - "[Enhancement] Localization"
+    validations:
+      required: true
+
   - type: dropdown
     id: module
     attributes:
-      label: Module
-      description: Which part of Horizon Suite would this apply to?
+      label: Module (label)
+      description: Pick the closest module label.
       options:
-        - Focus (quest/objective tracker)
-        - Presence (notifications, zone text)
-        - Core (options, general)
+        - "[Module] Focus"
+        - "[Module] Presence"
+        - "[Module] Vista"
+        - "[Module] Cache"
+        - "[Module] Essence"
+        - "[Module] Insight"
+        - "[Module] Flow"
+        - "[Module] Axis"
     validations:
       required: true
 

--- a/.github/workflows/relabel-issues.yml
+++ b/.github/workflows/relabel-issues.yml
@@ -26,17 +26,24 @@ jobs:
             if (!openMatch) throw new Error('Could not find Open Items section');
             const lines = openMatch[1].split('\n').filter(l => /^\s*-\s*`(BUG|FEAT|IMPR|IDEA|MOD|DOC)`/.test(l));
 
-            const typeMap = { BUG: 'bug', FEAT: 'feature', MOD: 'feature', IMPR: 'improvement', IDEA: 'idea', DOC: 'improvement' };
-            const priorityMap = { P0: 'Priority 0', P1: 'Priority 1', P2: 'Priority 2' };
+            const typeMap = {
+              BUG: '[Enhancement] Improvement',
+              FEAT: '[Enhancement] Feature',
+              MOD: '[Enhancement] Feature',
+              IMPR: '[Enhancement] Improvement',
+              IDEA: '[Enhancement] Feature',
+              DOC: '[Enhancement] Localization',
+            };
+            const priorityMap = { P0: '[Status] Logged', P1: '[Status] Logged', P2: '[Status] Logged' };
 
             const pipelineItems = lines.map(line => {
               const tagMatch = line.match(/`(BUG|FEAT|IMPR|IDEA|MOD|DOC)`/);
               const priMatch = line.match(/\[(P[012])\]/);
-              const modMatch = line.match(/`\[(Focus|Presence|Vista)\]`/);
+              const modMatch = line.match(/`\[(Focus|Presence|Vista|Cache|Essence|Insight|Flow|Axis)\]`/);
               return {
                 type: typeMap[tagMatch ? tagMatch[1] : 'FEAT'],
-                priority: priMatch ? priorityMap[priMatch[1]] : 'Priority 2',
-                module: modMatch ? modMatch[1] : null,
+                priority: priMatch ? priorityMap[priMatch[1]] : '[Status] Logged',
+                module: modMatch ? `[Module] ${modMatch[1]}` : null,
               };
             });
 

--- a/.github/workflows/setup-labels.yml
+++ b/.github/workflows/setup-labels.yml
@@ -11,6 +11,9 @@ jobs:
   create-labels:
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
       - name: Delete deprecated labels
         uses: actions/github-script@v7
         with:
@@ -21,6 +24,9 @@ jobs:
               'module:Vista', 'module:Cache', 'module:Pulse',
               'module:Essence', 'module:Insight', 'module:Verse',
               'priority:P0', 'priority:P1', 'priority:P2',
+              'bug', 'feature', 'improvement', 'idea',
+              'Focus', 'Presence', 'Core', 'Vista', 'Cache', 'Pulse', 'Essence', 'Insight', 'Verse',
+              'Priority 0', 'Priority 1', 'Priority 2',
             ];
             for (const name of toDelete) {
               try {
@@ -36,32 +42,21 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const labels = [
-              { name: 'bug', description: 'Defect / broken behavior', color: 'd73a4a' },
-              { name: 'feature', description: 'New capability', color: 'a2eeef' },
-              { name: 'improvement', description: 'Enhancement to existing functionality', color: '84b6eb' },
-              { name: 'idea', description: 'Speculative / backlog', color: 'fef2c0' },
-              { name: 'Focus', description: 'Focus tracker module', color: '1d76db' },
-              { name: 'Presence', description: 'Presence notification module', color: '1d76db' },
-              { name: 'Core', description: 'Core addon / options / general', color: '1d76db' },
-              { name: 'Vista', description: 'Vista / minimap module', color: '1d76db' },
-              { name: 'Cache', description: 'Cache / loot module', color: '1d76db' },
-              { name: 'Pulse', description: 'Pulse / combat module', color: '1d76db' },
-              { name: 'Essence', description: 'Essence / unit frames module', color: '1d76db' },
-              { name: 'Insight', description: 'Insight / tooltips module', color: '1d76db' },
-              { name: 'Verse', description: 'Verse / chat module', color: '1d76db' },
-              { name: 'Priority 0', description: 'Major / blocking', color: 'b60205' },
-              { name: 'Priority 1', description: 'Minor / next', color: 'fbca04' },
-              { name: 'Priority 2', description: 'Patch / low', color: '0e8a16' },
-            ];
+            const fs = require('fs');
+            const path = require('path');
+            const catalogPath = path.join(process.env.GITHUB_WORKSPACE, 'tools', 'gitlab-label-catalog.json');
+            const raw = fs.readFileSync(catalogPath, 'utf8');
+            const labels = JSON.parse(raw);
             for (const label of labels) {
+              const description = label.description || '';
+              const color = String(label.color || 'ededed').replace('#', '');
               try {
                 await github.rest.issues.createLabel({
                   owner: context.repo.owner,
                   repo: context.repo.repo,
                   name: label.name,
-                  description: label.description,
-                  color: label.color.replace('#', ''),
+                  description,
+                  color,
                 });
                 console.log(`Created label: ${label.name}`);
               } catch (err) {
@@ -70,8 +65,8 @@ jobs:
                     owner: context.repo.owner,
                     repo: context.repo.repo,
                     name: label.name,
-                    description: label.description,
-                    color: label.color.replace('#', ''),
+                    description,
+                    color,
                   });
                   console.log(`Updated label: ${label.name}`);
                 } else {

--- a/.gitignore
+++ b/.gitignore
@@ -28,5 +28,7 @@ docs/
 .luacheckrc
 tools/pipeline-viewer.html
 tools/serve-pipeline.ps1
+tools/gitlab-issues-dry-run.json
+tools/gitlab-issues-dry-run-example.json
 /wowapi/
 assets\social

--- a/tools/README.md
+++ b/tools/README.md
@@ -10,13 +10,16 @@ Scripts for **localisation** maintenance and project administration. Run from th
 | `locale-meta/` | Optional per-locale validation metadata (see `locale-meta/README.md`) |
 | `archived/` | **Historical** one-off migrations — do not use in normal workflow |
 | `color-palette-review.html` | Local HTML preview of the Focus colour palette for design review |
+| `gitlab_issue_dry_run.js` | Preview GitLab -> GitHub issue drafts without creating anything |
+| `gitlab-label-catalog.json` | GitLab-parity label catalog for GitHub (generated/updated by `gitlab_issue_dry_run.js`) |
 | `migrate-pipeline-to-issues.ps1` | Bulk-create GitHub Issues from `pipeline.md` Open Items (`gh` CLI) |
-| `setup-labels.ps1` | Create GitHub issue labels via `gh` CLI |
+| `setup-labels.ps1` | Create/update GitHub issue labels via `gh` CLI (reads `gitlab-label-catalog.json`) |
 
 ## Everyday commands
 
 | Script | Command | When |
 |--------|---------|------|
+| GitLab issue migration preview | `node tools/gitlab_issue_dry_run.js` | Before importing GitLab issues into GitHub; writes `tools/gitlab-issues-dry-run.json` and refreshes `tools/gitlab-label-catalog.json` |
 | Sync locale files to `enUS` order | `node tools/restructure_locales.js` | Rewrites `enUS.lua` format (no per-key `-- Context:`; no blank lines between keys; pads spaces so `=` and values align in one column from the longest `L["KEY"]`), then regenerates other locales; strips assignments that duplicate enUS (commented-out `-- L["KEY"] = …` so runtime uses `__index` fallback) |
 | Coverage check | `node tools/locale_audit.js --strict` | Before merge requests (same as CI `locale-check`); strict = every key has a row; coverage counts only strings that differ from enUS |
 | Optional key metadata | `node tools/locale_validate.js <locale> <KEY>` or `… --all-unvalidated` | Reviewer workflow |

--- a/tools/gitlab-label-catalog.json
+++ b/tools/gitlab-label-catalog.json
@@ -1,0 +1,62 @@
+[
+  {
+    "name": "[Enhancement] Feature",
+    "color": "a2eeef",
+    "description": "GitLab label (parity)"
+  },
+  {
+    "name": "[Enhancement] Improvement",
+    "color": "84b6eb",
+    "description": "GitLab label (parity)"
+  },
+  {
+    "name": "[Enhancement] Localization",
+    "color": "c5def5",
+    "description": "GitLab label (parity)"
+  },
+  {
+    "name": "[Module] Axis",
+    "color": "1d76db",
+    "description": "GitLab label (parity)"
+  },
+  {
+    "name": "[Module] Cache",
+    "color": "1d76db",
+    "description": "GitLab label (parity)"
+  },
+  {
+    "name": "[Module] Essence",
+    "color": "1d76db",
+    "description": "GitLab label (parity)"
+  },
+  {
+    "name": "[Module] Flow",
+    "color": "1d76db",
+    "description": "GitLab label (parity)"
+  },
+  {
+    "name": "[Module] Focus",
+    "color": "1d76db",
+    "description": "GitLab label (parity)"
+  },
+  {
+    "name": "[Module] Insight",
+    "color": "1d76db",
+    "description": "GitLab label (parity)"
+  },
+  {
+    "name": "[Module] Presence",
+    "color": "1d76db",
+    "description": "GitLab label (parity)"
+  },
+  {
+    "name": "[Module] Vista",
+    "color": "1d76db",
+    "description": "GitLab label (parity)"
+  },
+  {
+    "name": "[Status] Logged",
+    "color": "d4c5f9",
+    "description": "GitLab label (parity)"
+  }
+]

--- a/tools/gitlab_issue_dry_run.js
+++ b/tools/gitlab_issue_dry_run.js
@@ -1,0 +1,143 @@
+#!/usr/bin/env node
+
+const fs = require('fs');
+const path = require('path');
+const { buildDryRunReport } = require('./lib/gitlabIssueMigration.js');
+
+const ROOT = path.resolve(__dirname, '..');
+const DEFAULT_PROJECT = 'Crystilac/horizon-suite';
+const DEFAULT_OUTPUT = path.join(ROOT, 'tools', 'gitlab-issues-dry-run.json');
+const DEFAULT_LABEL_CATALOG = path.join(ROOT, 'tools', 'gitlab-label-catalog.json');
+
+function parseArgs(argv) {
+    const args = {
+        project: DEFAULT_PROJECT,
+        output: DEFAULT_OUTPUT,
+        input: null,
+    };
+
+    for (let i = 0; i < argv.length; i++) {
+        const arg = argv[i];
+        if (arg === '--project' && argv[i + 1]) {
+            args.project = argv[++i];
+        } else if (arg === '--output' && argv[i + 1]) {
+            args.output = path.resolve(argv[++i]);
+        } else if (arg === '--input' && argv[i + 1]) {
+            args.input = path.resolve(argv[++i]);
+        } else if (arg === '--help' || arg === '-h') {
+            args.help = true;
+        }
+    }
+
+    return args;
+}
+
+function printHelp() {
+    console.log('Usage: node tools/gitlab_issue_dry_run.js [--project namespace/project] [--input issues.json] [--output report.json]');
+    console.log('');
+    console.log('Without --input, the script fetches GitLab issues from the public API (all states, paginated).');
+    console.log('With --input, the script reads a saved GitLab issues JSON file instead.');
+    console.log('');
+    console.log(`Also writes ${path.relative(ROOT, DEFAULT_LABEL_CATALOG)} based on the union of labels attached to those issues.`);
+}
+
+function inferLabelCatalogEntry(name) {
+    if (name.indexOf('[Enhancement]') === 0) {
+        if (name === '[Enhancement] Improvement') {
+            return { name, color: '84b6eb', description: 'GitLab label (parity)' };
+        }
+        if (name === '[Enhancement] Localization') {
+            return { name, color: 'c5def5', description: 'GitLab label (parity)' };
+        }
+        return { name, color: 'a2eeef', description: 'GitLab label (parity)' };
+    }
+
+    if (name.indexOf('[Module]') === 0) {
+        return { name, color: '1d76db', description: 'GitLab label (parity)' };
+    }
+
+    if (name.indexOf('[Status]') === 0) {
+        return { name, color: 'd4c5f9', description: 'GitLab label (parity)' };
+    }
+
+    return { name, color: 'ededed', description: 'GitLab label (parity)' };
+}
+
+async function fetchGitlabIssuePage(project, page) {
+    const encoded = encodeURIComponent(project);
+    const url = `https://gitlab.com/api/v4/projects/${encoded}/issues?state=all&scope=all&per_page=100&page=${page}`;
+
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 20000);
+
+    try {
+        const response = await fetch(url, {
+            headers: { Accept: 'application/json' },
+            signal: controller.signal,
+        });
+        if (!response.ok) {
+            throw new Error(`GitLab API returned HTTP ${response.status}`);
+        }
+        return await response.json();
+    } finally {
+        clearTimeout(timeout);
+    }
+}
+
+async function fetchAllGitlabIssues(project) {
+    const issues = [];
+    let page = 1;
+
+    while (true) {
+        const batch = await fetchGitlabIssuePage(project, page);
+        if (!Array.isArray(batch) || batch.length === 0) {
+            break;
+        }
+
+        issues.push(...batch);
+        if (batch.length < 100) {
+            break;
+        }
+
+        page += 1;
+    }
+
+    return issues;
+}
+
+function readIssuesFromFile(inputPath) {
+    return JSON.parse(fs.readFileSync(inputPath, 'utf8'));
+}
+
+function writeLabelCatalogFromReport(report) {
+    const names = Array.isArray(report.labelCatalog) ? report.labelCatalog : [];
+    const entries = names.map((name) => inferLabelCatalogEntry(name));
+    fs.writeFileSync(DEFAULT_LABEL_CATALOG, JSON.stringify(entries, null, 2) + '\n', 'utf8');
+}
+
+async function main() {
+    const args = parseArgs(process.argv.slice(2));
+    if (args.help) {
+        printHelp();
+        return;
+    }
+
+    const issues = args.input ? readIssuesFromFile(args.input) : await fetchAllGitlabIssues(args.project);
+    const report = buildDryRunReport(issues);
+
+    fs.writeFileSync(args.output, JSON.stringify(report, null, 2) + '\n', 'utf8');
+    writeLabelCatalogFromReport(report);
+
+    console.log(`GitLab project: ${args.project}`);
+    console.log(`Issues scanned: ${report.counts.total}`);
+    console.log(`Open issues drafted: ${report.counts.open}`);
+    console.log(`Skipped closed issues: ${report.counts.skippedClosed}`);
+    console.log(`Unique GitLab labels (union): ${report.labelCatalog.length}`);
+    console.log(`Dry-run report: ${args.output}`);
+    console.log(`Label catalog: ${DEFAULT_LABEL_CATALOG}`);
+}
+
+main().catch((error) => {
+    console.error(`Dry run failed: ${error.message}`);
+    process.exitCode = 1;
+});

--- a/tools/lib/gitlabIssueMigration.js
+++ b/tools/lib/gitlabIssueMigration.js
@@ -1,0 +1,110 @@
+function normalizeGithubLabelList(gitlabLabels) {
+    const labels = Array.isArray(gitlabLabels) ? gitlabLabels : [];
+    const seen = {};
+    const normalized = [];
+
+    for (const raw of labels) {
+        if (typeof raw !== 'string') {
+            continue;
+        }
+
+        const name = raw.trim();
+        if (!name || seen[name]) {
+            continue;
+        }
+
+        seen[name] = true;
+        normalized.push(name);
+    }
+
+    return normalized;
+}
+
+function mapGithubLabels(gitlabLabels) {
+    return normalizeGithubLabelList(gitlabLabels);
+}
+
+function formatAuthor(author) {
+    if (!author) {
+        return 'Unknown';
+    }
+    const name = author.name || author.username || 'Unknown';
+    return author.username ? `${name} (@${author.username})` : name;
+}
+
+function normalizeBody(description) {
+    const body = (description || '').trim();
+    return body || '_No description provided in the original GitLab issue._';
+}
+
+function buildGithubDraft(issue) {
+    const labels = mapGithubLabels(issue.labels || []);
+    const sourceLines = [
+        `Migrated from GitLab issue #${issue.iid}`,
+        `Original URL: ${issue.web_url || ''}`,
+        `Original author: ${formatAuthor(issue.author)}`,
+        `Original created: ${issue.created_at || ''}`,
+        `Original state: ${issue.state || ''}`,
+    ];
+
+    const body = `${sourceLines.join('\n')}\n\n---\n\n${normalizeBody(issue.description)}`;
+
+    return {
+        gitlabIid: issue.iid,
+        title: issue.title,
+        labels,
+        body,
+        source: {
+            gitlabLabels: issue.labels || [],
+            webUrl: issue.web_url || null,
+            state: issue.state || null,
+        },
+    };
+}
+
+function isOpenIssue(issue) {
+    return issue && issue.state === 'opened';
+}
+
+function collectUniqueGitlabLabelsFromIssues(issues) {
+    const safeIssues = Array.isArray(issues) ? issues : [];
+    const catalog = [];
+
+    for (const issue of safeIssues) {
+        for (const label of issue.labels || []) {
+            catalog.push(label);
+        }
+    }
+
+    const normalized = normalizeGithubLabelList(catalog);
+    normalized.sort((a, b) => a.localeCompare(b));
+    return normalized;
+}
+
+function buildDryRunReport(issues) {
+    const safeIssues = Array.isArray(issues) ? issues : [];
+    const openIssues = safeIssues.filter(isOpenIssue);
+    const drafts = openIssues.map(buildGithubDraft);
+    const labelCatalog = collectUniqueGitlabLabelsFromIssues(safeIssues);
+
+    return {
+        generatedAt: new Date().toISOString(),
+        counts: {
+            total: safeIssues.length,
+            open: openIssues.length,
+            skippedClosed: safeIssues.length - openIssues.length,
+        },
+        labelCatalog,
+        idMap: drafts.map((draft) => ({
+            gitlabIid: draft.gitlabIid,
+            githubNumber: null,
+        })),
+        drafts,
+    };
+}
+
+module.exports = {
+    buildGithubDraft,
+    buildDryRunReport,
+    mapGithubLabels,
+};

--- a/tools/migrate-pipeline-to-issues.ps1
+++ b/tools/migrate-pipeline-to-issues.ps1
@@ -39,16 +39,21 @@ foreach ($line in $lines) {
     $tag = $Matches[1]
 
     # Extract priority
-    $priority = "Priority 2"
-    if ($line -match '\[P0\]') { $priority = "Priority 0" }
-    elseif ($line -match '\[P1\]') { $priority = "Priority 1" }
-    elseif ($line -match '\[P2\]') { $priority = "Priority 2" }
+    $priority = "[Status] Logged"
+    if ($line -match '\[P0\]') { $priority = "[Status] Logged" }
+    elseif ($line -match '\[P1\]') { $priority = "[Status] Logged" }
+    elseif ($line -match '\[P2\]') { $priority = "[Status] Logged" }
 
     # Extract module
     $module = $null
-    if ($line -match '`\[Focus\]`') { $module = "Focus" }
-    elseif ($line -match '`\[Presence\]`') { $module = "Presence" }
-    elseif ($line -match '`\[Vista\]`') { $module = "Vista" }
+    if ($line -match '`\[Focus\]`') { $module = "[Module] Focus" }
+    elseif ($line -match '`\[Presence\]`') { $module = "[Module] Presence" }
+    elseif ($line -match '`\[Vista\]`') { $module = "[Module] Vista" }
+    elseif ($line -match '`\[Cache\]`') { $module = "[Module] Cache" }
+    elseif ($line -match '`\[Essence\]`') { $module = "[Module] Essence" }
+    elseif ($line -match '`\[Insight\]`') { $module = "[Module] Insight" }
+    elseif ($line -match '`\[Flow\]`') { $module = "[Module] Flow" }
+    elseif ($line -match '`\[Axis\]`') { $module = "[Module] Axis" }
 
     # Extract title: strip tag, status, date, priority, module prefix
     $title = $line -replace '^\s*-\s*`(BUG|FEAT|IMPR|IDEA|MOD|DOC)` OPEN \d{4}-\d{2}-\d{2}\s*', ''
@@ -66,13 +71,13 @@ foreach ($line in $lines) {
 
     # Map tag to GitHub label
     $typeLabel = switch ($tag) {
-        "BUG" { "bug" }
-        "FEAT" { "feature" }
-        "MOD" { "feature" }
-        "IMPR" { "improvement" }
-        "IDEA" { "idea" }
-        "DOC" { "improvement" }
-        default { "feature" }
+        "BUG" { "[Enhancement] Improvement" }
+        "FEAT" { "[Enhancement] Feature" }
+        "MOD" { "[Enhancement] Feature" }
+        "IMPR" { "[Enhancement] Improvement" }
+        "IDEA" { "[Enhancement] Feature" }
+        "DOC" { "[Enhancement] Localization" }
+        default { "[Enhancement] Feature" }
     }
 
     $labelArgs = @($typeLabel, $priority)

--- a/tools/setup-labels.ps1
+++ b/tools/setup-labels.ps1
@@ -1,26 +1,30 @@
-# Create GitHub labels for Horizon Suite. Requires gh CLI (https://cli.github.com/).
+# Create GitHub labels for Horizon Suite (GitLab parity names).
+# Requires gh CLI (https://cli.github.com/).
 # Alternatively, run the Setup Labels workflow from GitHub Actions tab.
 
-$labels = @(
-    @{ name = "bug"; desc = "Defect / broken behavior"; color = "d73a4a" },
-    @{ name = "feature"; desc = "New capability"; color = "a2eeef" },
-    @{ name = "improvement"; desc = "Enhancement to existing functionality"; color = "84b6eb" },
-    @{ name = "idea"; desc = "Speculative / backlog"; color = "fef2c0" },
-    @{ name = "Focus"; desc = "Focus tracker module"; color = "1d76db" },
-    @{ name = "Presence"; desc = "Presence notification module"; color = "1d76db" },
-    @{ name = "Core"; desc = "Core addon / options / general"; color = "1d76db" },
-    @{ name = "Vista"; desc = "Vista / minimap module"; color = "1d76db" },
-    @{ name = "Yield"; desc = "Yield / loot module"; color = "1d76db" },
-    @{ name = "Pulse"; desc = "Pulse / combat module"; color = "1d76db" },
-    @{ name = "Essence"; desc = "Essence / unit frames module"; color = "1d76db" },
-    @{ name = "Insight"; desc = "Insight / tooltips module"; color = "1d76db" },
-    @{ name = "Verse"; desc = "Verse / chat module"; color = "1d76db" },
-    @{ name = "Priority 0"; desc = "Major / blocking"; color = "b60205" },
-    @{ name = "Priority 1"; desc = "Minor / next"; color = "fbca04" },
-    @{ name = "Priority 2"; desc = "Patch / low"; color = "0e8a16" }
-)
+$here = Split-Path -Parent $MyInvocation.MyCommand.Path
+$catalogPath = Join-Path $here "gitlab-label-catalog.json"
+$labels = Get-Content -Raw -Path $catalogPath | ConvertFrom-Json
 
 foreach ($l in $labels) {
-    gh label create $l.name --description $l.desc --color $l.color 2>$null
-    if ($LASTEXITCODE -eq 0) { Write-Host "Created: $($l.name)" } else { Write-Host "Skipped (exists): $($l.name)" }
+    $name = [string]$l.name
+    $desc = [string]$l.description
+    $color = [string]$l.color
+
+    if (-not $name) { continue }
+    if (-not $color) { $color = "ededed" }
+    $color = $color.TrimStart('#')
+
+    gh label create $name --description $desc --color $color 2>$null
+    if ($LASTEXITCODE -eq 0) {
+        Write-Host "Created: $name"
+        continue
+    }
+
+    gh label edit $name --description $desc --color $color 2>$null
+    if ($LASTEXITCODE -eq 0) {
+        Write-Host "Updated: $name"
+    } else {
+        Write-Host "Failed: $name"
+    }
 }

--- a/tools/tests/gitlab-issue-dry-run.test.js
+++ b/tools/tests/gitlab-issue-dry-run.test.js
@@ -1,0 +1,60 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { buildGithubDraft, buildDryRunReport } = require('../lib/gitlabIssueMigration.js');
+
+test('buildGithubDraft maps a GitLab open issue to a GitHub dry-run draft', () => {
+    const gitlabIssue = {
+        iid: 123,
+        title: 'Quest list sometimes resizes to default height',
+        description: '### Description\nTracker height resets after zoning.\n\n### Use case\nKeep my preferred height.',
+        labels: ['[Enhancement] Improvement', '[Module] Focus'],
+        state: 'opened',
+        web_url: 'https://gitlab.com/Crystilac/horizon-suite/-/issues/123',
+        created_at: '2026-04-01T12:30:00Z',
+        author: { username: 'tester', name: 'Test User' },
+    };
+
+    const draft = buildGithubDraft(gitlabIssue);
+
+    assert.equal(draft.title, gitlabIssue.title);
+    assert.deepEqual(draft.labels, ['[Enhancement] Improvement', '[Module] Focus']);
+    assert.match(draft.body, /Migrated from GitLab issue #123/);
+    assert.match(draft.body, /Original URL: https:\/\/gitlab\.com\/Crystilac\/horizon-suite\/-\/issues\/123/);
+    assert.match(draft.body, /Original author: Test User \(@tester\)/);
+    assert.match(draft.body, /Original created: 2026-04-01T12:30:00Z/);
+    assert.match(draft.body, /### Description/);
+});
+
+test('buildDryRunReport keeps only open issues and records the GitLab to GitHub preview map', () => {
+    const issues = [
+        {
+            iid: 7,
+            title: 'Open issue',
+            description: 'Open description',
+            labels: ['bug', '[Module] Core'],
+            state: 'opened',
+            web_url: 'https://gitlab.com/example/issues/7',
+            created_at: '2026-04-02T00:00:00Z',
+            author: { username: 'alpha', name: 'Alpha' },
+        },
+        {
+            iid: 8,
+            title: 'Closed issue',
+            description: 'Closed description',
+            labels: ['bug', '[Module] Core'],
+            state: 'closed',
+            web_url: 'https://gitlab.com/example/issues/8',
+            created_at: '2026-04-03T00:00:00Z',
+            author: { username: 'beta', name: 'Beta' },
+        },
+    ];
+
+    const report = buildDryRunReport(issues);
+
+    assert.equal(report.counts.total, 2);
+    assert.equal(report.counts.open, 1);
+    assert.equal(report.drafts.length, 1);
+    assert.deepEqual([...report.labelCatalog].sort(), ['bug', '[Module] Core'].sort());
+    assert.deepEqual(report.idMap, [{ gitlabIid: 7, githubNumber: null }]);
+});


### PR DESCRIPTION
## Summary
Closes #3.

## Changes
- Issue templates: GitLab-style type/module dropdowns; removed static default labels from YAML.
- \setup-labels.yml\: checkout repo; delete legacy Horizon/GitHub label names; create/update from \	ools/gitlab-label-catalog.json\.
- \elabel-issues.yml\ + \migrate-pipeline-to-issues.ps1\: map pipeline tags to \[Enhancement]\ / \[Module]\ / \[Status] Logged\ strings.
- \setup-labels.ps1\: read catalog; create or \gh label edit\ each label.
- New Node dry-run (\gitlab_issue_dry_run.js\, \lib/gitlabIssueMigration.js\) + tests; \.gitignore\ for local dry-run JSON; \	ools/README.md\ updated.

## Test plan
- [x] \
ode tools/tests/gitlab-issue-dry-run.test.js\

Made with [Cursor](https://cursor.com)