### PR TITLE
feat(vista): alphabetical sorting for addon minimap buttons (#122)

### DIFF
--- a/Localisation/enUS.lua
+++ b/Localisation/enUS.lua
@@ -1524,6 +1524,8 @@ L["VISTA_SIZE_OF_COLLECTED_ADDON_MINIMAP_BUTTONS"]            = "Size of collect
 -- =====================================================================
 L["VISTA_COLLECT_HORIZON_MINIMAP"]                            = "Include Horizon minimap icon"
 L["VISTA_COLLECT_HORIZON_MINIMAP_DESC"]                       = "Put Horizon's own minimap icon in the managed addon bar, right-click panel, or drawer instead of leaving it on the minimap edge."
+L["VISTA_SORT_BUTTONS_ALPHA"]                                 = "Sort buttons alphabetically"
+L["VISTA_SORT_BUTTONS_ALPHA_DESC"]                            = "Sort collected addon minimap buttons alphabetically by name."
 L["VISTA_ADDON_BUTTONS"]                                      = "Addon Buttons"
 L["VISTA_MINIMAP_ADDON_BUTTONS"]                              = "Minimap Addon Buttons"
 L["VISTA_BUTTON_MANAGEMENT"]                                  = "Button Management"

--- a/Localisation/locale_template.lua
+++ b/Localisation/locale_template.lua
@@ -1524,6 +1524,8 @@ L["VISTA_SIZE_OF_COLLECTED_ADDON_MINIMAP_BUTTONS"]            = "Size of collect
 -- =====================================================================
 L["VISTA_COLLECT_HORIZON_MINIMAP"]                            = "Include Horizon minimap icon"
 L["VISTA_COLLECT_HORIZON_MINIMAP_DESC"]                       = "Put Horizon's own minimap icon in the managed addon bar, right-click panel, or drawer instead of leaving it on the minimap edge."
+L["VISTA_SORT_BUTTONS_ALPHA"]                                 = "Sort buttons alphabetically"
+L["VISTA_SORT_BUTTONS_ALPHA_DESC"]                            = "Sort collected addon minimap buttons alphabetically by name."
 L["VISTA_ADDON_BUTTONS"]                                      = "Addon Buttons"
 L["VISTA_MINIMAP_ADDON_BUTTONS"]                              = "Minimap Addon Buttons"
 L["VISTA_BUTTON_MANAGEMENT"]                                  = "Button Management"

--- a/modules/Vista/VistaCore.lua
+++ b/modules/Vista/VistaCore.lua
@@ -3145,11 +3145,24 @@ local function CollectMinimapButtons()
     end
 
     if G.ButtonSortAlpha() then
+        -- Derive a friendly sort key:
+        --   1. LibDBIcon frames ("LibDBIcon10_<AddonName>") → addon name
+        --   2. LDB dataObject.label if present
+        --   3. Raw frame name with common minimap button suffixes stripped
         local function btnLabel(btn)
-            if btn.dataObject and type(btn.dataObject.title) == "string" and btn.dataObject.title ~= "" then
-                return btn.dataObject.title:lower()
+            local name = (btn.GetName and btn:GetName()) or ""
+            local ldb = name:match("^LibDBIcon%d*_(.+)$")
+            if ldb then return ldb:lower() end
+            if btn.dataObject and type(btn.dataObject.label) == "string" and btn.dataObject.label ~= "" then
+                return btn.dataObject.label:lower()
             end
-            return ((btn.GetName and btn:GetName()) or ""):lower()
+            local stripped = name
+            stripped = stripped:gsub("Mini[Mm]apButton$", "")
+            stripped = stripped:gsub("Mini[Mm]apIcon$", "")
+            stripped = stripped:gsub("MiniMap$", "")
+            stripped = stripped:gsub("Minimap$", "")
+            if stripped ~= "" then return stripped:lower() end
+            return name:lower()
         end
         table.sort(visible, function(a, b) return btnLabel(a) < btnLabel(b) end)
     end

--- a/modules/Vista/VistaCore.lua
+++ b/modules/Vista/VistaCore.lua
@@ -191,6 +191,7 @@ do
     G.ButtonDrawerLocked  = function() return DB("vistaDrawerButtonLocked", false) end
     G.ButtonWhitelist     = function() return DB("vistaButtonWhitelist",    nil) end
     G.IsButtonManaged     = function(n) return DB("vistaButtonManaged_" .. n, true) end
+    G.ButtonSortAlpha     = function() return DB("vistaButtonSortAlpha",    false) end
     G.CoordPrecision        = function() return tonumber(DB("vistaCoordPrecision", 1)) or 1 end
     G.BtnLayoutCols         = function() return tonumber(DB("vistaBtnLayoutCols",  5)) or 5 end
     G.BtnLayoutDir          = function() return DB("vistaBtnLayoutDir", "right") end
@@ -3141,6 +3142,14 @@ local function CollectMinimapButtons()
                 SuppressButtonShow(btn)
             end
         end
+    end
+
+    if G.ButtonSortAlpha() then
+        table.sort(visible, function(a, b)
+            local na = (a.GetName and a:GetName()) or ""
+            local nb = (b.GetName and b:GetName()) or ""
+            return na:lower() < nb:lower()
+        end)
     end
 
     if mode == BTN_MODE_MOUSEOVER then

--- a/modules/Vista/VistaCore.lua
+++ b/modules/Vista/VistaCore.lua
@@ -3145,11 +3145,13 @@ local function CollectMinimapButtons()
     end
 
     if G.ButtonSortAlpha() then
-        table.sort(visible, function(a, b)
-            local na = (a.GetName and a:GetName()) or ""
-            local nb = (b.GetName and b:GetName()) or ""
-            return na:lower() < nb:lower()
-        end)
+        local function btnLabel(btn)
+            if btn.dataObject and type(btn.dataObject.title) == "string" and btn.dataObject.title ~= "" then
+                return btn.dataObject.title:lower()
+            end
+            return ((btn.GetName and btn:GetName()) or ""):lower()
+        end
+        table.sort(visible, function(a, b) return btnLabel(a) < btnLabel(b) end)
     end
 
     if mode == BTN_MODE_MOUSEOVER then

--- a/options/OptionsData.lua
+++ b/options/OptionsData.lua
@@ -284,7 +284,7 @@ local VISTA_KEYS = {
     vistaBarBorderR = true, vistaBarBorderG = true, vistaBarBorderB = true, vistaBarBorderA = true,
     vistaRightClickLocked = true, vistaRightClickPanelX = true, vistaRightClickPanelY = true,
     vistaButtonMode = true, vistaHandleAddonButtons = true,
-    vistaCollectHorizonMinimapButton = true,
+    vistaCollectHorizonMinimapButton = true, vistaButtonSortAlpha = true,
     vistaDrawerButtonLocked = true, vistaButtonWhitelist = true,
     vistaMailBlink = true,
     -- Button sizes (separate per type)
@@ -2843,6 +2843,12 @@ local OptionCategories = {
                           setDB("vistaCollectHorizonMinimapButton", v)
                       end
                   end,
+                  disabled = function() return not getDB("vistaHandleAddonButtons", true) end },
+                { type = "toggle", name = L["VISTA_SORT_BUTTONS_ALPHA"] or "Sort buttons alphabetically",
+                  desc = L["VISTA_SORT_BUTTONS_ALPHA_DESC"] or "Sort collected addon minimap buttons alphabetically by name.",
+                  dbKey = "vistaButtonSortAlpha",
+                  get = function() return getDB("vistaButtonSortAlpha", false) end,
+                  set = function(v) setDB("vistaButtonSortAlpha", v) end,
                   disabled = function() return not getDB("vistaHandleAddonButtons", true) end },
                 { type = "dropdown", name = L["VISTA_BUTTON_MODE"] or "Button mode",
                   desc = L["VISTA_ADDON_BUTTONS_PRESENTED_HOVER_BAR_BELOW"] or "How addon buttons are presented: hover bar below minimap, panel on right-click, or floating drawer button.",


### PR DESCRIPTION
Closes #122

## Summary
- Adds an opt-in **Sort buttons alphabetically** toggle to Vista → Addon Buttons options
- When enabled, collected addon minimap buttons are sorted A–Z by frame name before being placed in the mouseover bar, right-click panel, or floating drawer
- Default is off to preserve existing discovery-order behaviour

## Implementation notes
- New DB key `vistaButtonSortAlpha` (bool, default `false`) registered in `VISTA_KEYS` — triggers `Vista.ApplyOptions` on change, which calls `CollectMinimapButtons()` and re-sorts immediately
- Sort is applied to the `visible` slice in `CollectMinimapButtons`, after managed/visible filtering, before mode branching — covers all three button modes in one place
- Buttons without a frame name sort to the top (empty string) so unnamed buttons stay stable

## Test plan
- [ ] Load in-game with two or more addon minimap buttons visible
- [ ] Open Vista → Addon Buttons; confirm new "Sort buttons alphabetically" toggle is present
- [ ] Toggle **on** — buttons reorder alphabetically immediately in the bar/panel/drawer
- [ ] Toggle **off** — buttons return to discovery order
- [ ] `/reload` and confirm setting persists
- [ ] Test all three button modes: Mouseover bar, Right-click panel, Floating drawer