### PR TITLE
fix(focus): suppress untracked nearby weeklies on right-click/untrack

### DIFF
--- a/modules/Focus/FocusCollapse.lua
+++ b/modules/Focus/FocusCollapse.lua
@@ -375,7 +375,7 @@ local function CountTrackedInLog(quests)
     for _, entry in ipairs(quests) do
         if not (entry.isRare or entry.category == "RARE" or entry.isAchievement or entry.category == "ACHIEVEMENT" or entry.isEndeavor or entry.category == "ENDEAVOR" or entry.isDecor or entry.category == "DECOR" or entry.isAppearance or entry.category == "APPEARANCE") then
             local qid = entry.questID
-            if qid and getLogIdx and getLogIdx(qid) and (not isWQ or not isWQ(qid)) then
+            if qid and getLogIdx and getLogIdx(qid) and (not isWQ or not isWQ(qid)) and entry.isTracked ~= false then
                 n = n + 1
             end
         end

--- a/modules/Focus/FocusInteractions.lua
+++ b/modules/Focus/FocusInteractions.lua
@@ -141,7 +141,23 @@ local function ShowQuestContextMenu(questID, questName, anchor)
             text = L["OPTIONS_FOCUS_STOP_TRACKING"] or "Stop tracking",
             notCheckable = true,
             func = function()
-                if C_QuestLog and C_QuestLog.RemoveQuestWatch then C_QuestLog.RemoveQuestWatch(questID) end
+                if anchor and anchor.isTracked == false then
+                    -- Quest is accepted+nearby but not in the watch list (e.g. warbound weekly).
+                    -- RemoveQuestWatch is a no-op; suppress via the session/permanent list.
+                    local usePermanent = addon.GetDB("permanentlySuppressUntracked", false)
+                    if usePermanent then
+                        local bl = addon.GetDB("permanentQuestBlacklist", nil)
+                        if type(bl) ~= "table" then bl = {} end
+                        bl[questID] = true
+                        addon.SetDB("permanentQuestBlacklist", bl)
+                        if addon.RefreshBlacklistGrid then addon.RefreshBlacklistGrid() end
+                    else
+                        if not addon.focus.recentlyUntrackedWeekliesAndDailies then addon.focus.recentlyUntrackedWeekliesAndDailies = {} end
+                        addon.focus.recentlyUntrackedWeekliesAndDailies[questID] = true
+                    end
+                elseif C_QuestLog and C_QuestLog.RemoveQuestWatch then
+                    C_QuestLog.RemoveQuestWatch(questID)
+                end
                 addon.ScheduleRefresh()
             end,
         }
@@ -1446,6 +1462,19 @@ QUEST_ACTIONS["untrack"] = function(entry)
             if addon.GetDB("suppressUntrackedUntilReload", false) then
                 addon.SetDB("sessionSuppressedQuests", addon.focus.recentlyUntrackedWorldQuests)
             end
+        end
+    elseif entry.isTracked == false then
+        -- Quest is accepted and nearby but not in the watch list (e.g. warbound weekly).
+        -- C_QuestLog.RemoveQuestWatch is a no-op here; suppress via the session/permanent list.
+        if usePermanent then
+            local bl = addon.GetDB("permanentQuestBlacklist", nil)
+            if type(bl) ~= "table" then bl = {} end
+            bl[entry.questID] = true
+            addon.SetDB("permanentQuestBlacklist", bl)
+            if addon.RefreshBlacklistGrid then addon.RefreshBlacklistGrid() end
+        else
+            if not addon.focus.recentlyUntrackedWeekliesAndDailies then addon.focus.recentlyUntrackedWeekliesAndDailies = {} end
+            addon.focus.recentlyUntrackedWeekliesAndDailies[entry.questID] = true
         end
     elseif C_QuestLog.RemoveQuestWatch then
         C_QuestLog.RemoveQuestWatch(entry.questID)


### PR DESCRIPTION
Closes #57

## Summary
Warbound weekly quests (e.g. "Grand Master Payne") are accepted by the player and surfaced via `FocusDailies` with `isTracked = false`. Because they are never in the watch list, three things misbehaved:
- The header counter was inflated (they were counted by `CountTrackedInLog` despite being untracked)
- Right-click "untrack" called `C_QuestLog.RemoveQuestWatch` — a no-op for unwatched quests — so the quest stayed visible
- Context menu "Stop tracking" had the same no-op issue

## Implementation notes
The suppression infrastructure for nearby weeklies/dailies already existed (`addon.focus.recentlyUntrackedWeekliesAndDailies`, checked in `FocusAggregator.lua:627`). The fix routes all three untrack paths through it when `entry.isTracked == false`, mirroring the existing world-quest suppression pattern. No new state or APIs required.

## Test plan
- Accept a warbound weekly quest (requires an active event such as Hallow's End)
- Confirm it appears in **Weekly Quests** while untracked
- Confirm the **header counter** does NOT include it
- **Right-click** (Horizon+ profile) → quest disappears; stays hidden until reload
- **Context menu → Stop tracking** (Blizzard+ profile right-click) → same result
- After reload quest reappears (session suppression clears on reload — expected)
- **Left-click / super-track** → quest promotes to Current Zone; counter now includes it (it is now explicitly tracked)