### PR TITLE
feat(axis): add module name style setting (Horizon / Subtitle / Descriptive)

### DIFF
--- a/Localisation/enUS.lua
+++ b/Localisation/enUS.lua
@@ -73,6 +73,11 @@ L["OPTIONS_AXIS_PROFILES"]                                            = "Profile
 L["OPTIONS_AXIS_MODULES"]                                             = "Modules"
 L["OPTIONS_AXIS_MODULE_TOGGLES"]                                      = "Module Toggles"
 L["OPTIONS_AXIS_MODULE_PREVIEW_DISCLAIMER"]                           = "This module is currently in an early preview (alpha) state. Daily use is not advised due to bugs or unfinished functionality."
+L["OPTIONS_AXIS_MODULE_NAME_DISPLAY"]                                 = "Module name style"
+L["OPTIONS_AXIS_MODULE_NAME_DISPLAY_DESC"]                            = "How module names appear in the settings panel navigation and search filter."
+L["OPTIONS_AXIS_MODULE_NAME_HORIZON"]                                 = "Horizon"
+L["OPTIONS_AXIS_MODULE_NAME_SUBTITLE"]                                = "Subtitle"
+L["OPTIONS_AXIS_MODULE_NAME_DESCRIPTIVE"]                             = "Descriptive"
 L["OPTIONS_MODULE_RELOAD_HINT"]                                       = "Reload the interface to finish applying module changes."
 L["OPTIONS_MODULE_RELOAD_BUTTON"]                                     = "Reload UI"
 

--- a/core/Config.lua
+++ b/core/Config.lua
@@ -627,5 +627,16 @@ addon.BrandDisplay = {
         essence = "Essence",
         meridian = "Meridian",
     },
+    -- Human-readable descriptions shown in "Subtitle" and "Descriptive" name modes.
+    descriptive = {
+        axis     = "Settings",
+        focus    = "Objective Tracker",
+        presence = "Notifications",
+        vista    = "Minimap",
+        insight  = "Tooltips",
+        cache    = "Loot Toasts",
+        essence  = "Character Sheet",
+        meridian = "Meridian",
+    },
 }
 

--- a/options/OptionsData.lua
+++ b/options/OptionsData.lua
@@ -9,8 +9,8 @@ if not _G[addon.DB_NAME] then _G[addon.DB_NAME] = {} end
 
 local L = addon.L
 local function BrandModule(moduleKey)
-    local bd = addon.BrandDisplay
-    local t = bd and bd.module
+    if addon.GetModuleDisplayName then return addon.GetModuleDisplayName(moduleKey) end
+    local t = addon.BrandDisplay and addon.BrandDisplay.module
     if not moduleKey or not t then return nil end
     return t[moduleKey]
 end
@@ -842,6 +842,26 @@ local OptionCategories = {
         moduleKey = nil,
         options = function()
             local opts = {}
+            opts[#opts + 1] = { type = "section", name = L["OPTIONS_AXIS_MODULE_NAME_DISPLAY"] or "Module name style" }
+            opts[#opts + 1] = {
+                type = "dropdown",
+                name = L["OPTIONS_AXIS_MODULE_NAME_DISPLAY"] or "Module name style",
+                desc = L["OPTIONS_AXIS_MODULE_NAME_DISPLAY_DESC"] or "How module names appear in the settings panel navigation and search filter.",
+                dbKey = "moduleNameDisplay",
+                options = {
+                    { L["OPTIONS_AXIS_MODULE_NAME_HORIZON"]     or "Horizon",     "horizon"     },
+                    { L["OPTIONS_AXIS_MODULE_NAME_SUBTITLE"]    or "Subtitle",    "subtitle"    },
+                    { L["OPTIONS_AXIS_MODULE_NAME_DESCRIPTIVE"] or "Descriptive", "descriptive" },
+                },
+                get = function() return getDB("moduleNameDisplay", "horizon") end,
+                set = function(v)
+                    setDB("moduleNameDisplay", v)
+                    local dash = _G.HorizonSuiteDashboard
+                    if dash and dash.RefreshModuleDisplayNames then
+                        dash.RefreshModuleDisplayNames()
+                    end
+                end,
+            }
             opts[#opts + 1] = { type = "section", name = L["OPTIONS_FOCUS_THEME"] or "Theme" }
             local function dashboardBackgroundDropdownOptions()
                 local order = addon.DashboardBackgroundThemeOrder or { "horizon", "midnight", "talents" }

--- a/options/OptionsPanel.lua
+++ b/options/OptionsPanel.lua
@@ -2069,6 +2069,7 @@ end
 -- Build sidebar grouped by moduleKey (Modules, Focus, Presence)
 -- Use "modules" as sentinel for nil (WoW Lua disallows nil as table index)
 local function BrandModule(k)
+    if addon.GetModuleDisplayName then return addon.GetModuleDisplayName(k) end
     local t = addon.BrandDisplay and addon.BrandDisplay.module
     return t and t[k] or nil
 end

--- a/options/dashboard/DashboardFrame.lua
+++ b/options/dashboard/DashboardFrame.lua
@@ -128,6 +128,7 @@ function addon.Dashboard_BuildMainFrame()
                 essence = addon.Dashboard_BrandModule("essence"),
                 meridian = addon.Dashboard_BrandModule("meridian"),
             }
+            f.dashboardModuleLabels = moduleLabels
 
             -- Preview-labelled modules (tiles, sidebar, welcome); keep in sync with OptionsData Modules toggles.
             local PREVIEW_MODULE_KEYS = { cache = true, essence = true }
@@ -1701,6 +1702,7 @@ function addon.Dashboard_BuildMainFrame()
             -- ===== POPULATE SIDEBAR =====
             -- Group categories by moduleKey; build all groups so we can show/hide on refresh.
             local MODULE_LABELS = { ["axis"] = addon.Dashboard_BrandModule("axis") or "Axis", ["modules"] = L["OPTIONS_AXIS_MODULES"] or "Modules", ["focus"] = addon.Dashboard_BrandModule("focus"), ["presence"] = addon.Dashboard_BrandModule("presence"), ["insight"] = addon.Dashboard_BrandModule("insight"), ["cache"] = addon.Dashboard_BrandModule("cache"), ["vista"] = addon.Dashboard_BrandModule("vista"), ["essence"] = addon.Dashboard_BrandModule("essence"), ["meridian"] = addon.Dashboard_BrandModule("meridian") }
+            f.dashboardMODULE_LABELS = MODULE_LABELS
             local groups = {}
             for i, cat in ipairs(addon.OptionCategories) do
                 local mk
@@ -1712,6 +1714,7 @@ function addon.Dashboard_BuildMainFrame()
                 if not groups[mk] then groups[mk] = { label = MODULE_LABELS[mk] or L["OPTIONS_FOCUS_OTHER"], categories = {} } end
                 tinsert(groups[mk].categories, i)
             end
+            f.dashboardSidebarGroups = groups
             local groupOrder = { "axis", "focus", "insight", "essence", "presence", "vista", "cache" }
             local sidebarRows = {}
 
@@ -2129,6 +2132,40 @@ function addon.Dashboard_BuildMainFrame()
 
             LayoutSidebar()
             RefreshSidebar()
+
+            --- Live-refresh module display names in the sidebar and search filter when the
+            --- moduleNameDisplay setting changes. Home tiles and baked toggle labels update on reload.
+            local MODULE_NAME_KEYS = { "axis", "focus", "presence", "vista", "insight", "cache", "essence", "meridian" }
+            f.RefreshModuleDisplayNames = function()
+                -- Re-populate label caches in place so runtime closures pick up new values.
+                if f.dashboardModuleLabels then
+                    for _, mk in ipairs(MODULE_NAME_KEYS) do
+                        f.dashboardModuleLabels[mk] = addon.GetModuleDisplayName(mk)
+                    end
+                end
+                if f.dashboardMODULE_LABELS then
+                    for _, mk in ipairs(MODULE_NAME_KEYS) do
+                        f.dashboardMODULE_LABELS[mk] = addon.GetModuleDisplayName(mk)
+                    end
+                end
+                -- Update already-rendered sidebar group header labels.
+                if f.dashboardSidebarGroups then
+                    for _, mk in ipairs(MODULE_NAME_KEYS) do
+                        local g = f.dashboardSidebarGroups[mk]
+                        if g and g.header and g.header.label then
+                            local txt = addon.GetModuleDisplayName(mk):upper()
+                            if PREVIEW_MODULE_KEYS[mk] then
+                                txt = txt .. " |cff228b22(Preview)|r"
+                            end
+                            g.header.label:SetText(txt)
+                        end
+                    end
+                end
+                -- Refresh the search filter label if one is currently shown.
+                if f.UpdateSearchModuleFilterLabel then
+                    f.UpdateSearchModuleFilterLabel()
+                end
+            end
 
             -- ==================================================================
             -- RESIZE GRABBER + Dashboard_CommitResize

--- a/options/dashboard/DashboardFrame.lua
+++ b/options/dashboard/DashboardFrame.lua
@@ -1875,7 +1875,7 @@ function addon.Dashboard_BuildMainFrame()
                         addon.Dashboard_RegisterTypographyFontString(typoRefs, headerLabel, 12, nil, true)
                         headerLabel:SetPoint("LEFT", chevron, "RIGHT", 4, 0)
                         headerLabel:SetTextColor(0.55, 0.55, 0.65, 1)
-                        local headerLabelText = (g.label or ""):upper()
+                        local headerLabelText = addon.FormatModuleNameForSidebar and addon.FormatModuleNameForSidebar(mk) or (g.label or ""):upper()
                         if PREVIEW_MODULE_KEYS[mk] then
                             headerLabelText = headerLabelText .. " |cff228b22(Preview)|r"
                         end
@@ -2153,7 +2153,7 @@ function addon.Dashboard_BuildMainFrame()
                     for _, mk in ipairs(MODULE_NAME_KEYS) do
                         local g = f.dashboardSidebarGroups[mk]
                         if g and g.header and g.header.label then
-                            local txt = addon.GetModuleDisplayName(mk):upper()
+                            local txt = addon.FormatModuleNameForSidebar and addon.FormatModuleNameForSidebar(mk) or addon.GetModuleDisplayName(mk):upper()
                             if PREVIEW_MODULE_KEYS[mk] then
                                 txt = txt .. " |cff228b22(Preview)|r"
                             end

--- a/options/dashboard/DashboardFrame.lua
+++ b/options/dashboard/DashboardFrame.lua
@@ -1720,6 +1720,31 @@ function addon.Dashboard_BuildMainFrame()
             -- Extra height added to group headers when subtitle mode is active.
             local SUBTITLE_EXTRA_H = 14
 
+            -- Returns (labelText, headerHeight) for a sidebar group header.
+            -- Extracted to a helper so its locals don't count against Dashboard_BuildMainFrame's
+            -- 200-local limit (Lua 5.1 enforces per-function, not per-block).
+            local function BuildSidebarGroupHeader(mk)
+                local bd = addon.BrandDisplay
+                local mode = (addon.GetDB and addon.GetDB("moduleNameDisplay", "horizon")) or "horizon"
+                local codeName = (bd and bd.module and bd.module[mk] or mk):upper()
+                local labelText
+                local height = HEADER_ROW_HEIGHT
+                if mode == "subtitle" then
+                    local desc = bd and bd.descriptive and bd.descriptive[mk]
+                    if desc then
+                        labelText = codeName .. "\n|cff505065" .. desc .. "|r"
+                        height = HEADER_ROW_HEIGHT + SUBTITLE_EXTRA_H
+                    else
+                        labelText = codeName
+                    end
+                elseif mode == "descriptive" then
+                    labelText = (bd and bd.descriptive and bd.descriptive[mk] or codeName):upper()
+                else
+                    labelText = codeName
+                end
+                return labelText, height
+            end
+
             local function ShouldShowDashboardSubcategory(mk, cat)
                 if not cat then return false end
                 if mk == "axis" and cat.key == "Modules" then
@@ -1823,10 +1848,7 @@ function addon.Dashboard_BuildMainFrame()
                     else
                         -- Header row (clickable, collapsible)
                         local prevLastRow = lastSidebarRow
-                        local _bd = addon.BrandDisplay
-                        local _curMode = addon.GetDB and addon.GetDB("moduleNameDisplay", "horizon") or "horizon"
-                        local _hasSubtitle = (_curMode == "subtitle") and _bd and _bd.descriptive and (_bd.descriptive[mk] ~= nil)
-                        local headerH = HEADER_ROW_HEIGHT + (_hasSubtitle and SUBTITLE_EXTRA_H or 0)
+                        local headerLabelText, headerH = BuildSidebarGroupHeader(mk)
                         local header = CreateFrame("Button", nil, sidebarScrollContent)
                         header:SetSize(SIDEBAR_WIDTH - 1, headerH)
                         header.baseHeight = HEADER_ROW_HEIGHT
@@ -1885,18 +1907,6 @@ function addon.Dashboard_BuildMainFrame()
                         headerLabel:SetWidth(SIDEBAR_WIDTH - SIDEBAR_CONTENT_X_INSET - 20)
                         headerLabel:SetJustifyV("TOP")
                         headerLabel:SetTextColor(0.55, 0.55, 0.65, 1)
-                        -- Build label text: in subtitle mode the descriptor goes on a second line,
-                        -- muted and in mixed case so it reads as secondary to the code-name.
-                        local _codeName = (_bd and _bd.module and _bd.module[mk] or mk):upper()
-                        local headerLabelText
-                        if _curMode == "subtitle" and _hasSubtitle then
-                            local _desc = _bd.descriptive[mk]
-                            headerLabelText = _codeName .. "\n|cff505065" .. _desc .. "|r"
-                        elseif _curMode == "descriptive" then
-                            headerLabelText = (_bd and _bd.descriptive and _bd.descriptive[mk] or _codeName):upper()
-                        else
-                            headerLabelText = _codeName
-                        end
                         if PREVIEW_MODULE_KEYS[mk] then
                             headerLabelText = headerLabelText .. " |cff228b22(Preview)|r"
                         end

--- a/options/dashboard/DashboardFrame.lua
+++ b/options/dashboard/DashboardFrame.lua
@@ -2172,9 +2172,6 @@ function addon.Dashboard_BuildMainFrame()
             --- moduleNameDisplay setting changes. Home tiles and baked toggle labels update on reload.
             local MODULE_NAME_KEYS = { "axis", "focus", "presence", "vista", "insight", "cache", "essence", "meridian" }
             f.RefreshModuleDisplayNames = function()
-                local bd = addon.BrandDisplay
-                local mode = addon.GetDB and addon.GetDB("moduleNameDisplay", "horizon") or "horizon"
-
                 -- Re-populate label caches in place so runtime closures pick up new values.
                 if f.dashboardModuleLabels then
                     for _, mk in ipairs(MODULE_NAME_KEYS) do
@@ -2187,23 +2184,17 @@ function addon.Dashboard_BuildMainFrame()
                     end
                 end
                 -- Update already-rendered sidebar group header labels and heights.
+                -- Delegate format/height computation to BuildSidebarGroupHeader so build/refresh
+                -- paths stay in sync if the format changes.
                 if f.dashboardSidebarGroups then
                     for _, mk in ipairs(MODULE_NAME_KEYS) do
                         local g = f.dashboardSidebarGroups[mk]
                         if g and g.header and g.header.label then
-                            local codeName = (bd and bd.module and bd.module[mk] or mk):upper()
-                            local desc = bd and bd.descriptive and bd.descriptive[mk]
-                            local txt
-                            if mode == "subtitle" and desc then
-                                txt = codeName .. "\n|cff505065" .. desc .. "|r"
-                                g.header:SetHeight((g.header.baseHeight or HEADER_ROW_HEIGHT) + SUBTITLE_EXTRA_H)
-                            else
-                                txt = (mode == "descriptive" and desc) and desc:upper() or codeName
-                                g.header:SetHeight(g.header.baseHeight or HEADER_ROW_HEIGHT)
-                            end
+                            local txt, h = BuildSidebarGroupHeader(mk)
                             if PREVIEW_MODULE_KEYS[mk] then
                                 txt = txt .. " |cff228b22(Preview)|r"
                             end
+                            g.header:SetHeight(h)
                             g.header.label:SetText(txt)
                             if g.header.updateSpacer then g.header.updateSpacer() end
                         end

--- a/options/dashboard/DashboardFrame.lua
+++ b/options/dashboard/DashboardFrame.lua
@@ -1717,6 +1717,8 @@ function addon.Dashboard_BuildMainFrame()
             f.dashboardSidebarGroups = groups
             local groupOrder = { "axis", "focus", "insight", "essence", "presence", "vista", "cache" }
             local sidebarRows = {}
+            -- Extra height added to group headers when subtitle mode is active.
+            local SUBTITLE_EXTRA_H = 14
 
             local function ShouldShowDashboardSubcategory(mk, cat)
                 if not cat then return false end
@@ -1821,11 +1823,16 @@ function addon.Dashboard_BuildMainFrame()
                     else
                         -- Header row (clickable, collapsible)
                         local prevLastRow = lastSidebarRow
+                        local _bd = addon.BrandDisplay
+                        local _curMode = addon.GetDB and addon.GetDB("moduleNameDisplay", "horizon") or "horizon"
+                        local _hasSubtitle = (_curMode == "subtitle") and _bd and _bd.descriptive and (_bd.descriptive[mk] ~= nil)
+                        local headerH = HEADER_ROW_HEIGHT + (_hasSubtitle and SUBTITLE_EXTRA_H or 0)
                         local header = CreateFrame("Button", nil, sidebarScrollContent)
-                        header:SetSize(SIDEBAR_WIDTH - 1, HEADER_ROW_HEIGHT)
+                        header:SetSize(SIDEBAR_WIDTH - 1, headerH)
+                        header.baseHeight = HEADER_ROW_HEIGHT
                         header:SetPoint("TOPLEFT", lastSidebarRow, "BOTTOMLEFT", 0, 0)
                         lastSidebarRow = header
-                        yOff = yOff + HEADER_ROW_HEIGHT
+                        yOff = yOff + headerH
                         header.groupKey = mk
                         g.header = header
                         local headerBtnBg = header:CreateTexture(nil, "BACKGROUND")
@@ -1855,7 +1862,8 @@ function addon.Dashboard_BuildMainFrame()
                             end
                         end
                         addon.Dashboard_RegisterTypographyFontString(typoRefs, chevron, 11, nil, true)
-                        chevron:SetPoint("LEFT", header, "LEFT", 8, 0)
+                        -- TOP-anchored so it stays in the code-name row regardless of header height.
+                        chevron:SetPoint("TOPLEFT", header, "TOPLEFT", 8, -9)
                         chevron:SetTextColor(0.55, 0.55, 0.65, 1)
                         header.chevron = chevron
                         local headerLabel = header:CreateFontString(nil, "OVERLAY")
@@ -1873,9 +1881,22 @@ function addon.Dashboard_BuildMainFrame()
                             end
                         end
                         addon.Dashboard_RegisterTypographyFontString(typoRefs, headerLabel, 12, nil, true)
-                        headerLabel:SetPoint("LEFT", chevron, "RIGHT", 4, 0)
+                        headerLabel:SetPoint("TOPLEFT", chevron, "TOPRIGHT", 4, 0)
+                        headerLabel:SetWidth(SIDEBAR_WIDTH - SIDEBAR_CONTENT_X_INSET - 20)
+                        headerLabel:SetJustifyV("TOP")
                         headerLabel:SetTextColor(0.55, 0.55, 0.65, 1)
-                        local headerLabelText = addon.FormatModuleNameForSidebar and addon.FormatModuleNameForSidebar(mk) or (g.label or ""):upper()
+                        -- Build label text: in subtitle mode the descriptor goes on a second line,
+                        -- muted and in mixed case so it reads as secondary to the code-name.
+                        local _codeName = (_bd and _bd.module and _bd.module[mk] or mk):upper()
+                        local headerLabelText
+                        if _curMode == "subtitle" and _hasSubtitle then
+                            local _desc = _bd.descriptive[mk]
+                            headerLabelText = _codeName .. "\n|cff505065" .. _desc .. "|r"
+                        elseif _curMode == "descriptive" then
+                            headerLabelText = (_bd and _bd.descriptive and _bd.descriptive[mk] or _codeName):upper()
+                        else
+                            headerLabelText = _codeName
+                        end
                         if PREVIEW_MODULE_KEYS[mk] then
                             headerLabelText = headerLabelText .. " |cff228b22(Preview)|r"
                         end
@@ -2117,6 +2138,8 @@ function addon.Dashboard_BuildMainFrame()
                 end
             end
 
+            f.DashboardRefreshSidebar = RefreshSidebar
+
             --- Live refresh when modules are toggled (called from SetModuleEnabled).
             addon.Dashboard_Refresh = function()
                 if not f or not f:IsShown() then return end
@@ -2137,6 +2160,9 @@ function addon.Dashboard_BuildMainFrame()
             --- moduleNameDisplay setting changes. Home tiles and baked toggle labels update on reload.
             local MODULE_NAME_KEYS = { "axis", "focus", "presence", "vista", "insight", "cache", "essence", "meridian" }
             f.RefreshModuleDisplayNames = function()
+                local bd = addon.BrandDisplay
+                local mode = addon.GetDB and addon.GetDB("moduleNameDisplay", "horizon") or "horizon"
+
                 -- Re-populate label caches in place so runtime closures pick up new values.
                 if f.dashboardModuleLabels then
                     for _, mk in ipairs(MODULE_NAME_KEYS) do
@@ -2148,19 +2174,31 @@ function addon.Dashboard_BuildMainFrame()
                         f.dashboardMODULE_LABELS[mk] = addon.GetModuleDisplayName(mk)
                     end
                 end
-                -- Update already-rendered sidebar group header labels.
+                -- Update already-rendered sidebar group header labels and heights.
                 if f.dashboardSidebarGroups then
                     for _, mk in ipairs(MODULE_NAME_KEYS) do
                         local g = f.dashboardSidebarGroups[mk]
                         if g and g.header and g.header.label then
-                            local txt = addon.FormatModuleNameForSidebar and addon.FormatModuleNameForSidebar(mk) or addon.GetModuleDisplayName(mk):upper()
+                            local codeName = (bd and bd.module and bd.module[mk] or mk):upper()
+                            local desc = bd and bd.descriptive and bd.descriptive[mk]
+                            local txt
+                            if mode == "subtitle" and desc then
+                                txt = codeName .. "\n|cff505065" .. desc .. "|r"
+                                g.header:SetHeight((g.header.baseHeight or HEADER_ROW_HEIGHT) + SUBTITLE_EXTRA_H)
+                            else
+                                txt = (mode == "descriptive" and desc) and desc:upper() or codeName
+                                g.header:SetHeight(g.header.baseHeight or HEADER_ROW_HEIGHT)
+                            end
                             if PREVIEW_MODULE_KEYS[mk] then
                                 txt = txt .. " |cff228b22(Preview)|r"
                             end
                             g.header.label:SetText(txt)
+                            if g.header.updateSpacer then g.header.updateSpacer() end
                         end
                     end
                 end
+                -- Relayout sidebar so scroll height accounts for any height changes above.
+                if f.DashboardRefreshSidebar then f.DashboardRefreshSidebar() end
                 -- Refresh the search filter label if one is currently shown.
                 if f.UpdateSearchModuleFilterLabel then
                     f.UpdateSearchModuleFilterLabel()

--- a/options/dashboard/DashboardFrame.lua
+++ b/options/dashboard/DashboardFrame.lua
@@ -1884,8 +1884,7 @@ function addon.Dashboard_BuildMainFrame()
                             end
                         end
                         addon.Dashboard_RegisterTypographyFontString(typoRefs, chevron, 11, nil, true)
-                        -- TOP-anchored so it stays in the code-name row regardless of header height.
-                        chevron:SetPoint("TOPLEFT", header, "TOPLEFT", 8, -9)
+                        chevron:SetPoint("LEFT", header, "LEFT", 8, 0)
                         chevron:SetTextColor(0.55, 0.55, 0.65, 1)
                         header.chevron = chevron
                         local headerLabel = header:CreateFontString(nil, "OVERLAY")
@@ -1903,9 +1902,12 @@ function addon.Dashboard_BuildMainFrame()
                             end
                         end
                         addon.Dashboard_RegisterTypographyFontString(typoRefs, headerLabel, 12, nil, true)
-                        headerLabel:SetPoint("TOPLEFT", chevron, "TOPRIGHT", 4, 0)
-                        headerLabel:SetWidth(SIDEBAR_WIDTH - SIDEBAR_CONTENT_X_INSET - 20)
-                        headerLabel:SetJustifyV("TOP")
+                        -- Use LEFT anchor (vertically centered to chevron) to match original single-line
+                        -- formatting. With multiline text (\n for subtitle), the fontstring expands
+                        -- symmetrically around the anchor, so both lines remain left-aligned and
+                        -- naturally centered in the taller header frame.
+                        headerLabel:SetPoint("LEFT", chevron, "RIGHT", 4, 0)
+                        headerLabel:SetJustifyH("LEFT")
                         headerLabel:SetTextColor(0.55, 0.55, 0.65, 1)
                         if PREVIEW_MODULE_KEYS[mk] then
                             headerLabelText = headerLabelText .. " |cff228b22(Preview)|r"

--- a/options/dashboard/DashboardUtil.lua
+++ b/options/dashboard/DashboardUtil.lua
@@ -26,12 +26,29 @@ local FOOTER_LINK_MAX_VISUAL_H = 16
 local FOOTER_LINK_ICON_INSET = 4
 local FOOTER_LINK_GAP = 10
 
+--- Returns the display name for a module key based on the moduleNameDisplay DB setting.
+--- Modes: "horizon" (code-name only), "subtitle" (code-name – descriptor), "descriptive" (descriptor only).
+--- @param moduleKey string|nil
+--- @return string
+function addon.GetModuleDisplayName(moduleKey)
+    local bd = addon.BrandDisplay
+    if not bd or not moduleKey then return moduleKey or "" end
+    local codeName = (bd.module and bd.module[moduleKey]) or moduleKey
+    local mode = addon.GetDB and addon.GetDB("moduleNameDisplay", "horizon") or "horizon"
+    if mode == "subtitle" then
+        local desc = bd.descriptive and bd.descriptive[moduleKey]
+        return desc and (codeName .. " \226\128\147 " .. desc) or codeName
+    elseif mode == "descriptive" then
+        return (bd.descriptive and bd.descriptive[moduleKey]) or codeName
+    end
+    return codeName
+end
+
 --- @param moduleKey string|nil
 --- @return string|nil
 function addon.Dashboard_BrandModule(moduleKey)
-    local t = addon.BrandDisplay and addon.BrandDisplay.module
-    if not moduleKey or not t then return nil end
-    return t[moduleKey]
+    if not moduleKey then return nil end
+    return addon.GetModuleDisplayName(moduleKey)
 end
 
 -- Categories shown under the Axis hub (dashboard + search); keep in sync with OptionCategories keys.

--- a/options/dashboard/DashboardUtil.lua
+++ b/options/dashboard/DashboardUtil.lua
@@ -44,9 +44,9 @@ function addon.GetModuleDisplayName(moduleKey)
     return codeName
 end
 
---- Returns a sidebar-ready formatted string: code-name uppercased, subtitle descriptor in
---- a muted colour at original case to create visual hierarchy within a single fontstring.
---- WoW fontstrings cannot change font size inline, so colour contrast is used instead.
+--- Returns a single-line formatted string suitable for compact contexts (search filter, tooltips).
+--- In "subtitle" mode the descriptor is appended in muted colour separated by an en dash.
+--- The sidebar group headers use a two-line layout instead (see DashboardFrame.lua).
 --- @param moduleKey string|nil
 --- @return string
 function addon.FormatModuleNameForSidebar(moduleKey)

--- a/options/dashboard/DashboardUtil.lua
+++ b/options/dashboard/DashboardUtil.lua
@@ -44,6 +44,29 @@ function addon.GetModuleDisplayName(moduleKey)
     return codeName
 end
 
+--- Returns a sidebar-ready formatted string: code-name uppercased, subtitle descriptor in
+--- a muted colour at original case to create visual hierarchy within a single fontstring.
+--- WoW fontstrings cannot change font size inline, so colour contrast is used instead.
+--- @param moduleKey string|nil
+--- @return string
+function addon.FormatModuleNameForSidebar(moduleKey)
+    local bd = addon.BrandDisplay
+    if not bd or not moduleKey then return (moduleKey or ""):upper() end
+    local codeName = (bd.module and bd.module[moduleKey] or moduleKey):upper()
+    local mode = addon.GetDB and addon.GetDB("moduleNameDisplay", "horizon") or "horizon"
+    if mode == "subtitle" then
+        local desc = bd.descriptive and bd.descriptive[moduleKey]
+        if desc then
+            -- Muted grayish colour for the descriptor; kept in mixed case to further
+            -- differentiate from the uppercased code-name.
+            return codeName .. " |cff505065\226\128\147 " .. desc .. "|r"
+        end
+    elseif mode == "descriptive" then
+        return (bd.descriptive and bd.descriptive[moduleKey] or codeName):upper()
+    end
+    return codeName
+end
+
 --- @param moduleKey string|nil
 --- @return string|nil
 function addon.Dashboard_BrandModule(moduleKey)


### PR DESCRIPTION
Closes #77

## Summary
Adds a **Module name style** dropdown to the Global Settings panel that controls how module names are displayed across the settings dashboard navigation and search filter.

| Mode | Example |
|------|---------|
| **Horizon** *(default)* | Vista |
| **Subtitle** | Vista – Minimap |
| **Descriptive** | Minimap |

The setting updates the dashboard sidebar group headers and search filter label live (no reload required). Home tiles and module toggle labels in the Modules section update on the next `/reload` since they are baked at frame-build time.

## Implementation notes
- `addon.GetModuleDisplayName(key)` in `DashboardUtil.lua` is the single resolver — reads `moduleNameDisplay` DB key (default `"horizon"`) and formats using `addon.BrandDisplay.descriptive`.
- `addon.Dashboard_BrandModule()` now delegates to `GetModuleDisplayName()` so all callers get the new behaviour automatically.
- `f.RefreshModuleDisplayNames()` on the dashboard frame updates the two label caches and sidebar header text in place; called from the option's `set()` callback.
- Legacy `OptionsPanel.lua` `BrandModule()` also delegates; sidebar group headers there are baked at load time (legacy panel — acceptable).

## Test plan
- [ ] Open dashboard → sidebar shows "Focus", "Vista", "Presence" etc. unchanged (Horizon mode default)
- [ ] Global Settings → change "Module name style" to **Subtitle** → sidebar immediately shows "Focus – Objective Tracker", "Vista – Minimap" etc.
- [ ] Change to **Descriptive** → sidebar shows "Objective Tracker", "Minimap" etc.
- [ ] Open search filter dropdown → module names reflect current setting
- [ ] `/reload` → setting persists and names are correct on reload
- [ ] Module toggle labels in Modules section: unchanged until reload (expected V1 behaviour)