### PR TITLE
chore(ci): move issuelog discord post to 06:00 london

### DIFF
--- a/.github/workflows/issuelog.yml
+++ b/.github/workflows/issuelog.yml
@@ -3,13 +3,13 @@ name: Post Issue Log to Discord
 # Posts the hero + category messages to Discord. Deletes old messages and
 # posts new ones each run (triggers channel activity).
 # Message IDs are persisted via GitHub Actions cache (delete-before-save
-# to avoid immutability). Scheduled daily at 13:17 UTC; also runs on manual
-# dispatch.
+# to avoid immutability). Scheduled daily at 05:00 UTC (06:00 London BST,
+# 05:00 London GMT); also runs on manual dispatch.
 
 on:
   workflow_dispatch:
   schedule:
-    - cron: '17 13 * * *'   # daily @ 13:17 UTC
+    - cron: '0 5 * * *'   # daily @ 05:00 UTC (06:00 BST / 05:00 GMT)
 
 permissions:
   issues: read


### PR DESCRIPTION
## Summary
- Move the `Post Issue Log to Discord` workflow from `17 13 * * *` (13:17 UTC) to `0 5 * * *` (05:00 UTC).
- 05:00 UTC lands at 06:00 London during BST, 05:00 during GMT.
- GitHub Actions cron is UTC-only and does not track DST, so one bias is unavoidable; chose summer-accurate.

## Test plan
- [ ] Workflow YAML parses (GitHub Actions will validate on push).
- [ ] Manual dispatch still works (`workflow_dispatch` untouched).
- [ ] Next scheduled run fires at 05:00 UTC.