### PR TITLE
fix(ci): scope issuelog cache to message-id file only

### DIFF
--- a/.github/workflows/issuelog.yml
+++ b/.github/workflows/issuelog.yml
@@ -34,8 +34,8 @@ jobs:
       - name: Restore cached message IDs
         uses: actions/cache/restore@v4
         with:
-          path: .release
-          key: issuelog-msg-id
+          path: .release/discord-issuelog-message-id
+          key: issuelog-msg-id-v2
 
       - name: Generate issue log payloads
         run: bash .release/run-issuelog.sh
@@ -107,7 +107,7 @@ jobs:
       - name: Save message IDs to cache
         if: steps.discord.outputs.skip != 'true' && steps.discord.outputs.id != ''
         run: |
-          gh cache delete issuelog-msg-id --repo "$GITHUB_REPOSITORY" || true
+          gh cache delete issuelog-msg-id-v2 --repo "$GITHUB_REPOSITORY" || true
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -115,6 +115,6 @@ jobs:
         if: steps.discord.outputs.skip != 'true' && steps.discord.outputs.id != ''
         uses: actions/cache/save@v4
         with:
-          path: .release
-          key: issuelog-msg-id
+          path: .release/discord-issuelog-message-id
+          key: issuelog-msg-id-v2
 

--- a/.release/run-issuelog.sh
+++ b/.release/run-issuelog.sh
@@ -7,25 +7,15 @@ set -e
 
 export GITHUB_REPOSITORY="${GITHUB_REPOSITORY:-Tacit-Labs/Horizon-Suite}"
 
-# Fetch all open issues (paginated; default limit would miss issues past 100)
-ISSUES="[]"
-page=1
-while true; do
-  batch=$(gh issue list --state open --json number,title,labels,body,url,createdAt,updatedAt,assignees --limit 100 --page "$page" 2>/dev/null || echo "[]")
-  cnt=$(echo "$batch" | jq 'length')
-  if [ "$cnt" -eq 0 ]; then
-    break
-  fi
-  ISSUES=$(jq -n --argjson acc "$ISSUES" --argjson b "$batch" '$acc + $b')
-  if [ "$cnt" -lt 100 ]; then
-    break
-  fi
-  page=$((page + 1))
-  if [ "$page" -gt 50 ]; then
-    echo "Warning: stopped pagination after 50 pages" >&2
-    break
-  fi
-done
+# Fetch all open issues. `gh issue list` auto-paginates internally up to --limit;
+# there is no --page flag (using one silently returns empty and produces 0 counts).
+ISSUES=$(gh issue list --state open --json number,title,labels,body,url,createdAt,updatedAt,assignees --limit 1000 2>&1)
+if ! echo "$ISSUES" | jq empty >/dev/null 2>&1; then
+  echo "Error: gh issue list failed or returned non-JSON output:" >&2
+  echo "$ISSUES" | head -c 1200 >&2
+  exit 1
+fi
+echo "Fetched $(echo "$ISSUES" | jq 'length') open issue(s)"
 
 BUGS=""
 FEATURES=""


### PR DESCRIPTION
## Summary

Follow-up to #82. After that merge, the Discord issue-log post still showed all zeros because the `actions/cache` step was restoring a stale copy of `.release/run-issuelog.sh` on top of the checkout — undoing the `--page` fix before it could run. Workflow log confirmed: the `Generate issue log payloads` step completed in ~90 ms (no real `gh` API call) and never printed the new `Fetched N open issue(s)` line.

Root cause: the cache `path` was the entire `.release/` directory, so `cache/save` archived the script alongside the message-id file, and the next run's `cache/restore` clobbered the freshly-checked-out script.

## Changes

- Scope `cache/restore` and `cache/save` `path` to `.release/discord-issuelog-message-id` (just the one file that actually needs to persist across runs).
- Bump the cache key from `issuelog-msg-id` → `issuelog-msg-id-v2` to invalidate the poisoned cache on first run after merge.

## Test plan

- [ ] Merge, then trigger `Post Issue Log to Discord` via `workflow_dispatch`
- [ ] Verify the `Generate issue log payloads` step prints `Fetched N open issue(s)` and takes noticeably longer than ~90ms
- [ ] Verify the Discord post header shows real counts (non-zero for Bugs/Features/Improvements as appropriate)
- [ ] One stale message from the previous (cache-invalidated) run may remain in the channel; delete manually. Subsequent runs should resume normal delete-and-repost behavior.

https://claude.ai/code/session_016BnB3aL74jFRPAabQy8P5V