### PR TITLE
feat(focus): categorise weekly meta quests under Weekly section

### DIFF
--- a/Utilities.lua
+++ b/Utilities.lua
@@ -1192,6 +1192,10 @@ function addon.GetQuestBaseCategory(questID)
             if IsPreyQuest(questID) then return "PREY" end
             return "WEEKLY"
         end
+        if qc == Enum.QuestClassification.Meta then
+            if IsPreyQuest(questID) then return "PREY" end
+            return "WEEKLY"
+        end
         if qc == Enum.QuestClassification.Important then return "IMPORTANT" end
         if qc == Enum.QuestClassification.Legendary then return "LEGENDARY" end
     end


### PR DESCRIPTION
Closes #104

## Summary
Adds an `Enum.QuestClassification.Meta` branch to `addon.GetQuestBaseCategory` so weekly meta quests (the chosen weekly activity) classify as `WEEKLY` and appear alongside other weekly-reset content in the Focus tracker.

## Implementation notes
`GetQuestBaseCategory` in `Utilities.lua` is the single source of truth for Focus quest classification. It already handled `Calling`, `Campaign`, `Recurring`, `Important`, and `Legendary`, but not `Meta` — so meta quests fell through to `DEFAULT`. Downstream consumers (`FocusDailies`, `FocusAggregator`, `FocusLayout`, `FocusEntryRenderer`, `FocusSectionHeaders`) already treat `WEEKLY` as a first-class category, so no other files need edits. The existing `Meta → "quest-wrapper-available"` icon atlas mapping in `modules/Focus/FocusCategories.lua` remains correct.

## Test plan
- [ ] \`/reload\` with a meta quest accepted; confirm it appears under the **Weekly** section header (not Other / DEFAULT).
- [ ] Meta quest retains its wrapper icon (\`quest-wrapper-available\`).
- [ ] Completing a meta quest transitions it to the **Complete** group (or stays under Weekly when \`showCompleteGroup\` is off, matching other weeklies).
- [ ] Regression check: regular weekly, daily, and campaign quests still route to their respective sections.