### PR TITLE
fix(insight): defer cursor anchor to next tick to avoid map tooltip taint

### DIFF
--- a/modules/Insight/InsightCursorAnchor.lua
+++ b/modules/Insight/InsightCursorAnchor.lua
@@ -1,7 +1,10 @@
 --[[
     Horizon Suite - Insight Cursor Anchor
     Hook GameTooltip_SetDefaultAnchor and apply cursor-side or fixed positioning.
-    No per-frame updates, no manual line clearing, no state tracking.
+    Anchor changes are deferred to the next tick via C_Timer.NewTimer so the
+    secure post-hook never mutates the tooltip synchronously inside Blizzard's
+    tooltip-update chain (prevents widget-set taint on map / POI tooltips —
+    see modules/Insight/CLAUDE.md).
 ]]
 
 if not _G.HorizonSuite and not _G.HorizonSuiteBeta then _G.HorizonSuite = {} end
@@ -43,26 +46,80 @@ local function GetCursorOffsetY()
     return tonumber(addon.GetDB("insightCursorOffsetY", 0)) or 0
 end
 
+local function IsOwnedByWorldMap(frame)
+    if not frame or not _G.WorldMapFrame then return false end
+    local cur = frame
+    for _ = 1, 8 do
+        if not cur then return false end
+        if cur == _G.WorldMapFrame then return true end
+        if type(cur.GetParent) ~= "function" then return false end
+        cur = cur:GetParent()
+    end
+    return false
+end
+
+local function IsUsable(tooltip)
+    if not tooltip or not tooltip.SetOwner then return false end
+    if tooltip.IsForbidden and tooltip:IsForbidden() then return false end
+    return true
+end
+
 function Insight.HookCursorAnchor()
     GameTooltip:SetClampedToScreen(true)
     hooksecurefunc("GameTooltip_SetDefaultAnchor", function(tooltip, parent)
         if not Insight.IsInsightEnabled() then return end
-        if not tooltip or not tooltip.SetOwner then return end
-        if tooltip.IsForbidden and tooltip:IsForbidden() then return end
+        if not IsUsable(tooltip) then return end
         if parent and parent.IsForbidden and parent:IsForbidden() then return end
 
+        -- Skip custom anchoring for tooltips owned by the world map: keeps
+        -- Blizzard's native anchor and avoids a one-frame jump.
+        local ownerForCheck = parent or (tooltip.GetOwner and tooltip:GetOwner())
+        if IsOwnedByWorldMap(ownerForCheck) then return end
+
         local mode = GetAnchorMode()
+        if mode ~= "cursor" and mode ~= "fixed" then return end
+
+        -- Capture config now so the deferred closure uses the values that
+        -- were in effect at hook time.
+        local cursorSide, cursorOffX, cursorOffY
+        local fixedPoint, fixedX, fixedY
         if mode == "cursor" then
-            local side = GetCursorSide()
-            if side == "left" then
-                tooltip:SetOwner(parent, "ANCHOR_CURSOR_LEFT", GetCursorOffsetX(), GetCursorOffsetY())
-            elseif side == "right" then
-                tooltip:SetOwner(parent, "ANCHOR_CURSOR_RIGHT", GetCursorOffsetX(), GetCursorOffsetY())
+            cursorSide = GetCursorSide()
+            if cursorSide ~= "left" and cursorSide ~= "right" then
+                -- "center": let Blizzard handle ANCHOR_CURSOR natively.
+                return
             end
-            -- "center": let Blizzard handle ANCHOR_CURSOR natively
-        elseif mode == "fixed" then
-            tooltip:ClearAllPoints()
-            tooltip:SetPoint(GetFixedPoint(), UIParent, GetFixedPoint(), GetFixedX(), GetFixedY())
+            cursorOffX = GetCursorOffsetX()
+            cursorOffY = GetCursorOffsetY()
+        else -- "fixed"
+            fixedPoint = GetFixedPoint()
+            fixedX = GetFixedX()
+            fixedY = GetFixedY()
         end
+
+        -- Coalesce repeated SetDefaultAnchor calls on the same tooltip.
+        local pending = tooltip._insightAnchorTimer
+        if pending then
+            if type(pending.Cancel) == "function" then
+                pending:Cancel()
+            end
+            tooltip._insightAnchorTimer = nil
+        end
+
+        tooltip._insightAnchorTimer = C_Timer.NewTimer(0, function()
+            tooltip._insightAnchorTimer = nil
+            if not Insight.IsInsightEnabled() then return end
+            if not IsUsable(tooltip) then return end
+
+            if mode == "cursor" then
+                if not parent then return end
+                if parent.IsForbidden and parent:IsForbidden() then return end
+                local anchor = (cursorSide == "left") and "ANCHOR_CURSOR_LEFT" or "ANCHOR_CURSOR_RIGHT"
+                tooltip:SetOwner(parent, anchor, cursorOffX, cursorOffY)
+            else -- "fixed"
+                tooltip:ClearAllPoints()
+                tooltip:SetPoint(fixedPoint, UIParent, fixedPoint, fixedX, fixedY)
+            end
+        end)
     end)
 end


### PR DESCRIPTION
## Summary
- Defer the Insight cursor-anchor mutation to the next tick via \`C_Timer.NewTimer(0, ...)\` so the secure post-hook on \`GameTooltip_SetDefaultAnchor\` never runs synchronously inside Blizzard's tooltip-update chain.
- Skip custom anchoring entirely for tooltips owned by \`WorldMapFrame\`, which is the taint surface for map POI tooltips.
- Coalesce repeated \`SetDefaultAnchor\` calls on the same tooltip by cancelling any pending timer before scheduling a new one.

## Changes
- \`modules/Insight/InsightCursorAnchor.lua\`:
  - New \`IsOwnedByWorldMap(frame)\` walker (bounded to 8 ancestors) and \`IsUsable(tooltip)\` helper
  - Capture config values at hook time; apply them inside the deferred closure so behaviour matches the caller's intent
  - Cancel \`tooltip._insightAnchorTimer\` if a new hook fires before the previous one resolves

## Test Plan
- [ ] Open the world map and hover POIs — no taint errors, no one-frame jump; Blizzard's native anchor is used
- [ ] Hover items/spells with cursor mode set to left and right — anchor applies on next tick, offsets respected
- [ ] Switch to fixed mode — tooltip clamps to configured point on UIParent
- [ ] Switch to \`center\` cursor side — Blizzard's native \`ANCHOR_CURSOR\` is preserved (early return)
- [ ] Enter combat / use action bars heavily — no taint on secure frames