### PR TITLE
fix(focus): restore Current Event for untracked World Quests in area

### DIFF
--- a/modules/Focus/FocusAggregator.lua
+++ b/modules/Focus/FocusAggregator.lua
@@ -612,8 +612,12 @@ local function ReadTrackedQuests()
         local explicitlyKept = (opts.isTracked == true) or (opts.isAutoAdded == false)
             or (superTracked and e.questID == superTracked)
 
+        -- Bypass the untrack blacklist when the player is physically inside the quest area
+        -- (must still appear as Current Event) or for BonusObjective event quests
+        -- (proximity-only; never belong in the World Quests section anyway).
+        local currentEventEligible = opts.isInQuestArea == true or opts.isEventQuest == true
         if not seen[e.questID]
-            and not isBlacklisted
+            and (not isBlacklisted or currentEventEligible)
             and not isCompleted
             and (showWorldQuests == true or explicitlyKept) then
              addQuest(e.questID, opts)

--- a/modules/Focus/FocusWorldQuests.lua
+++ b/modules/Focus/FocusWorldQuests.lua
@@ -405,7 +405,11 @@ local function GetWorldAndCallingQuestIDsToShow(nearbySet, taskQuestOnlySet)
         local recentlyUntracked = addon.focus.recentlyUntrackedWorldQuests
         local ids = {}
         for questID, _ in pairs(nearbySet) do
-            if not seen[questID] and (not recentlyUntracked or not recentlyUntracked[questID]) then
+            -- Allow through when in the quest area even if untracked: the quest still
+            -- belongs in Current Event when the player is physically inside it.
+            -- IsPlayerInQuestArea is only called when the quest is actually blacklisted
+            -- (short-circuit or), so the API cost is negligible.
+            if not seen[questID] and (not recentlyUntracked or not recentlyUntracked[questID] or IsPlayerInQuestArea(questID)) then
                 -- Gate *untracked* map-derived entries by current zone map.
                 -- Watch-list WQs are handled above and remain visible if active.
                 if not IsQuestOnPlayerZoneMap(questID) then


### PR DESCRIPTION
Closes #50

## Summary
After using "Stop Tracking" on a World Quest, the Current Event section was invisible when entering the quest's zone — even after `/reload`. The untrack blacklist in the world quest aggregator loop was filtering the quest out entirely, preventing it from ever reaching the `CURRENT_EVENT` routing logic.

## Changes
- `modules/Focus/FocusAggregator.lua`: Added `currentEventEligible` bypass to the blacklist guard in the WQ collection loop. When `opts.isInQuestArea == true` (player is physically inside the quest area) or `opts.isEventQuest == true` (BonusObjective-type zone events), the quest passes through regardless of untrack state. The aggregator's existing routing (line 204) then correctly places it into `CURRENT_EVENT` rather than the World Quests section.

## Test plan
- [ ] Track any active World Quest in the Quest Log
- [ ] Use Horizon Focus' "Stop Tracking" on it — confirm it disappears from the **World Quests** section
- [ ] Travel into the World Quest's zone area — confirm **Current Event** section appears with objectives/timer
- [ ] `/reload` while still in the zone — Current Event should persist
- [ ] Leave the zone — Current Event should disappear
- [ ] Re-enter the zone — Current Event should reappear, still absent from World Quests section