### PR TITLE
Improve issuelog reliability and GitLab issue import tooling

### DIFF
--- a/.github/workflows/issuelog.yml
+++ b/.github/workflows/issuelog.yml
@@ -45,6 +45,14 @@ jobs:
           MSG_ID_FILE=.release/discord-issuelog-message-id
           NEW_IDS=$(mktemp)
 
+          if [ -z "${WEBHOOK_URL:-}" ]; then
+            echo "::notice::Discord issuelog skipped: repository secret DISCORD_WEBHOOK_ISSUELOG is not set (or empty)."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            rm -f "$NEW_IDS"
+            exit 0
+          fi
+          echo "skip=false" >> "$GITHUB_OUTPUT"
+
           # Delete all previously cached messages (one ID per line)
           if [ -f "$MSG_ID_FILE" ]; then
             while IFS= read -r id || [ -n "$id" ]; do
@@ -94,14 +102,14 @@ jobs:
           echo "id=$(head -1 "$MSG_ID_FILE" 2>/dev/null || true)" >> $GITHUB_OUTPUT
 
       - name: Save message IDs to cache
-        if: steps.discord.outputs.id != ''
+        if: steps.discord.outputs.skip != 'true' && steps.discord.outputs.id != ''
         run: |
           gh cache delete issuelog-msg-id --repo "$GITHUB_REPOSITORY" || true
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Write cache
-        if: steps.discord.outputs.id != ''
+        if: steps.discord.outputs.skip != 'true' && steps.discord.outputs.id != ''
         uses: actions/cache/save@v4
         with:
           path: .release

--- a/.gitignore
+++ b/.gitignore
@@ -30,5 +30,6 @@ tools/pipeline-viewer.html
 tools/serve-pipeline.ps1
 tools/gitlab-issues-dry-run.json
 tools/gitlab-issues-dry-run-example.json
+tools/gitlab-issue-import-results.json
 /wowapi/
 assets\social

--- a/.release/run-issuelog.sh
+++ b/.release/run-issuelog.sh
@@ -5,10 +5,27 @@ set -e
 # Output: .release/discord-issuelog-payload-{bugs,features,improvements,ideas}.json
 # One message per type; each message has its own 6000-char limit (avoids Discord total-embed limit).
 
-export GITHUB_REPOSITORY="${GITHUB_REPOSITORY:-Crystilac93/Horizon-Suite}"
+export GITHUB_REPOSITORY="${GITHUB_REPOSITORY:-Tacit-Labs/Horizon-Suite}"
 
-# Fetch all open issues (number, title, labels, body, url)
-ISSUES=$(gh issue list --state open --json number,title,labels,body,url --limit 100 2>/dev/null || echo "[]")
+# Fetch all open issues (paginated; default limit would miss issues past 100)
+ISSUES="[]"
+page=1
+while true; do
+  batch=$(gh issue list --state open --json number,title,labels,body,url --limit 100 --page "$page" 2>/dev/null || echo "[]")
+  cnt=$(echo "$batch" | jq 'length')
+  if [ "$cnt" -eq 0 ]; then
+    break
+  fi
+  ISSUES=$(jq -n --argjson acc "$ISSUES" --argjson b "$batch" '$acc + $b')
+  if [ "$cnt" -lt 100 ]; then
+    break
+  fi
+  page=$((page + 1))
+  if [ "$page" -gt 50 ]; then
+    echo "Warning: stopped pagination after 50 pages" >&2
+    break
+  fi
+done
 
 BUGS=""
 FEATURES=""
@@ -20,18 +37,30 @@ while IFS= read -r line; do
   title=$(echo "$line" | jq -r '.title')
   url=$(echo "$line" | jq -r '.url')
   labels=$(echo "$line" | jq -r '.labels[].name' | tr '\n' ' ')
+  labels_lc=$(echo "$labels" | tr '[:upper:]' '[:lower:]')
   body=$(echo "$line" | jq -r '.body // ""')
 
-  # Determine module tag
+  # Determine module tag (plain names or GitLab-parity [Module] … labels)
   module=""
-  [[ "$labels" =~ Focus ]]    && module="[Focus] "
-  [[ "$labels" =~ Presence ]] && module="[Presence] "
-  [[ "$labels" =~ Core ]]     && module="[Core] "
-  [[ "$labels" =~ Vista ]]    && module="[Vista] "
-  [[ "$labels" =~ Cache ]]    && module="[Cache] "
-  [[ "$labels" =~ Pulse ]]    && module="[Pulse] "
-  [[ "$labels" =~ Insight ]]  && module="[Insight] "
-  [[ "$labels" =~ Verse ]]    && module="[Verse] "
+  if [[ "$labels_lc" =~ \[module\]\ focus ]]; then module="[Focus] "
+  elif [[ "$labels_lc" =~ \[module\]\ presence ]]; then module="[Presence] "
+  elif [[ "$labels_lc" =~ \[module\]\ axis ]] || [[ "$labels_lc" =~ \[module\]\ core ]]; then module="[Core] "
+  elif [[ "$labels_lc" =~ \[module\]\ vista ]]; then module="[Vista] "
+  elif [[ "$labels_lc" =~ \[module\]\ cache ]]; then module="[Cache] "
+  elif [[ "$labels_lc" =~ \[module\]\ pulse ]]; then module="[Pulse] "
+  elif [[ "$labels_lc" =~ \[module\]\ insight ]]; then module="[Insight] "
+  elif [[ "$labels_lc" =~ \[module\]\ verse ]]; then module="[Verse] "
+  elif [[ "$labels_lc" =~ \[module\]\ essence ]]; then module="[Essence] "
+  elif [[ "$labels_lc" =~ \[module\]\ flow ]]; then module="[Flow] "
+  elif [[ "$labels_lc" =~ (^|[[:space:]])focus($|[[:space:]]) ]]; then module="[Focus] "
+  elif [[ "$labels_lc" =~ (^|[[:space:]])presence($|[[:space:]]) ]]; then module="[Presence] "
+  elif [[ "$labels_lc" =~ (^|[[:space:]])core($|[[:space:]]) ]]; then module="[Core] "
+  elif [[ "$labels_lc" =~ (^|[[:space:]])vista($|[[:space:]]) ]]; then module="[Vista] "
+  elif [[ "$labels_lc" =~ (^|[[:space:]])cache($|[[:space:]]) ]]; then module="[Cache] "
+  elif [[ "$labels_lc" =~ (^|[[:space:]])pulse($|[[:space:]]) ]]; then module="[Pulse] "
+  elif [[ "$labels_lc" =~ (^|[[:space:]])insight($|[[:space:]]) ]]; then module="[Insight] "
+  elif [[ "$labels_lc" =~ (^|[[:space:]])verse($|[[:space:]]) ]]; then module="[Verse] "
+  fi
 
   # Extract ### Description section from body (text between ### Description and next ###)
   desc=$(printf '%s' "$body" | awk '
@@ -55,14 +84,14 @@ while IFS= read -r line; do
     bullet="• ${module}[${title}](${url})"
   fi
 
-  # Route to bucket by type label
-  if [[ "$labels" =~ bug ]]; then
+  # Route to bucket: legacy GitHub labels (bug, feature, …) or GitLab-parity [Enhancement] …
+  if [[ "$labels_lc" =~ (^|[[:space:]])bug($|[[:space:]]) ]]; then
     BUGS="${BUGS}${bullet}"$'\n'
-  elif [[ "$labels" =~ feature ]]; then
+  elif [[ "$labels_lc" =~ \[enhancement\]\ feature ]] || [[ "$labels_lc" =~ (^|[[:space:]])feature($|[[:space:]]) ]]; then
     FEATURES="${FEATURES}${bullet}"$'\n'
-  elif [[ "$labels" =~ improvement ]]; then
+  elif [[ "$labels_lc" =~ \[enhancement\]\ improvement ]] || [[ "$labels_lc" =~ \[enhancement\]\ localization ]] || [[ "$labels_lc" =~ (^|[[:space:]])improvement($|[[:space:]]) ]]; then
     IMPROVEMENTS="${IMPROVEMENTS}${bullet}"$'\n'
-  elif [[ "$labels" =~ idea ]]; then
+  elif [[ "$labels_lc" =~ (^|[[:space:]])idea($|[[:space:]]) ]]; then
     IDEAS="${IDEAS}${bullet}"$'\n'
   fi
 

--- a/tools/README.md
+++ b/tools/README.md
@@ -11,6 +11,7 @@ Scripts for **localisation** maintenance and project administration. Run from th
 | `archived/` | **Historical** one-off migrations — do not use in normal workflow |
 | `color-palette-review.html` | Local HTML preview of the Focus colour palette for design review |
 | `gitlab_issue_dry_run.js` | Preview GitLab -> GitHub issue drafts without creating anything |
+| `gitlab_issue_import.js` | Create GitHub issues from a dry-run JSON (`gh issue create`; use `--execute`) |
 | `gitlab-label-catalog.json` | GitLab-parity label catalog for GitHub (generated/updated by `gitlab_issue_dry_run.js`) |
 | `migrate-pipeline-to-issues.ps1` | Bulk-create GitHub Issues from `pipeline.md` Open Items (`gh` CLI) |
 | `setup-labels.ps1` | Create/update GitHub issue labels via `gh` CLI (reads `gitlab-label-catalog.json`) |
@@ -20,6 +21,7 @@ Scripts for **localisation** maintenance and project administration. Run from th
 | Script | Command | When |
 |--------|---------|------|
 | GitLab issue migration preview | `node tools/gitlab_issue_dry_run.js` | Before importing GitLab issues into GitHub; writes `tools/gitlab-issues-dry-run.json` and refreshes `tools/gitlab-label-catalog.json` |
+| GitLab issue import | `node tools/gitlab_issue_import.js --from tools/gitlab-issues-dry-run.json` then `... --execute` | Creates issues on GitHub (run **Setup Labels** first); skips IIDs already present in issue bodies |
 | Sync locale files to `enUS` order | `node tools/restructure_locales.js` | Rewrites `enUS.lua` format (no per-key `-- Context:`; no blank lines between keys; pads spaces so `=` and values align in one column from the longest `L["KEY"]`), then regenerates other locales; strips assignments that duplicate enUS (commented-out `-- L["KEY"] = …` so runtime uses `__index` fallback) |
 | Coverage check | `node tools/locale_audit.js --strict` | Before merge requests (same as CI `locale-check`); strict = every key has a row; coverage counts only strings that differ from enUS |
 | Optional key metadata | `node tools/locale_validate.js <locale> <KEY>` or `… --all-unvalidated` | Reviewer workflow |

--- a/tools/gitlab_issue_import.js
+++ b/tools/gitlab_issue_import.js
@@ -1,0 +1,296 @@
+#!/usr/bin/env node
+/**
+ * Create GitHub issues from a gitlab_issue_dry_run.js report (drafts[]).
+ * Uses `gh issue create` (GitHub CLI). Requires `gh auth` and repo access.
+ *
+ * Usage:
+ *   node tools/gitlab_issue_import.js --from tools/gitlab-issues-dry-run.json
+ *   node tools/gitlab_issue_import.js --from tools/gitlab-issues-dry-run.json --execute
+ *   node tools/gitlab_issue_import.js --from ... --execute --limit 5
+ *   node tools/gitlab_issue_import.js --from ... --execute --no-skip-existing
+ *
+ * Options:
+ *   --from <path>     Dry-run JSON (default: tools/gitlab-issues-dry-run.json)
+ *   --repo owner/name  Override repo (default: parsed from `git remote get-url origin`)
+ *   --execute         Actually run `gh issue create` (default is print-only)
+ *   --limit <n>       Import at most n drafts (in file order); 0 = all
+ *   --skip-existing   Skip drafts whose GitLab IID already appears in a GitHub issue body (default: on)
+ *   --no-skip-existing
+ *   --delay-ms <n>    Pause between creates (default 400)
+ */
+
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+const { spawnSync } = require('child_process');
+const { setTimeout: delay } = require('timers/promises');
+
+const ROOT = path.resolve(__dirname, '..');
+const DEFAULT_FROM = path.join(ROOT, 'tools', 'gitlab-issues-dry-run.json');
+const MIGRATED_LINE_RE = /Migrated from GitLab issue #(\d+)/;
+
+function parseGitRemoteRepo() {
+    try {
+        const r = spawnSync('git', ['remote', 'get-url', 'origin'], {
+            cwd: ROOT,
+            encoding: 'utf8',
+        });
+        if (r.status !== 0) {
+            return null;
+        }
+        const url = (r.stdout || '').trim();
+        const m = url.match(/github\.com[:/]([^/]+\/[^/.]+?)(?:\.git)?$/i);
+        return m ? m[1] : null;
+    } catch {
+        return null;
+    }
+}
+
+function parseArgs(argv) {
+    const args = {
+        from: DEFAULT_FROM,
+        repo: parseGitRemoteRepo(),
+        execute: false,
+        limit: 0,
+        skipExisting: true,
+        delayMs: 400,
+        help: false,
+    };
+
+    for (let i = 0; i < argv.length; i++) {
+        const arg = argv[i];
+        if (arg === '--from' && argv[i + 1]) {
+            args.from = path.resolve(argv[++i]);
+        } else if (arg === '--repo' && argv[i + 1]) {
+            args.repo = argv[++i];
+        } else if (arg === '--execute') {
+            args.execute = true;
+        } else if (arg === '--limit' && argv[i + 1]) {
+            args.limit = Math.max(0, parseInt(argv[++i], 10) || 0);
+        } else if (arg === '--skip-existing') {
+            args.skipExisting = true;
+        } else if (arg === '--no-skip-existing') {
+            args.skipExisting = false;
+        } else if (arg === '--delay-ms' && argv[i + 1]) {
+            args.delayMs = Math.max(0, parseInt(argv[++i], 10) || 0);
+        } else if (arg === '--help' || arg === '-h') {
+            args.help = true;
+        }
+    }
+
+    return args;
+}
+
+function printHelp() {
+    console.log(`Usage: node tools/gitlab_issue_import.js [--from report.json] [--repo owner/name] [--limit N] [--execute]`);
+    console.log('');
+    console.log('Without --execute, prints planned imports only.');
+    console.log('With --execute, runs gh issue create for each draft (respects --skip-existing by default).');
+}
+
+function ghSpawn(args, opts) {
+    const r = spawnSync('gh', args, {
+        encoding: 'utf8',
+        maxBuffer: 64 * 1024 * 1024,
+        ...opts,
+    });
+    return r;
+}
+
+function listGithubIssuesForMigrationScan(repo) {
+    const all = [];
+    let page = 1;
+    const perPage = 100;
+
+    while (true) {
+        const pathArg = `/repos/${repo}/issues?state=all&per_page=${perPage}&page=${page}`;
+        const r = ghSpawn(['api', '-H', 'Accept: application/vnd.github+json', pathArg], {});
+        if (r.status !== 0) {
+            throw new Error(`gh api failed (${r.status}): ${(r.stderr || r.stdout || '').trim()}`);
+        }
+        const batch = JSON.parse(r.stdout || '[]');
+        if (!Array.isArray(batch) || batch.length === 0) {
+            break;
+        }
+        for (const item of batch) {
+            if (item && item.pull_request) {
+                continue;
+            }
+            all.push(item);
+        }
+        if (batch.length < perPage) {
+            break;
+        }
+        page += 1;
+        if (page > 500) {
+            throw new Error('Too many GitHub issues pages while scanning for existing migrations (abort).');
+        }
+    }
+
+    return all;
+}
+
+function buildMigratedGitlabIidSet(issues) {
+    const set = {};
+    for (const issue of issues) {
+        if (!issue || issue.pull_request) {
+            continue;
+        }
+        const body = issue.body || '';
+        const m = body.match(MIGRATED_LINE_RE);
+        if (m) {
+            const iid = parseInt(m[1], 10);
+            if (iid > 0) {
+                set[iid] = issue.number;
+            }
+        }
+    }
+    return set;
+}
+
+function parseCreatedIssueUrl(stdout) {
+    const text = (stdout || '').trim();
+    const m = text.match(/\/issues\/(\d+)\s*$/m) || text.match(/github\.com\/[^/]+\/[^/]+\/issues\/(\d+)/);
+    return m ? parseInt(m[1], 10) : null;
+}
+
+function createGithubIssue(draft, repo) {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'hs-gl-import-'));
+    try {
+        const bodyFile = path.join(tmpDir, 'body.md');
+        fs.writeFileSync(bodyFile, draft.body, 'utf8');
+
+        const args = ['issue', 'create', '-R', repo, '--title', draft.title, '--body-file', bodyFile];
+        const labels = Array.isArray(draft.labels) ? draft.labels : [];
+        for (const label of labels) {
+            if (typeof label === 'string' && label.length) {
+                args.push('--label', label);
+            }
+        }
+
+        const r = ghSpawn(args, {});
+        if (r.status !== 0) {
+            return {
+                ok: false,
+                error: (r.stderr || r.stdout || 'gh issue create failed').trim(),
+            };
+        }
+
+        const number = parseCreatedIssueUrl(r.stdout);
+        return { ok: true, number, url: (r.stdout || '').trim() };
+    } finally {
+        try {
+            fs.rmSync(tmpDir, { recursive: true, force: true });
+        } catch {
+            /* ignore */
+        }
+    }
+}
+
+async function main() {
+    const args = parseArgs(process.argv.slice(2));
+    if (args.help) {
+        printHelp();
+        return;
+    }
+
+    if (!args.repo) {
+        console.error('Could not determine GitHub repo. Pass --repo owner/name or set origin to a github.com remote.');
+        process.exitCode = 1;
+        return;
+    }
+
+    if (!fs.existsSync(args.from)) {
+        console.error(`Report not found: ${args.from}`);
+        process.exitCode = 1;
+        return;
+    }
+
+    const report = JSON.parse(fs.readFileSync(args.from, 'utf8'));
+    const drafts = Array.isArray(report.drafts) ? report.drafts : [];
+    if (drafts.length === 0) {
+        console.error('No drafts found in report (expected report.drafts[]).');
+        process.exitCode = 1;
+        return;
+    }
+
+    let selected = drafts;
+    if (args.limit > 0) {
+        selected = drafts.slice(0, args.limit);
+    }
+
+    let migratedMap = {};
+    if (args.execute && args.skipExisting) {
+        console.log(`Scanning ${args.repo} for existing GitLab migrations...`);
+        const ghIssues = listGithubIssuesForMigrationScan(args.repo);
+        migratedMap = buildMigratedGitlabIidSet(ghIssues);
+        console.log(`Found ${Object.keys(migratedMap).length} already-imported GitLab IIDs.`);
+    }
+
+    const results = [];
+    for (const draft of selected) {
+        const iid = draft.gitlabIid;
+        if (!iid) {
+            results.push({ gitlabIid: null, ok: false, error: 'draft missing gitlabIid' });
+            continue;
+        }
+
+        if (args.execute && args.skipExisting && migratedMap[iid]) {
+            const existing = migratedMap[iid];
+            console.log(`Skip GitLab #${iid} -> already GitHub #${existing}`);
+            results.push({ gitlabIid: iid, ok: true, skipped: true, githubNumber: existing });
+            continue;
+        }
+
+        if (!args.execute) {
+            console.log(`Would create: GitLab #${iid} -> "${draft.title}" labels=${JSON.stringify(draft.labels || [])}`);
+            results.push({ gitlabIid: iid, ok: true, dryRun: true });
+            continue;
+        }
+
+        console.log(`Creating GitLab #${iid}: ${draft.title}`);
+        const created = createGithubIssue(draft, args.repo);
+        if (!created.ok) {
+            console.error(`FAILED GitLab #${iid}: ${created.error}`);
+            results.push({ gitlabIid: iid, ok: false, error: created.error });
+            process.exitCode = 1;
+            break;
+        }
+
+        console.log(`  -> GitHub #${created.number} ${created.url || ''}`);
+        migratedMap[iid] = created.number;
+        results.push({
+            gitlabIid: iid,
+            ok: true,
+            githubNumber: created.number,
+            url: created.url,
+        });
+
+        if (args.delayMs) {
+            await delay(args.delayMs);
+        }
+    }
+
+    const outPath = path.join(ROOT, 'tools', 'gitlab-issue-import-results.json');
+    fs.writeFileSync(
+        outPath,
+        JSON.stringify(
+            {
+                generatedAt: new Date().toISOString(),
+                repo: args.repo,
+                execute: args.execute,
+                from: args.from,
+                results,
+            },
+            null,
+            2,
+        ) + '\n',
+        'utf8',
+    );
+    console.log(`Wrote ${path.relative(ROOT, outPath)}`);
+}
+
+main().catch((err) => {
+    console.error(err);
+    process.exitCode = 1;
+});


### PR DESCRIPTION
Refs #3

### Summary

- **CI (issuelog.yml):** Skip Discord posting when the webhook secret is missing or empty, and avoid cache steps when skipped.
- **Local (run-issuelog.sh):** Default GITHUB_REPOSITORY to Tacit-Labs/Horizon-Suite, paginate gh issue list past 100 issues, and route buckets using GitLab-parity labels ([Module] ..., [Enhancement] ...) plus word-boundary matching for legacy short labels.
- **Tooling:** Add tools/gitlab_issue_import.js (create issues from dry-run JSON), document it in tools/README.md, and ignore tools/gitlab-issue-import-results.json in .gitignore.