### PR TITLE
Point repository links at Tacit-Labs GitHub org

### DIFF
--- a/.release/issuelog.md
+++ b/.release/issuelog.md
@@ -1,41 +1,41 @@
 # HorizonSuite — Open Issues
 
-> Generated 2026-03-01 · [View on GitHub](https://github.com/Crystilac93/Horizon-Suite/issues)
+> Generated 2026-03-01 · [View on GitHub](https://github.com/Tacit-Labs/Horizon-Suite/issues)
 
 ---
 
 ## 🐛 Known Bugs
 
-- [Presence] [World quest alerts only appear in Undermine, not in Khaz Algar or other zones](https://github.com/Crystilac93/Horizon-Suite/issues/296)
-- [Focus] [Focus font outline option missing or cut off in options](https://github.com/Crystilac93/Horizon-Suite/issues/295)
-- [Presence] [Quest update toasts do not colour-code by quest category (gold campaign, blue scenario)](https://github.com/Crystilac93/Horizon-Suite/issues/292)
-- [Presence] [Prey quest completion prompt does not appear when Horizon Suite is enabled](https://github.com/Crystilac93/Horizon-Suite/issues/288)
+- [Presence] [World quest alerts only appear in Undermine, not in Khaz Algar or other zones](https://github.com/Tacit-Labs/Horizon-Suite/issues/296)
+- [Focus] [Focus font outline option missing or cut off in options](https://github.com/Tacit-Labs/Horizon-Suite/issues/295)
+- [Presence] [Quest update toasts do not colour-code by quest category (gold campaign, blue scenario)](https://github.com/Tacit-Labs/Horizon-Suite/issues/292)
+- [Presence] [Prey quest completion prompt does not appear when Horizon Suite is enabled](https://github.com/Tacit-Labs/Horizon-Suite/issues/288)
 
 ---
 
 ## ✨ Feature Requests
 
-- [Presence] [Presence notification for renown rank increases](https://github.com/Crystilac93/Horizon-Suite/issues/297)
-- [Focus] [Classic toggle: suppress/blacklist quests and focus quest without opening quest log](https://github.com/Crystilac93/Horizon-Suite/issues/263)
-- [Focus] [[Feature]: Have some Ideas :)](https://github.com/Crystilac93/Horizon-Suite/issues/205)
-- [Focus] [Show tracked appearance/transmog items in the tracker](https://github.com/Crystilac93/Horizon-Suite/issues/202)
-- [Core] [Test mode that shows all elements for easy positioning](https://github.com/Crystilac93/Horizon-Suite/issues/184)
-- [Presence] [Option to keep Blizzard achievement toasts visible alongside Presence](https://github.com/Crystilac93/Horizon-Suite/issues/155)
-- [Focus] [Setting to change which key press hides quests from tracker](https://github.com/Crystilac93/Horizon-Suite/issues/149)
-- [Focus] [Show Enemy Groups remaining in Delves for the Bountiful chest](https://github.com/Crystilac93/Horizon-Suite/issues/84)
-- [Focus] [Integration with Auctionator/Auctioneer for search materials.](https://github.com/Crystilac93/Horizon-Suite/issues/43)
-- [Presence] [Warfront objectives not shown in the tracker.](https://github.com/Crystilac93/Horizon-Suite/issues/40)
+- [Presence] [Presence notification for renown rank increases](https://github.com/Tacit-Labs/Horizon-Suite/issues/297)
+- [Focus] [Classic toggle: suppress/blacklist quests and focus quest without opening quest log](https://github.com/Tacit-Labs/Horizon-Suite/issues/263)
+- [Focus] [[Feature]: Have some Ideas :)](https://github.com/Tacit-Labs/Horizon-Suite/issues/205)
+- [Focus] [Show tracked appearance/transmog items in the tracker](https://github.com/Tacit-Labs/Horizon-Suite/issues/202)
+- [Core] [Test mode that shows all elements for easy positioning](https://github.com/Tacit-Labs/Horizon-Suite/issues/184)
+- [Presence] [Option to keep Blizzard achievement toasts visible alongside Presence](https://github.com/Tacit-Labs/Horizon-Suite/issues/155)
+- [Focus] [Setting to change which key press hides quests from tracker](https://github.com/Tacit-Labs/Horizon-Suite/issues/149)
+- [Focus] [Show Enemy Groups remaining in Delves for the Bountiful chest](https://github.com/Tacit-Labs/Horizon-Suite/issues/84)
+- [Focus] [Integration with Auctionator/Auctioneer for search materials.](https://github.com/Tacit-Labs/Horizon-Suite/issues/43)
+- [Presence] [Warfront objectives not shown in the tracker.](https://github.com/Tacit-Labs/Horizon-Suite/issues/40)
 
 ---
 
 ## 🔧 Improvements
 
-- [Focus] [Custom waypoints and farm routes similar to TomTom.](https://github.com/Crystilac93/Horizon-Suite/issues/33)
-- [Focus] [Filter which kinds of world quests auto-add to the tracker (e.g. by type, reward, zone).](https://github.com/Crystilac93/Horizon-Suite/issues/31)
+- [Focus] [Custom waypoints and farm routes similar to TomTom.](https://github.com/Tacit-Labs/Horizon-Suite/issues/33)
+- [Focus] [Filter which kinds of world quests auto-add to the tracker (e.g. by type, reward, zone).](https://github.com/Tacit-Labs/Horizon-Suite/issues/31)
 
 ---
 
 ## 💡 Ideas
 
-- [Insight] [Potential additions for character tooltips](https://github.com/Crystilac93/Horizon-Suite/issues/193)
-- [Core] [Show preview button for all relevant features in options](https://github.com/Crystilac93/Horizon-Suite/issues/47)
+- [Insight] [Potential additions for character tooltips](https://github.com/Tacit-Labs/Horizon-Suite/issues/193)
+- [Core] [Show preview button for all relevant features in options](https://github.com/Tacit-Labs/Horizon-Suite/issues/47)

--- a/.release/run-changelog.sh
+++ b/.release/run-changelog.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 set -e
-export GITHUB_REPOSITORY="${GITHUB_REPOSITORY:-Crystilac93/Horizon-Suite}"
+export GITHUB_REPOSITORY="${GITHUB_REPOSITORY:-Tacit-Labs/Horizon-Suite}"
 
 LAST_TAG=$(git describe --tags --abbrev=0 --match 'v*' 2>/dev/null || echo "")
 if [ -n "$LAST_TAG" ]; then

--- a/README-curseforge.md
+++ b/README-curseforge.md
@@ -132,7 +132,7 @@ Every module shares the same design foundations, so they feel like one cohesive 
 
 **Optional:** [SharedMedia](https://www.curseforge.com/wow/addons/sharedmedia) for expanded font choices and progress bar textures. [RondoMedia](https://www.curseforge.com/wow/addons/rondomedia) by RondoFerrari for class icons in Insight tooltips and the Dashboard header icon when class colours are on.
 
-1. Install via [CurseForge](https://www.curseforge.com/projects/1457844), [Wago](https://addons.wago.io/addons/jK8gY56y), or download the [latest release](https://github.com/Crystilac93/Horizon-Suite/releases/latest) and extract the `HorizonSuite` folder. ([Beta](https://github.com/Crystilac93/Horizon-Suite/releases/tag/beta))
+1. Install via [CurseForge](https://www.curseforge.com/projects/1457844), [Wago](https://addons.wago.io/addons/jK8gY56y), or download the [latest release](https://github.com/Tacit-Labs/Horizon-Suite/releases/latest) and extract the `HorizonSuite` folder. ([Beta](https://github.com/Tacit-Labs/Horizon-Suite/releases/tag/beta))
 2. Place it in `World of Warcraft\_retail_\Interface\AddOns\`.
 3. Enable **Horizon Suite** in your AddOn list.
 4. Open the **dashboard** (`/hsd`, the minimap button, or **Options** on the tracker).
@@ -145,7 +145,7 @@ Every module shares the same design foundations, so they feel like one cohesive 
 Horizon Suite is built with the community, not just for it. Feature requests and bug reports shape every update.
 
 **[Discord](https://discord.gg/nFabdZmvSB)** — The best place to get help, share feedback, or see what's coming next.
-**[GitHub Issues](https://github.com/Crystilac93/Horizon-Suite/issues)** — Bug reports and feature requests welcome. Use the Bug report or Feature request template. Reports from Discord, Reddit, or CurseForge are also welcome.
+**[GitHub Issues](https://github.com/Tacit-Labs/Horizon-Suite/issues)** — Bug reports and feature requests welcome. Use the Bug report or Feature request template. Reports from Discord, Reddit, or CurseForge are also welcome.
 **[Patreon](https://patreon.com/HorizonSuite)** | **[Ko-fi](https://ko-fi.com/T6T71TX1Y1)** — Support development and keep the lights on.
 
 ---

--- a/README-wago.md
+++ b/README-wago.md
@@ -94,7 +94,7 @@
 
 **Optional:** [SharedMedia](https://www.curseforge.com/wow/addons/sharedmedia) (e.g. SharedMedia Additional Fonts) for expanded font choices in Typography and statusbar textures for progress bars. If not installed, the font dropdown shows only Game Font and any custom path you enter; progress bars use Solid texture. [RondoMedia](https://www.curseforge.com/wow/addons/rondomedia) by RondoFerrari for class icons in Insight tooltips and, when Dashboard class colours are on, for the Dashboard header class icon (Axis → Class Colours → Dashboard class icon style—separate from Insight).
 
-1. Install via [CurseForge](https://www.curseforge.com/projects/1457844), [Wago](https://addons.wago.io/addons/jK8gY56y), or download the [latest release](https://github.com/Crystilac93/Horizon-Suite/releases/latest) and extract the `HorizonSuite` folder. ([Beta](https://github.com/Crystilac93/Horizon-Suite/releases/tag/beta))
+1. Install via [CurseForge](https://www.curseforge.com/projects/1457844), [Wago](https://addons.wago.io/addons/jK8gY56y), or download the [latest release](https://github.com/Tacit-Labs/Horizon-Suite/releases/latest) and extract the `HorizonSuite` folder. ([Beta](https://github.com/Tacit-Labs/Horizon-Suite/releases/tag/beta))
 2. Place it in `World of Warcraft\_retail_\Interface\AddOns\`.
 3. Enable **Horizon Suite** in your AddOn list.
 4. Open the **dashboard** (`/hsd`, the minimap button, or **Options** on the tracker).
@@ -106,7 +106,7 @@
 
 ## 🤝 Contributing
 
-**Issues** — [GitHub Issues](https://github.com/Crystilac93/Horizon-Suite/issues). Use the Bug report or Feature request template. Reports from Discord, Reddit, or CurseForge are welcome.
+**Issues** — [GitHub Issues](https://github.com/Tacit-Labs/Horizon-Suite/issues). Use the Bug report or Feature request template. Reports from Discord, Reddit, or CurseForge are welcome.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Insight - Tooltips
 
 **Optional:** [SharedMedia](https://www.curseforge.com/wow/addons/sharedmedia) (e.g. SharedMedia Additional Fonts) for expanded font choices in Typography and statusbar textures for progress bars. If not installed, the font dropdown shows only Game Font and any custom path you enter; progress bars use Solid texture. [RondoMedia](https://www.curseforge.com/wow/addons/rondomedia) by RondoFerrari for class icons in Insight tooltips and, when Dashboard class colours are on, for the Dashboard header class icon (Axis → Class Colours → Dashboard class icon style—separate from Insight).
 
-1. Install via [CurseForge](https://www.curseforge.com/projects/1457844), [Wago](https://addons.wago.io/addons/jK8gY56y), or download the [latest release](https://github.com/Crystilac93/Horizon-Suite/releases/latest) and extract the `HorizonSuite` folder. ([Beta](https://github.com/Crystilac93/Horizon-Suite/releases/tag/beta))
+1. Install via [CurseForge](https://www.curseforge.com/projects/1457844), [Wago](https://addons.wago.io/addons/jK8gY56y), or download the [latest release](https://github.com/Tacit-Labs/Horizon-Suite/releases/latest) and extract the `HorizonSuite` folder. ([Beta](https://github.com/Tacit-Labs/Horizon-Suite/releases/tag/beta))
 2. Place it in `World of Warcraft\_retail_\Interface\AddOns\`.
 3. Enable **Horizon Suite** in your AddOn list.
 4. Open the **dashboard** (`/hsd`, the minimap button, or **Options** on the tracker).
@@ -106,7 +106,7 @@ Insight - Tooltips
 
 ## 🤝 Contributing
 
-**Issues** — [GitHub Issues](https://github.com/Crystilac93/Horizon-Suite/issues). Use the Bug report or Feature request template. Reports from Discord, Reddit, or CurseForge are welcome.
+**Issues** — [GitHub Issues](https://github.com/Tacit-Labs/Horizon-Suite/issues). Use the Bug report or Feature request template. Reports from Discord, Reddit, or CurseForge are welcome.
 
 ---
 

--- a/options/dashboard/DashboardFrame.lua
+++ b/options/dashboard/DashboardFrame.lua
@@ -895,7 +895,7 @@ function addon.Dashboard_BuildMainFrame()
             dashAccentRefs.underline = detailTitleUnderline
 
             -- Patch Notes only: full changelog link (top-right of frame, aligned with title row).
-            local PN_CHANGELOG_URL = "https://github.com/Crystilac93/Horizon-Suite/blob/main/CHANGELOG.md"
+            local PN_CHANGELOG_URL = "https://github.com/Tacit-Labs/Horizon-Suite/blob/main/CHANGELOG.md"
             local pnChangelogHeaderBtn = CreateFrame("Button", nil, f)
             pnChangelogHeaderBtn:SetFrameLevel(f:GetFrameLevel() + 12)
             pnChangelogHeaderBtn:SetPoint("TOPRIGHT", f, "TOPRIGHT", -48, DASH_HEAD_TITLE_Y)

--- a/options/dashboard/DashboardUtil.lua
+++ b/options/dashboard/DashboardUtil.lua
@@ -467,7 +467,7 @@ function addon.Dashboard_CreateCommunityFooter(parent, env)
         { label = L["DASH_DISCORD"] or "Discord", url = "https://discord.gg/nFabdZmvSB", icon = DASHBOARD_FOOTER_MEDIA .. "discord.tga" },
         { label = L["DASH_KO_FI"] or "Ko-fi", url = "https://ko-fi.com/horizonsuite", icon = DASHBOARD_FOOTER_MEDIA .. "kofi.tga" },
         { label = L["DASH_PATREON"] or "Patreon", url = "https://patreon.com/HorizonSuite", icon = DASHBOARD_FOOTER_MEDIA .. "patreon.tga" },
-        { label = L["DASH_GITHUB"] or "GitHub", url = "https://github.com/Crystilac93/Horizon-Suite", icon = DASHBOARD_FOOTER_MEDIA .. "github.tga" },
+        { label = L["DASH_GITHUB"] or "GitHub", url = "https://github.com/Tacit-Labs/Horizon-Suite", icon = DASHBOARD_FOOTER_MEDIA .. "github.tga" },
         { label = L["DASH_CURSEFORGE"] or "CurseForge", url = "https://www.curseforge.com/projects/1457844", icon = DASHBOARD_FOOTER_MEDIA .. "CurseForge.tga" },
         { label = L["DASH_WAGO"] or "Wago", url = "https://addons.wago.io/addons/jK8gY56y", icon = DASHBOARD_FOOTER_MEDIA .. "wago.tga" },
     }

--- a/tools/locale_audit_discord.js
+++ b/tools/locale_audit_discord.js
@@ -87,8 +87,8 @@ const description = [
     '_meta v/u/r = validated / unvalidated / needs_review (tools/locale-meta/)_',
     '',
     '**Want to help translate?**',
-    '1. See [TRANSLATING.md](https://github.com/Crystilac93/Horizon-Suite/blob/main/TRANSLATING.md)',
-    '2. Use [locale_template.lua](https://github.com/Crystilac93/Horizon-Suite/blob/main/Localisation/locale_template.lua)',
+    '1. See [TRANSLATING.md](https://github.com/Tacit-Labs/Horizon-Suite/blob/main/TRANSLATING.md)',
+    '2. Use [locale_template.lua](https://github.com/Tacit-Labs/Horizon-Suite/blob/main/Localisation/locale_template.lua)',
     '3. Post your file in <#localisation-submission> for review!',
 ].join('\n');
 


### PR DESCRIPTION
Closes #71

## Summary
- README (GitHub, CurseForge, Wago): release and Issues links use \Tacit-Labs/Horizon-Suite\.
- Dashboard: community footer GitHub URL and patch-notes changelog URL updated.
- Release tooling: default \GITHUB_REPOSITORY\ and \.release/issuelog.md\ issue links.
- \	ools/locale_audit_discord.js\: translating doc links in Discord embed text.

## Test plan
- [ ] Open README links in browser (latest release, beta, Issues).
- [ ] In-game: dashboard footer GitHub button and patch notes changelog link open correct repo paths.
- [ ] Optional: run changelog script dry-run if you use it locally.

Made with [Cursor](https://cursor.com)