### PR TITLE
fix(focus): show % progress bar on multi-objective mixed quests

### DIFF
--- a/modules/Focus/FocusEntryRenderer.lua
+++ b/modules/Focus/FocusEntryRenderer.lua
@@ -1302,9 +1302,12 @@ local function ApplyScenarioOrWQTimerBar(entry, questData, textWidth, prevAnchor
         end
     end
 
-    -- Percent progress bar: find the first unfinished objective with percent that has numRequired > 1.
-    -- Skip objectives where numRequired <= 1 (single kills/loots don't need a bar).
-    -- Also skip if the objective progress bar system already handles this entry (avoid duplicates).
+    -- Percent progress bar: find the first unfinished objective with percent.
+    -- Eligible when arithmetic (numRequired > 1) or intrinsically percent-based
+    -- (progressbar type / weighted / text "N%") — the latter often carry
+    -- numRequired == 1 or nil on multi-objective quests and must not be filtered
+    -- out by the nr > 1 gate (that was the multi-objective percent bar bug).
+    -- Also skip if the objective progress bar system already handles this entry.
     -- Abundance: prefer the "abundance held" or "abundance bag" objective when present.
     local progressBarTypeFilter = addon.GetDB("progressBarTypeFilter", "percent_only")
     local firstPercent
@@ -1315,9 +1318,10 @@ local function ApplyScenarioOrWQTimerBar(entry, questData, textWidth, prevAnchor
         for _, o in ipairs(questData.objectives or {}) do
             if o.percent ~= nil and not o.finished then
                 local nr = o.numRequired
-                if nr ~= nil and type(nr) == "number" and nr > 1 then
+                local intrinsic = IsIntrinsicallyPercentBased(o)
+                local hasArithmeticRequirement = (nr ~= nil and type(nr) == "number" and nr > 1)
+                if hasArithmeticRequirement or intrinsic then
                     local isPercentOnly = (progressBarTypeFilter == "percent_only")
-                    local intrinsic = IsIntrinsicallyPercentBased(o)
                     local hasArithmetic = (o.numFulfilled ~= nil and o.numRequired ~= nil and type(o.numRequired) == "number" and o.numRequired > 1)
                     if isPercentOnly and hasArithmetic and not intrinsic then
                         -- Skip: X/Y objective when percent_only

--- a/modules/Focus/FocusEntryRenderer.lua
+++ b/modules/Focus/FocusEntryRenderer.lua
@@ -633,8 +633,11 @@ local function ApplyObjectives(entry, questData, textWidth, prevAnchor, totalH, 
             progressBarNf = barNf
             progressBarNr = barNr
             progressBarPercent = barPct
-        elseif barCount == 1 and questData.objectives and #questData.objectives == 1 then
-            -- Non-scenario: only show bar when exactly one objective total and it is eligible.
+        elseif barCount == 1 then
+            -- Non-scenario: show bar when exactly one objective is eligible under the current
+            -- filter. This covers single-objective quests and the multi-objective case where the
+            -- filter narrows eligibility to a single objective (e.g. percent_only with a mixed
+            -- [X/Y, %] quest picks the % objective's bar).
             progressBarObjIdx = barIdx
             progressBarNf = barNf
             progressBarNr = barNr
@@ -1495,7 +1498,7 @@ local function PopulateEntry(entry, questData, groupKey)
         local isScenarioEntry = questData.isScenarioMain or questData.isScenarioBonus
         if isScenarioEntry and barCount > 0 then
             questData._progressBarActive = true
-        elseif barCount == 1 and questData.objectives and #questData.objectives == 1 then
+        elseif barCount == 1 then
             questData._progressBarActive = true
         end
     end


### PR DESCRIPTION
## Summary

Reported: on a tracked quest whose objective set combines X/Y and %, with
*"Show progress bar for only %"* enabled, the progress bar did not render. The
same objective shape renders fine on delves, where the objective text includes a
trailing `(N%)` (e.g. *"Détruire les réserves de mana (0%)"*).

Root cause: `modules/Focus/FocusEntryRenderer.lua` has three progress-bar paths:

1. **Per-objective bar** — gated on a single objective for non-scenario entries,
   so multi-objective quests skip it.
2. **Quest-level summary bar (`wqProgressBar`)** — the fallback, but its
   selection loop filtered objectives by `numRequired > 1`. Pure progressbar /
   weighted / `"N%"`-text objectives carry `numRequired == 1` or `nil`, so they
   were dropped.
3. **Pre-compute in `PopulateEntry`** — uses the shared
   `IsIntrinsicallyPercentBased` classifier correctly.

Delves avoided the bug because they use the scenario-entry per-objective path,
which allows multiple eligible objectives.

## Implementation notes

Single change in `FocusEntryRenderer.lua` (the `wqProgressBar` selection loop):
replace the `nr > 1` gate with `hasArithmeticRequirement or intrinsic`, reusing
the existing `IsIntrinsicallyPercentBased` helper so behaviour stays coherent
with paths 1 and 3. No option keys, no DB migrations, no localisation changes.

The inner `isPercentOnly and hasArithmetic and not intrinsic` skip branch is
preserved, so an X/Y objective in `percent_only` mode still gets filtered out.

## Test plan

In retail, Focus tracker visible, `/reload` after each setting change:

- [ ] **Reported case** — track a quest with mixed `[X/Y, %]` objectives under
  `progressBarTypeFilter = "percent_only"`. Summary bar renders for the %
  objective at the bottom of the entry.
- [ ] **Delve regression** — multi-objective weighted delve: per-objective bars
  still render inline; no duplicate summary bar.
- [ ] **Single-objective % quest** (e.g. a progressbar World Quest) — per-objective
  bar renders as before.
- [ ] **Single-objective X/Y quest** — no bar in `percent_only`; bar in
  `xy_only` / `both`.
- [ ] **`xy_only` filter with `[X/Y, %]`** — bar shows X/Y format; no regression.
- [ ] **`both` filter with `[X/Y, %]`** — first eligible objective selected.
- [ ] **Achievement with `showAchievementProgressBars`** — unchanged.
- [ ] Inspect with `/hs dumpquest <name>` to confirm `type` / `isWeighted` /
  `numRequired` values on the problematic objective.

## Context

Bug report (user-provided, no existing GH issue):

> When we have a multi-objective that combines X/Y and %, the progress bar isn't
> showing up for % (setting enabled for "show progress bar for only %").
> In my case (show progress bar only for %), the progress should appear for % in
> multi-objective quests. But for delves, it works well.