### PR TITLE
fix(focus): suppress (X/Y) on single-objective quests

### DIFF
--- a/modules/Focus/FocusEntryRenderer.lua
+++ b/modules/Focus/FocusEntryRenderer.lua
@@ -1701,8 +1701,8 @@ local function PopulateEntry(entry, questData, groupKey)
             for _, o in ipairs(questData.objectives) do if o.finished then done = done + 1 end end
         end
         if done and total then
-            -- Achievements: omit (0/1)-style title; single-step criteria are obvious from the description line.
-            if not (questData.isAchievement and type(total) == "number" and total == 1) then
+            -- Omit (0/1)-style titles for any single-step quest, achievement, or endeavor — the progress pair is redundant when the objective row already conveys it.
+            if not (type(total) == "number" and total == 1) then
                 displayTitle = ("%s (%s)"):format(displayTitle, FormatProgressPair(done, total))
             end
         end


### PR DESCRIPTION
Closes #19

## Summary
When **Completed count** is on, Focus currently appends `(0/1)` or `(1/1)` to every single-objective quest title. Achievements already suppress this; this PR widens the guard so quests and endeavors with a single step also skip the redundant decoration.

## Implementation notes
One-line change in `modules/Focus/FocusEntryRenderer.lua:1705`. The existing guard was gated on `questData.isAchievement`; dropping that clause applies the same suppression rule uniformly to quests/achievements/endeavors when `total == 1`. Inline comment updated to match the broader scope. No option, localisation, or DB changes.

## Test plan
- [ ] `/reload` with **Completed count** toggled **on**.
- [ ] Single-objective quest (e.g. *Call of the Primus*, *The War Within Recap*, a `Ready to Turn In` world quest): title no longer shows `(0/1)` or `(1/1)`.
- [ ] Multi-objective quest (e.g. 0/5 gather): title still shows `(X/Y)`.
- [ ] Single-criterion achievement tracked in Focus: still suppressed (no regression).
- [ ] Multi-criterion achievement: still shows `(X/Y)`.
- [ ] Toggle **Completed count off**: multi-objective quests drop their `(X/Y)`, achievements/endeavors still show their counts (forced-on via the outer condition at line 1691).