### PR TITLE
fix(focus): update ACTION_LABELS to renamed FOCUS_CLICK_ACTION_* keys

### DIFF
--- a/modules/Focus/FocusClickConfig.lua
+++ b/modules/Focus/FocusClickConfig.lua
@@ -15,15 +15,15 @@ local FOCUS_CLICK_PROFILES_LOCKED_TO_BLIZZARD = false
 -- ============================================================================
 
 local ACTION_LABELS = {
-    none           = "OPTIONS_FOCUS_CLICK_ACTION_NONE",
-    superTrack     = "OPTIONS_FOCUS_CLICK_ACTION_SUPER_TRACK",
-    openDetails    = "OPTIONS_FOCUS_CLICK_ACTION_OPEN_DETAILS",
-    untrack        = "OPTIONS_FOCUS_CLICK_ACTION_UNTRACK",
-    contextMenu    = "OPTIONS_FOCUS_CLICK_ACTION_CONTEXT_MENU",
-    share          = "OPTIONS_FOCUS_CLICK_ACTION_SHARE",
-    abandon        = "OPTIONS_FOCUS_CLICK_ACTION_ABANDON",
-    wowhear        = "OPTIONS_FOCUS_CLICK_ACTION_WOWHEAD",
-    chatLink       = "OPTIONS_FOCUS_CLICK_ACTION_CHAT_LINK",
+    none           = "FOCUS_CLICK_ACTION_NONE",
+    superTrack     = "FOCUS_CLICK_ACTION_SUPER_TRACK",
+    openDetails    = "FOCUS_CLICK_ACTION_OPEN_DETAILS",
+    untrack        = "FOCUS_CLICK_ACTION_UNTRACK",
+    contextMenu    = "FOCUS_CLICK_ACTION_CONTEXT_MENU",
+    share          = "FOCUS_CLICK_ACTION_SHARE",
+    abandon        = "FOCUS_CLICK_ACTION_ABANDON",
+    wowhear        = "FOCUS_CLICK_ACTION_WOWHEAD",
+    chatLink       = "FOCUS_CLICK_ACTION_CHAT_LINK",
 }
 
 -- ============================================================================


### PR DESCRIPTION
Commit ed7b75c stripped OPTIONS_* prefixes from locale keys but missed
the ACTION_LABELS table in FocusClickConfig.lua, so every click-action
dropdown fell back to its raw action key (superTrack, openDetails, …)
instead of the localized label.