### PR TITLE
chore(release): host issuelog logo in-repo for v2 webhook

### DIFF
--- a/.release/run-issuelog-v2.sh
+++ b/.release/run-issuelog-v2.sh
@@ -27,9 +27,10 @@ REPO_URL="https://github.com/${GITHUB_REPOSITORY}"
 TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 DATE_HUMAN=$(date -u +"%b %-d, %Y")
 
-# Horizon logo thumbnail: GitHub serves org avatars from this URL.
-# Swap for a dedicated asset later by editing this single constant.
-HORIZON_LOGO="https://github.com/Tacit-Labs.png"
+# Horizon logo thumbnail: served from the repo via raw.githubusercontent.
+# Swap for a different asset later by editing this single constant (bump a
+# ?v=N suffix if you overwrite the file in-place, since Discord caches by URL).
+HORIZON_LOGO="https://raw.githubusercontent.com/Tacit-Labs/Horizon-Suite/main/assets/social/issuelog-logo.png"
 AVATAR_URL="$HORIZON_LOGO"
 USERNAME="HorizonSuite Issue Bot"
 


### PR DESCRIPTION
## Summary
- Commits a dedicated issuelog logo asset at \`assets/social/issuelog-logo.png\` and points the v2 issuelog webhook at it via raw.githubusercontent.
- Removes reliance on the GitHub org avatar URL, which is not owned by this repo and can change.

## Changes
- \`assets/social/issuelog-logo.png\` — new committed asset
- \`.release/run-issuelog-v2.sh\` — \`HORIZON_LOGO\` constant now points at the in-repo asset; comment notes Discord caches by URL so bump a \`?v=N\` suffix if replacing in place

## Test Plan
- [ ] Trigger the v2 issuelog workflow and confirm the Discord embed thumbnail renders from the new URL
- [ ] Verify the asset is accessible at the raw.githubusercontent path after merge to main