### PR TITLE
chore(gitignore): ignore python bytecode artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,7 @@ tools/gitlab-issues-dry-run-example.json
 tools/gitlab-issue-import-results.json
 /wowapi/
 assets\social
+
+# Python bytecode
+__pycache__/
+*.pyc


### PR DESCRIPTION
Adds `__pycache__/` and `*.pyc` to `.gitignore` so locally-generated Python bytecode doesn't show up in `git status`. Repo-hygiene only; no runtime or packaging impact.