### PR TITLE
fix(focus): apply Axis title/objective colours to recipes

### DIFF
--- a/modules/Focus/FocusColors.lua
+++ b/modules/Focus/FocusColors.lua
@@ -97,6 +97,7 @@ local function MatrixKey(category)
     if category == "ENDEAVOR" then return "ENDEAVORS" end
     if category == "DECOR" then return "DECOR" end
     if category == "APPEARANCE" then return "APPEARANCES" end
+    if category == "RECIPE" then return "RECIPES" end
     return category
 end
 


### PR DESCRIPTION
Closes #106

## Summary
Recipes use `category = "RECIPE"` but the Axis color matrix is keyed by group (`RECIPES`). `MatrixKey` was missing the `RECIPE → RECIPES` mapping (peers like `RARE → RARES`, `APPEARANCE → APPEARANCES` were already mapped), so swatches set on the **Recipes** card never resolved and entries kept the sage-green default.

## Implementation notes
One-line addition to `MatrixKey` in `modules/Focus/FocusColors.lua`. No DB migration or cache invalidation needed — `GetTitleColor` / `GetObjectiveColor` are queried per render, so the next refresh picks up the correct swatch.

The `recipeRarityColors` quality override (Focus → Recipes) still sits on top of the base colour by design; users who want their Axis colour applied unconditionally must disable rarity colours.

## Test plan
- [ ] `/reload` after install
- [ ] Track a recipe in the profession UI
- [ ] Axis → Colors → Per Category → **Recipes**: change **Title** swatch — confirm recipe title adopts the new colour
- [ ] Change **Objective** swatch — confirm reagent rows adopt the new colour (toggle off Focus → Recipes → Rarity colours to bypass per-item quality tint)
- [ ] Click **Reset** on the Recipes card — entry returns to sage-green default
- [ ] Regression: confirm Appearances / Achievements / Endeavors swatches still apply