### PR TITLE
fix(insight): honour Cursor:Center anchor instead of Fixed

### DIFF
--- a/modules/Insight/InsightCursorAnchor.lua
+++ b/modules/Insight/InsightCursorAnchor.lua
@@ -58,8 +58,9 @@ function Insight.HookCursorAnchor()
                 tooltip:SetOwner(parent, "ANCHOR_CURSOR_LEFT", GetCursorOffsetX(), GetCursorOffsetY())
             elseif side == "right" then
                 tooltip:SetOwner(parent, "ANCHOR_CURSOR_RIGHT", GetCursorOffsetX(), GetCursorOffsetY())
+            else
+                tooltip:SetOwner(parent, "ANCHOR_CURSOR", 0, 0)
             end
-            -- "center": let Blizzard handle ANCHOR_CURSOR natively
         elseif mode == "fixed" then
             tooltip:ClearAllPoints()
             tooltip:SetPoint(GetFixedPoint(), UIParent, GetFixedPoint(), GetFixedX(), GetFixedY())


### PR DESCRIPTION
Closes #100

## Summary
- `GameTooltip_SetDefaultAnchor` hook in `modules/Insight/InsightCursorAnchor.lua` treated `Cursor:Center` as a no-op, so tooltips stuck to Blizzard's default BOTTOMRIGHT fixed position.
- Now explicitly calls `tooltip:SetOwner(parent, "ANCHOR_CURSOR", 0, 0)` for the center case so the tooltip tracks the cursor like the left/right branches.

## Implementation notes
- Offsets pass `0, 0` for the center case because the options panel hides the X/Y sliders when `insightCursorSide == "center"` (see `options/OptionsData.lua:2223-2224`).
- No options, localisation, or SavedVariables changes — `insightCursorSide = "center"` is already registered.
- Did not refactor to the deferred `C_Timer.NewTimer(0, …)` pattern noted in `modules/Insight/CLAUDE.md`. The existing `left` / `right` / `fixed` branches call `SetOwner` / `ClearAllPoints` / `SetPoint` synchronously; aligning the whole hook with that note is a separate refactor, out of scope for this fix.

## Test plan
In-game, after `/reload`:

- [ ] **Cursor:Center headline fix** — Options → Insight → Global Tooltips → Tooltip anchor = Cursor, Cursor side = Center. Hover a unit, a bag item, an action bar button, and a quest log entry. Tooltip tracks under the cursor; does not snap to BOTTOMRIGHT.
- [ ] **Regression: Cursor:Left / Cursor:Right** — Switch Cursor side to Left then Right. Offset sliders reappear; tooltip anchors to the correct side with stored `insightCursorOffsetX/Y` applied.
- [ ] **Regression: Fixed anchor** — Set Tooltip anchor = Fixed. Tooltip appears at stored `insightFixedPoint` / `insightFixedX` / `insightFixedY`. Reset-position button returns to BOTTOMRIGHT -60, 120.
- [ ] **Profile swap** — Switch between character-default, per-spec, and global profiles with different `insightAnchorMode` / `insightCursorSide` combos; anchor follows the active profile on next tooltip show.
- [ ] **Lua error sweep** — `/console scriptErrors 1`; hover WorldMap POIs, quest log entries, bag items. No "attempt to compare secret" or `SetWidth` errors from the `GameTooltip_AddWidgetSet` widget-layout path.