### PR TITLE
perf(focus): debounce events, cache scans, skip redundant layout work

### DIFF
--- a/modules/Focus/FocusAggregator.lua
+++ b/modules/Focus/FocusAggregator.lua
@@ -316,18 +316,12 @@ local function SortAndGroupQuests(quests)
     return result
 end
 
---- Build the full list of quests by calling each provider and normalizing.
--- Cache for "does questID's parent-map chain reach zoneMapID?" — the expensive part of
--- IsQuestOnPlayerZoneMap / questMapMatchesPlayer. Both helpers were walking up to 10
--- parents per quest per FullLayout. Result is deterministic given (questID, zoneMapID),
--- so we memoise per zoneMapID and wipe when the player changes zone.
+-- Memoises the parent-map walk shared by IsQuestOnPlayerZoneMap / questMapMatchesPlayer.
+-- Invalidated when the player's zoneMapID changes.
 local questAncestorCacheZoneMapID = nil
 local questAncestorCache = {}
 local ANCESTOR_WALK_DEPTH = 10
 
---- True when questID's zoneMapID (or an ancestor within ANCESTOR_WALK_DEPTH parents) equals
---- zoneMapID. Results are cached until the player's zoneMapID changes. Returns false when the
---- APIs are unavailable or the quest's zoneMapID hasn't resolved yet (caller handles fallbacks).
 local function QuestAncestorMatchesZone(questID, zoneMapID)
     if not questID or not zoneMapID then return false end
     if questAncestorCacheZoneMapID ~= zoneMapID then
@@ -341,7 +335,7 @@ local function QuestAncestorMatchesZone(questID, zoneMapID)
     end
     local ok, qMapID = pcall(C_TaskQuest.GetQuestZoneID, questID)
     if not ok or not qMapID or qMapID == 0 then
-        -- qMapID not yet resolved; don't cache so we re-check next call once the API settles.
+        -- Leave uncached so we re-check after the API settles.
         return false
     end
     local checkID = qMapID

--- a/modules/Focus/FocusAggregator.lua
+++ b/modules/Focus/FocusAggregator.lua
@@ -317,6 +317,47 @@ local function SortAndGroupQuests(quests)
 end
 
 --- Build the full list of quests by calling each provider and normalizing.
+-- Cache for "does questID's parent-map chain reach zoneMapID?" — the expensive part of
+-- IsQuestOnPlayerZoneMap / questMapMatchesPlayer. Both helpers were walking up to 10
+-- parents per quest per FullLayout. Result is deterministic given (questID, zoneMapID),
+-- so we memoise per zoneMapID and wipe when the player changes zone.
+local questAncestorCacheZoneMapID = nil
+local questAncestorCache = {}
+local ANCESTOR_WALK_DEPTH = 10
+
+--- True when questID's zoneMapID (or an ancestor within ANCESTOR_WALK_DEPTH parents) equals
+--- zoneMapID. Results are cached until the player's zoneMapID changes. Returns false when the
+--- APIs are unavailable or the quest's zoneMapID hasn't resolved yet (caller handles fallbacks).
+local function QuestAncestorMatchesZone(questID, zoneMapID)
+    if not questID or not zoneMapID then return false end
+    if questAncestorCacheZoneMapID ~= zoneMapID then
+        wipe(questAncestorCache)
+        questAncestorCacheZoneMapID = zoneMapID
+    end
+    local cached = questAncestorCache[questID]
+    if cached ~= nil then return cached end
+    if not (C_TaskQuest and C_TaskQuest.GetQuestZoneID and C_Map and C_Map.GetMapInfo) then
+        return false
+    end
+    local ok, qMapID = pcall(C_TaskQuest.GetQuestZoneID, questID)
+    if not ok or not qMapID or qMapID == 0 then
+        -- qMapID not yet resolved; don't cache so we re-check next call once the API settles.
+        return false
+    end
+    local checkID = qMapID
+    for _ = 1, ANCESTOR_WALK_DEPTH do
+        if checkID == zoneMapID then
+            questAncestorCache[questID] = true
+            return true
+        end
+        local info = C_Map.GetMapInfo(checkID)
+        if not info or not info.parentMapID or info.parentMapID == 0 then break end
+        checkID = info.parentMapID
+    end
+    questAncestorCache[questID] = false
+    return false
+end
+
 --- Respects filterByZone and test data. Merges Collect* providers and ReadScenarioEntries.
 --- @return table Array of normalized entry tables (see entry shape in FocusState.lua)
 local function ReadTrackedQuests()
@@ -355,17 +396,12 @@ local function ReadTrackedQuests()
         if not zoneMapID or not (C_TaskQuest and C_TaskQuest.GetQuestZoneID) or not (C_Map and C_Map.GetMapInfo) then
             return true
         end
-        local ok, qMapID = pcall(C_TaskQuest.GetQuestZoneID, questID)
-        if not ok or not qMapID or qMapID == 0 then
-            return true
+        -- Short-circuit: API unresolved for questID (matches old "return true" behaviour).
+        if C_TaskQuest.GetQuestZoneID then
+            local ok, qMapID = pcall(C_TaskQuest.GetQuestZoneID, questID)
+            if not ok or not qMapID or qMapID == 0 then return true end
         end
-        local checkID = qMapID
-        for _ = 1, 10 do
-            if checkID == zoneMapID then return true end
-            local info = C_Map.GetMapInfo(checkID)
-            if not info or not info.parentMapID or info.parentMapID == 0 then break end
-            checkID = info.parentMapID
-        end
+        if QuestAncestorMatchesZone(questID, zoneMapID) then return true end
         -- Fallback: name-based zone check for quests with non-geographic zone IDs (e.g. Prey).
         local zn = addon.GetQuestZoneName and addon.GetQuestZoneName(questID)
         if zn and playerZone and zn:lower() == playerZone:lower() then return true end
@@ -378,24 +414,14 @@ local function ReadTrackedQuests()
         if not questID or questID <= 0 then return false end
         if not zoneMapID or not C_TaskQuest or not C_TaskQuest.GetQuestZoneID or not C_Map or not C_Map.GetMapInfo then
             -- Fallback to legacy name-based filter when map APIs aren't available.
-            local playerZone = (addon.GetPlayerCurrentZoneName and addon.GetPlayerCurrentZoneName()) or nil
+            local playerZoneLocal = (addon.GetPlayerCurrentZoneName and addon.GetPlayerCurrentZoneName()) or nil
             local zn = addon.GetQuestZoneName and addon.GetQuestZoneName(questID)
-            return (not zn) or (not playerZone) or zn:lower() == playerZone:lower()
+            return (not zn) or (not playerZoneLocal) or zn:lower() == playerZoneLocal:lower()
         end
-
+        -- Short-circuit: API unresolved for questID → don't hard-filter.
         local ok, qMapID = pcall(C_TaskQuest.GetQuestZoneID, questID)
-        if not ok or not qMapID or qMapID == 0 then
-            -- If task quest API can't resolve it, don't hard-filter it out.
-            return true
-        end
-
-        local checkID = qMapID
-        for _ = 1, 8 do
-            if checkID == zoneMapID then return true end
-            local info = C_Map.GetMapInfo(checkID)
-            if not info or not info.parentMapID or info.parentMapID == 0 then break end
-            checkID = info.parentMapID
-        end
+        if not ok or not qMapID or qMapID == 0 then return true end
+        if QuestAncestorMatchesZone(questID, zoneMapID) then return true end
         -- Fallback: name-based zone check for quests with non-geographic zone IDs (e.g. Prey).
         local zn = addon.GetQuestZoneName and addon.GetQuestZoneName(questID)
         if zn and playerZone and zn:lower() == playerZone:lower() then return true end

--- a/modules/Focus/FocusAnimation.lua
+++ b/modules/Focus/FocusAnimation.lua
@@ -123,16 +123,13 @@ local function RunMapCheck()
         addon.focus.lastZoneMapID = zoneMapID
         addon.focus.lastPlayerMapID = rawMapID
         if addon.zoneTaskQuestCache then wipe(addon.zoneTaskQuestCache) end
-        addon.focus.nearbyQuestCacheDirty = true
-        addon.focus.nearbyQuestCache = nil
-        addon.focus.nearbyTaskQuestCache = nil
+        -- Nearby WQ cache self-invalidates via the zoneMapID compare in GetNearbyQuestIDs.
         ScheduleMapChangeDebouncedRefresh()
     elseif rawMapID and rawMapID ~= addon.focus.lastPlayerMapID then
-        -- rawMapID changed (e.g. left event area within same zone); invalidate nearby cache.
+        -- rawMapID changed within the same zoneMapID (e.g. left event sub-area). The nearby
+        -- WQ cache is zone-scoped — mapIDsToQuery derives from zoneMapID — so the warm cache
+        -- is still valid. Not invalidating here was the single biggest flight-stutter win.
         addon.focus.lastPlayerMapID = rawMapID
-        addon.focus.nearbyQuestCacheDirty = true
-        addon.focus.nearbyQuestCache = nil
-        addon.focus.nearbyTaskQuestCache = nil
         ScheduleMapChangeDebouncedRefresh()
     elseif not addon.focus.lastZoneMapID and zoneMapID then
         addon.focus.lastZoneMapID = zoneMapID

--- a/modules/Focus/FocusAnimation.lua
+++ b/modules/Focus/FocusAnimation.lua
@@ -89,6 +89,27 @@ local function SetPanelHeight(h)
     HS:SetPoint("TOPRIGHT", UIParent, "TOPRIGHT", right - uiRight, topBefore - uiTop)
 end
 
+-- PLAYER_MAP_CHANGED can fire several times in quick succession during zone transitions
+-- (subzone → zone → continent). Coalesce the downstream ScheduleRefresh so we run a single
+-- FullLayout after the burst settles. Cache invalidation still happens synchronously so the
+-- next layout reads fresh data.
+local MAP_CHANGE_REFRESH_DEBOUNCE = 0.1
+local mapChangeRefreshTimer
+local function ScheduleMapChangeDebouncedRefresh()
+    if not addon.focus.enabled or not addon.ScheduleRefresh then return end
+    if mapChangeRefreshTimer then mapChangeRefreshTimer:Cancel() end
+    if C_Timer and C_Timer.NewTimer then
+        mapChangeRefreshTimer = C_Timer.NewTimer(MAP_CHANGE_REFRESH_DEBOUNCE, function()
+            mapChangeRefreshTimer = nil
+            if addon.focus.enabled and addon.ScheduleRefresh then addon.ScheduleRefresh() end
+        end)
+    else
+        C_Timer.After(MAP_CHANGE_REFRESH_DEBOUNCE, function()
+            if addon.focus.enabled and addon.ScheduleRefresh then addon.ScheduleRefresh() end
+        end)
+    end
+end
+
 --- Detects player map changes and invalidates zone task quest cache.
 --- Called on a timer; no params or return.
 local function RunMapCheck()
@@ -105,14 +126,14 @@ local function RunMapCheck()
         addon.focus.nearbyQuestCacheDirty = true
         addon.focus.nearbyQuestCache = nil
         addon.focus.nearbyTaskQuestCache = nil
-        if addon.ScheduleRefresh then addon.ScheduleRefresh() end
+        ScheduleMapChangeDebouncedRefresh()
     elseif rawMapID and rawMapID ~= addon.focus.lastPlayerMapID then
         -- rawMapID changed (e.g. left event area within same zone); invalidate nearby cache.
         addon.focus.lastPlayerMapID = rawMapID
         addon.focus.nearbyQuestCacheDirty = true
         addon.focus.nearbyQuestCache = nil
         addon.focus.nearbyTaskQuestCache = nil
-        if addon.ScheduleRefresh then addon.ScheduleRefresh() end
+        ScheduleMapChangeDebouncedRefresh()
     elseif not addon.focus.lastZoneMapID and zoneMapID then
         addon.focus.lastZoneMapID = zoneMapID
         addon.focus.lastPlayerMapID = rawMapID

--- a/modules/Focus/FocusAnimation.lua
+++ b/modules/Focus/FocusAnimation.lua
@@ -89,10 +89,8 @@ local function SetPanelHeight(h)
     HS:SetPoint("TOPRIGHT", UIParent, "TOPRIGHT", right - uiRight, topBefore - uiTop)
 end
 
--- PLAYER_MAP_CHANGED can fire several times in quick succession during zone transitions
--- (subzone → zone → continent). Coalesce the downstream ScheduleRefresh so we run a single
--- FullLayout after the burst settles. Cache invalidation still happens synchronously so the
--- next layout reads fresh data.
+-- PLAYER_MAP_CHANGED fires in bursts during zone transitions; debounce collapses the burst
+-- into a single FullLayout after it settles.
 local MAP_CHANGE_REFRESH_DEBOUNCE = 0.1
 local mapChangeRefreshTimer
 local function ScheduleMapChangeDebouncedRefresh()
@@ -110,8 +108,7 @@ local function ScheduleMapChangeDebouncedRefresh()
     end
 end
 
---- Detects player map changes and invalidates zone task quest cache.
---- Called on a timer; no params or return.
+--- Tracks map changes; the WQ cache self-invalidates via zoneMapID compare in GetNearbyQuestIDs.
 local function RunMapCheck()
     if not addon.focus.enabled or not C_Map or not C_Map.GetBestMapForUnit then return end
 
@@ -123,12 +120,9 @@ local function RunMapCheck()
         addon.focus.lastZoneMapID = zoneMapID
         addon.focus.lastPlayerMapID = rawMapID
         if addon.zoneTaskQuestCache then wipe(addon.zoneTaskQuestCache) end
-        -- Nearby WQ cache self-invalidates via the zoneMapID compare in GetNearbyQuestIDs.
         ScheduleMapChangeDebouncedRefresh()
     elseif rawMapID and rawMapID ~= addon.focus.lastPlayerMapID then
-        -- rawMapID changed within the same zoneMapID (e.g. left event sub-area). The nearby
-        -- WQ cache is zone-scoped — mapIDsToQuery derives from zoneMapID — so the warm cache
-        -- is still valid. Not invalidating here was the single biggest flight-stutter win.
+        -- rawMapID changed within the same zoneMapID — WQ cache stays warm (zone-scoped).
         addon.focus.lastPlayerMapID = rawMapID
         ScheduleMapChangeDebouncedRefresh()
     elseif not addon.focus.lastZoneMapID and zoneMapID then

--- a/modules/Focus/FocusBlizzard.lua
+++ b/modules/Focus/FocusBlizzard.lua
@@ -33,8 +33,7 @@ local trackerSuppressed = false
 local wqtSuppressed = false
 local wqtPanelOnShowHooked = false
 
---- Hide the WQT panel if it's currently visible. Guarded against combat lockdown
---- (Hide() on a protected frame during combat would taint).
+-- Skipped in combat: Hide() on a protected frame would taint.
 local function HideWQTPanelIfShown()
     local wqtFrame = _G.WorldQuestTrackerScreenPanel
     if wqtFrame and wqtFrame:IsShown() and not InCombatLockdown() then
@@ -42,8 +41,6 @@ local function HideWQTPanelIfShown()
     end
 end
 
---- Install a once-off OnShow hook on the WQT panel so it's re-hidden whenever WQT
---- tries to show it. Replaces the previous 1s polling ticker.
 local function EnsureWQTPanelOnShowHook()
     if wqtPanelOnShowHooked then return end
     local wqtFrame = _G.WorldQuestTrackerScreenPanel
@@ -53,7 +50,6 @@ local function EnsureWQTPanelOnShowHook()
         HideWQTPanelIfShown()
     end)
     wqtPanelOnShowHooked = true
-    -- Cover the case where the panel was already shown when we install the hook.
     HideWQTPanelIfShown()
 end
 
@@ -95,8 +91,7 @@ end
 
 --- Restore the default objective tracker and WQT panel when Focus is disabled.
 local function RestoreTracker()
-    -- The WQT panel OnShow hook is left in place — it's a no-op when focus.enabled is false,
-    -- and HookScript doesn't support removal. Re-enabling Focus just re-arms the guard.
+    -- WQT OnShow hook is left in place: HookScript can't be removed and it no-ops when disabled.
     if not trackerSuppressed then return end
     if ObjectiveTrackerFrame then
         -- pcall: frame methods can throw on protected or invalid frames.
@@ -169,8 +164,6 @@ local function HookWQTTracking()
             if wqtPanel and wqtPanel:IsShown() then
                 wqtPanel:Hide()
             end
-            -- One deferred refresh covers the WQT tracking propagation; the nested
-            -- FullLayout re-trigger was redundant with ScheduleRefresh's layout pass.
             C_Timer.After(0.1, function()
                 if addon.ScheduleRefresh then addon.ScheduleRefresh() end
             end)

--- a/modules/Focus/FocusBlizzard.lua
+++ b/modules/Focus/FocusBlizzard.lua
@@ -6,7 +6,6 @@
 
 local addon = _G._HorizonSuite_Loading or _G.HorizonSuiteBeta or _G.HorizonSuite
 
-local WQT_SUPPRESSION_TICK_INTERVAL = 1.0
 local WQT_ADDON_LOAD_DELAY = 0.5
 local WQT_ADDON_ALREADY_LOADED_DELAY = 1
 
@@ -32,7 +31,31 @@ end
 
 local trackerSuppressed = false
 local wqtSuppressed = false
-local wqtSuppressionTicker = nil
+local wqtPanelOnShowHooked = false
+
+--- Hide the WQT panel if it's currently visible. Guarded against combat lockdown
+--- (Hide() on a protected frame during combat would taint).
+local function HideWQTPanelIfShown()
+    local wqtFrame = _G.WorldQuestTrackerScreenPanel
+    if wqtFrame and wqtFrame:IsShown() and not InCombatLockdown() then
+        wqtFrame:Hide()
+    end
+end
+
+--- Install a once-off OnShow hook on the WQT panel so it's re-hidden whenever WQT
+--- tries to show it. Replaces the previous 1s polling ticker.
+local function EnsureWQTPanelOnShowHook()
+    if wqtPanelOnShowHooked then return end
+    local wqtFrame = _G.WorldQuestTrackerScreenPanel
+    if not wqtFrame or not wqtFrame.HookScript then return end
+    wqtFrame:HookScript("OnShow", function()
+        if not addon.focus.enabled then return end
+        HideWQTPanelIfShown()
+    end)
+    wqtPanelOnShowHooked = true
+    -- Cover the case where the panel was already shown when we install the hook.
+    HideWQTPanelIfShown()
+end
 
 -- ============================================================================
 -- Public functions
@@ -52,25 +75,7 @@ local function TrySuppressTracker()
                 wqtSuppressed = true
             end
         end
-        if not wqtSuppressionTicker and addon.focus.enabled then
-            local wqtLoaded = (C_AddOns and C_AddOns.IsAddOnLoaded and C_AddOns.IsAddOnLoaded("WorldQuestTracker"))
-                or _G.WorldQuestTrackerAddon or _G.WorldQuestTrackerScreenPanel
-            if wqtLoaded then
-                wqtSuppressionTicker = C_Timer.NewTicker(WQT_SUPPRESSION_TICK_INTERVAL, function()
-                    if not addon.focus.enabled then
-                        if wqtSuppressionTicker then
-                            wqtSuppressionTicker:Cancel()
-                            wqtSuppressionTicker = nil
-                        end
-                        return
-                    end
-                    local wqtFrame = _G.WorldQuestTrackerScreenPanel
-                    if wqtFrame and wqtFrame:IsShown() and not InCombatLockdown() then
-                        wqtFrame:Hide()
-                    end
-                end)
-            end
-        end
+        if addon.focus.enabled then EnsureWQTPanelOnShowHook() end
         return
     end
     if trackerSuppressed then return end
@@ -85,33 +90,13 @@ local function TrySuppressTracker()
             wqtSuppressed = true
         end
     end
-    if not wqtSuppressionTicker and addon.focus.enabled then
-        local wqtLoaded = (C_AddOns and C_AddOns.IsAddOnLoaded and C_AddOns.IsAddOnLoaded("WorldQuestTracker"))
-            or _G.WorldQuestTrackerAddon or _G.WorldQuestTrackerScreenPanel
-        if wqtLoaded then
-            wqtSuppressionTicker = C_Timer.NewTicker(WQT_SUPPRESSION_TICK_INTERVAL, function()
-                if not addon.focus.enabled then
-                    if wqtSuppressionTicker then
-                        wqtSuppressionTicker:Cancel()
-                        wqtSuppressionTicker = nil
-                    end
-                    return
-                end
-                local wqtFrame = _G.WorldQuestTrackerScreenPanel
-                if wqtFrame and wqtFrame:IsShown() and not InCombatLockdown() then
-                    wqtFrame:Hide()
-                end
-            end)
-        end
-    end
+    if addon.focus.enabled then EnsureWQTPanelOnShowHook() end
 end
 
 --- Restore the default objective tracker and WQT panel when Focus is disabled.
 local function RestoreTracker()
-    if wqtSuppressionTicker then
-        wqtSuppressionTicker:Cancel()
-        wqtSuppressionTicker = nil
-    end
+    -- The WQT panel OnShow hook is left in place — it's a no-op when focus.enabled is false,
+    -- and HookScript doesn't support removal. Re-enabling Focus just re-arms the guard.
     if not trackerSuppressed then return end
     if ObjectiveTrackerFrame then
         -- pcall: frame methods can throw on protected or invalid frames.
@@ -184,9 +169,10 @@ local function HookWQTTracking()
             if wqtPanel and wqtPanel:IsShown() then
                 wqtPanel:Hide()
             end
+            -- One deferred refresh covers the WQT tracking propagation; the nested
+            -- FullLayout re-trigger was redundant with ScheduleRefresh's layout pass.
             C_Timer.After(0.1, function()
                 if addon.ScheduleRefresh then addon.ScheduleRefresh() end
-                if addon.FullLayout then C_Timer.After(0.2, addon.FullLayout) end
             end)
         end)
         wqtHooked = true

--- a/modules/Focus/FocusEntryPool.lua
+++ b/modules/Focus/FocusEntryPool.lua
@@ -843,6 +843,11 @@ local function ClearEntry(entry, full)
     entry.isGroupQuest   = nil
     entry.isAutoComplete = nil
     entry._inlineTimerBaseTitle, entry._inlineTimerStr, entry._inlineTimerDuration, entry._inlineTimerStartTime = nil, nil, nil, nil
+    -- Clear cached layout position so the next FullLayout re-applies SetPoint/SetWidth;
+    -- without this an entry re-acquired into a different slot would keep stale _lastEntry*.
+    entry._lastEntryX     = nil
+    entry._lastEntryY     = nil
+    entry._lastEntryWidth = nil
     entry.hoverAnimState = nil
     entry.hoverAnimTime = nil
     entry._baseTitleColor = nil

--- a/modules/Focus/FocusEntryPool.lua
+++ b/modules/Focus/FocusEntryPool.lua
@@ -848,6 +848,9 @@ local function ClearEntry(entry, full)
     entry._lastEntryX     = nil
     entry._lastEntryY     = nil
     entry._lastEntryWidth = nil
+    -- Clear PopulateEntry's data signature so an entry re-acquired for a different quest
+    -- re-populates from scratch instead of hitting the same-signature fast-path.
+    entry._populateSig    = nil
     entry.hoverAnimState = nil
     entry.hoverAnimTime = nil
     entry._baseTitleColor = nil

--- a/modules/Focus/FocusEntryRenderer.lua
+++ b/modules/Focus/FocusEntryRenderer.lua
@@ -2266,16 +2266,8 @@ local function PopulateEntry(entry, questData, groupKey)
     return totalH
 end
 
--- PopulateEntry dominates the per-layout cost (~1.1ms per entry × 20-30 entries = 30ms+).
--- Most layouts during flight paint the same data twice because zone events fire repeatedly
--- with no actual quest-data change. We compute a compact signature from the questData fields
--- that drive the visible output, and when the signature matches the entry's last-painted
--- signature we skip the work entirely. The signature is ~30μs to compute, the saved
--- PopulateEntry call is ~1.1ms — net is a ~30× win per skipped entry.
---
--- Fields NOT in the signature (they don't affect PopulateEntry's output, OR they already
--- drive separate code paths): animState, position, hover/anim state, timer bar countdown
--- (handled by the scenario-bar ticker, not PopulateEntry).
+-- Signature of the questData fields that drive PopulateEntry's visible output. Changes to
+-- any visible-impact field must be reflected here or stale entries will render.
 local function BuildEntrySignature(qData, groupKey)
     if not qData then return nil end
     local key = qData.entryKey or qData.questID
@@ -2327,9 +2319,6 @@ local function PopulateEntryCached(entry, questData, groupKey)
     if not entry or not questData then return origPopulateEntry(entry, questData, groupKey) end
     local sig = BuildEntrySignature(questData, groupKey)
     if sig and entry._populateSig == sig then
-        -- Same data as the last paint of this entry — skip the heavy text / objective /
-        -- color / icon rebuild. entry.entryHeight and other fields from the last paint are
-        -- still valid because none of the data feeding them changed.
         return entry.entryHeight
     end
     local result = origPopulateEntry(entry, questData, groupKey)

--- a/modules/Focus/FocusEntryRenderer.lua
+++ b/modules/Focus/FocusEntryRenderer.lua
@@ -2266,4 +2266,75 @@ local function PopulateEntry(entry, questData, groupKey)
     return totalH
 end
 
-addon.PopulateEntry = PopulateEntry
+-- PopulateEntry dominates the per-layout cost (~1.1ms per entry × 20-30 entries = 30ms+).
+-- Most layouts during flight paint the same data twice because zone events fire repeatedly
+-- with no actual quest-data change. We compute a compact signature from the questData fields
+-- that drive the visible output, and when the signature matches the entry's last-painted
+-- signature we skip the work entirely. The signature is ~30μs to compute, the saved
+-- PopulateEntry call is ~1.1ms — net is a ~30× win per skipped entry.
+--
+-- Fields NOT in the signature (they don't affect PopulateEntry's output, OR they already
+-- drive separate code paths): animState, position, hover/anim state, timer bar countdown
+-- (handled by the scenario-bar ticker, not PopulateEntry).
+local function BuildEntrySignature(qData, groupKey)
+    if not qData then return nil end
+    local key = qData.entryKey or qData.questID
+    if not key then return nil end
+    local parts = {
+        tostring(key),
+        tostring(groupKey or ""),
+        qData.title or "",
+        tostring(qData.category or ""),
+        tostring(qData.baseCategory or ""),
+        qData.zoneName or "",
+        qData.itemLink or "",
+        tostring(qData.itemTexture or ""),
+        tostring(qData.questLevel or ""),
+        qData.isComplete and "1" or "0",
+        qData.isSuperTracked and "1" or "0",
+        qData.isTracked and "1" or "0",
+        qData.isInQuestArea and "1" or "0",
+        qData.isNearby and "1" or "0",
+        qData.isEventQuest and "1" or "0",
+        qData.isAutoComplete and "1" or "0",
+        qData.isRare and "1" or "0",
+        qData.isRareLoot and "1" or "0",
+        qData.isDungeonQuest and "1" or "0",
+        qData.isRaidQuest and "1" or "0",
+        qData.isAutoAdded and "1" or "0",
+        qData.isRecipe and "1" or "0",
+        qData.isAppearance and "1" or "0",
+        tostring(qData.questTypeAtlas or ""),
+        tostring(qData.outputQuality or ""),
+        tostring(qData.tierSpellID or ""),
+    }
+    local objs = qData.objectives
+    if objs then
+        for i = 1, #objs do
+            local o = objs[i]
+            parts[#parts + 1] = (o.text or "") .. ":" ..
+                tostring(o.numFulfilled or "") .. "/" ..
+                tostring(o.numRequired or "") .. ":" ..
+                (o.finished and "1" or "0") .. ":" ..
+                tostring(o.percent or "")
+        end
+    end
+    return table.concat(parts, "|")
+end
+
+local origPopulateEntry = PopulateEntry
+local function PopulateEntryCached(entry, questData, groupKey)
+    if not entry or not questData then return origPopulateEntry(entry, questData, groupKey) end
+    local sig = BuildEntrySignature(questData, groupKey)
+    if sig and entry._populateSig == sig then
+        -- Same data as the last paint of this entry — skip the heavy text / objective /
+        -- color / icon rebuild. entry.entryHeight and other fields from the last paint are
+        -- still valid because none of the data feeding them changed.
+        return entry.entryHeight
+    end
+    local result = origPopulateEntry(entry, questData, groupKey)
+    entry._populateSig = sig
+    return result
+end
+
+addon.PopulateEntry = PopulateEntryCached

--- a/modules/Focus/FocusEvents.lua
+++ b/modules/Focus/FocusEvents.lua
@@ -69,36 +69,13 @@ eventFrame:RegisterEvent("WORLD_MAP_OPEN")
 pcall(function() eventFrame:RegisterEvent("AUCTION_HOUSE_SHOW") end)
 pcall(function() eventFrame:RegisterEvent("AUCTION_HOUSE_CLOSED") end)
 
-local VIGNETTE_DEBOUNCE = 0.5
-
--- UPDATE_UI_WIDGET fires in bursts in widget-heavy scenarios; debounce to avoid full layout per tick.
-local UPDATE_UI_WIDGET_DEBOUNCE = 0.2
-local updateWidgetDebounceTimer
-
--- Coalesce rapid scenario criteria / spell updates into a single deferred layout.
+local VIGNETTE_DEBOUNCE          = 0.5
+local UPDATE_UI_WIDGET_DEBOUNCE  = 0.2
 local SCENARIO_CRITERIA_DEBOUNCE = 0.12
-local scenarioCriteriaDebounceTimer
+local QUEST_UPDATE_DEBOUNCE      = 0.08
+local NEARBY_POI_DEBOUNCE        = 0.2
+local ZONE_CHANGE_DEBOUNCE       = 0.15
 
--- Coalesce bursts of QUEST_WATCH_UPDATE / QUEST_LOG_UPDATE / UNIT_QUEST_LOG_CHANGED.
--- These events fire on every objective tick; the flash check still runs immediately, only
--- the FullLayout request is deferred so closely-spaced updates produce one layout pass.
-local QUEST_UPDATE_DEBOUNCE = 0.08
-local questUpdateDebounceTimer
-
--- Coalesce bursts of AREA_POIS_UPDATED / TASK_PROGRESS_UPDATE. These events invalidate the
--- nearby-WQ cache; debouncing the refresh prevents a full GetNearbyQuestIDs rebuild per event
--- during a POI storm. The cache is marked dirty immediately so correctness is preserved.
-local NEARBY_POI_DEBOUNCE = 0.2
-local nearbyPoiDebounceTimer
-
--- ZONE_CHANGED / ZONE_CHANGED_NEW_AREA / ZONE_CHANGED_INDOORS all fire during flight (often
--- in bursts of 3-5 within a second as the player crosses subzones). The original handler ran
--- an immediate ScheduleRefresh plus 0.4s/1.5s/2.5s late retries per event, which stacked into
--- 12+ FullLayouts during a flight path. We now debounce the immediate refresh and keep a
--- single set of cancellable late-retry timers that are restarted on each zone change — so
--- retries fire once, after the last zone change in the burst settles.
-local ZONE_CHANGE_DEBOUNCE = 0.15
-local zoneChangeDebounceTimer
 local zoneLateRetry04Timer
 local zoneLateRetry15Timer
 local zoneLateRetry25Timer
@@ -123,78 +100,47 @@ end
 
 addon.ScheduleRefresh = ScheduleRefresh
 
-local vignetteDebounceTimer
-local function OnVignettesUpdated()
-    if not addon.focus.enabled then return end
-    if not addon.GetDB("showRareBosses", true) and not addon.GetDB("showRareLoot", false) then return end
-    if vignetteDebounceTimer then vignetteDebounceTimer:Cancel() end
-    if C_Timer and C_Timer.NewTimer then
-        vignetteDebounceTimer = C_Timer.NewTimer(VIGNETTE_DEBOUNCE, function()
-            vignetteDebounceTimer = nil
-            if addon.focus.enabled then ScheduleRefresh() end
-        end)
-    else
-        C_Timer.After(VIGNETTE_DEBOUNCE, function()
-            if addon.focus.enabled then ScheduleRefresh() end
-        end)
+-- Factory: returns a closure that, when called, starts (or restarts) a timer which fires
+-- ScheduleRefresh after `duration`. Each call site gets its own timer handle so different
+-- event classes debounce independently. Uses C_Timer.NewTimer when available (so we can
+-- cancel in-flight timers) and falls back to C_Timer.After for older clients.
+local function MakeDebouncedRefresh(duration)
+    local timer
+    return function()
+        if not addon.focus.enabled then return end
+        if timer then timer:Cancel() end
+        if C_Timer and C_Timer.NewTimer then
+            timer = C_Timer.NewTimer(duration, function()
+                timer = nil
+                if addon.focus.enabled then ScheduleRefresh() end
+            end)
+        else
+            C_Timer.After(duration, function()
+                if addon.focus.enabled then ScheduleRefresh() end
+            end)
+        end
     end
 end
 
+local ScheduleVignetteDebouncedRefresh         = MakeDebouncedRefresh(VIGNETTE_DEBOUNCE)
+local ScheduleScenarioCriteriaDebouncedRefresh = MakeDebouncedRefresh(SCENARIO_CRITERIA_DEBOUNCE)
+local ScheduleQuestUpdateDebouncedRefresh      = MakeDebouncedRefresh(QUEST_UPDATE_DEBOUNCE)
+local ScheduleNearbyPoiDebouncedRefresh        = MakeDebouncedRefresh(NEARBY_POI_DEBOUNCE)
+local ScheduleZoneChangeDebouncedRefresh       = MakeDebouncedRefresh(ZONE_CHANGE_DEBOUNCE)
+
+local function OnVignettesUpdated()
+    if not addon.focus.enabled then return end
+    if not addon.GetDB("showRareBosses", true) and not addon.GetDB("showRareLoot", false) then return end
+    ScheduleVignetteDebouncedRefresh()
+end
+
+local ScheduleUpdateUiWidgetDebouncedRefresh = MakeDebouncedRefresh(UPDATE_UI_WIDGET_DEBOUNCE)
 local function OnUpdateUiWidgetDebounced()
     if not addon.focus.enabled then return end
     if not ((addon.IsDelveActive and addon.IsDelveActive()) or (addon.IsScenarioActive and addon.IsScenarioActive())) then
         return
     end
-    if updateWidgetDebounceTimer then updateWidgetDebounceTimer:Cancel() end
-    updateWidgetDebounceTimer = C_Timer.After(UPDATE_UI_WIDGET_DEBOUNCE, function()
-        updateWidgetDebounceTimer = nil
-        if addon.focus.enabled then ScheduleRefresh() end
-    end)
-end
-
-local function ScheduleScenarioCriteriaDebouncedRefresh()
-    if not addon.focus.enabled then return end
-    if scenarioCriteriaDebounceTimer then scenarioCriteriaDebounceTimer:Cancel() end
-    if C_Timer and C_Timer.NewTimer then
-        scenarioCriteriaDebounceTimer = C_Timer.NewTimer(SCENARIO_CRITERIA_DEBOUNCE, function()
-            scenarioCriteriaDebounceTimer = nil
-            if addon.focus.enabled then ScheduleRefresh() end
-        end)
-    else
-        C_Timer.After(SCENARIO_CRITERIA_DEBOUNCE, function()
-            if addon.focus.enabled then ScheduleRefresh() end
-        end)
-    end
-end
-
-local function ScheduleQuestUpdateDebouncedRefresh()
-    if not addon.focus.enabled then return end
-    if questUpdateDebounceTimer then questUpdateDebounceTimer:Cancel() end
-    if C_Timer and C_Timer.NewTimer then
-        questUpdateDebounceTimer = C_Timer.NewTimer(QUEST_UPDATE_DEBOUNCE, function()
-            questUpdateDebounceTimer = nil
-            if addon.focus.enabled then ScheduleRefresh() end
-        end)
-    else
-        C_Timer.After(QUEST_UPDATE_DEBOUNCE, function()
-            if addon.focus.enabled then ScheduleRefresh() end
-        end)
-    end
-end
-
-local function ScheduleNearbyPoiDebouncedRefresh()
-    if not addon.focus.enabled then return end
-    if nearbyPoiDebounceTimer then nearbyPoiDebounceTimer:Cancel() end
-    if C_Timer and C_Timer.NewTimer then
-        nearbyPoiDebounceTimer = C_Timer.NewTimer(NEARBY_POI_DEBOUNCE, function()
-            nearbyPoiDebounceTimer = nil
-            if addon.focus.enabled then ScheduleRefresh() end
-        end)
-    else
-        C_Timer.After(NEARBY_POI_DEBOUNCE, function()
-            if addon.focus.enabled then ScheduleRefresh() end
-        end)
-    end
+    ScheduleUpdateUiWidgetDebouncedRefresh()
 end
 
 local RunMplusHeightTransitionCheck  -- forward declaration; defined below
@@ -205,9 +151,9 @@ local function CancelZoneLateRetries()
     if zoneLateRetry25Timer then zoneLateRetry25Timer:Cancel(); zoneLateRetry25Timer = nil end
 end
 
--- Schedule the three late-retry refreshes after a zone change, cancelling any retries still
--- pending from a previous zone change in the same burst. These retries catch late-updating
--- APIs (map pin acquisition, WQ list propagation) after the zone settles.
+-- Late retries catch APIs that lag after a zone change (map pins, WQ propagation). Timers
+-- are cancelled-and-restarted on each new zone event so a flight burst fires them once,
+-- after the last zone change settles, rather than once per zone change.
 local function ScheduleZoneLateRetries()
     CancelZoneLateRetries()
     if not (C_Timer and C_Timer.NewTimer) then
@@ -234,21 +180,6 @@ local function ScheduleZoneLateRetries()
         zoneLateRetry25Timer = nil
         if addon.focus.enabled then ScheduleRefresh() end
     end)
-end
-
-local function ScheduleZoneChangeDebouncedRefresh()
-    if not addon.focus.enabled then return end
-    if zoneChangeDebounceTimer then zoneChangeDebounceTimer:Cancel() end
-    if C_Timer and C_Timer.NewTimer then
-        zoneChangeDebounceTimer = C_Timer.NewTimer(ZONE_CHANGE_DEBOUNCE, function()
-            zoneChangeDebounceTimer = nil
-            if addon.focus.enabled then ScheduleRefresh() end
-        end)
-    else
-        C_Timer.After(ZONE_CHANGE_DEBOUNCE, function()
-            if addon.focus.enabled then ScheduleRefresh() end
-        end)
-    end
 end
 
 _G.HorizonSuite_ApplyTypography  = addon.ApplyTypography
@@ -426,10 +357,7 @@ end
 local function OnPlayerLoginOrEnteringWorld()
     if addon.focus.enabled then
         addon.focus.zoneJustChanged = true
-        -- Invalidate the nearby WQ scan cache so we scan fresh for the current zone.
         addon.focus.nearbyQuestCacheDirty = true
-        addon.focus.nearbyQuestCache = nil
-        addon.focus.nearbyTaskQuestCache = nil
         addon.TrySuppressTracker()
         ScheduleRefresh()
         C_Timer.After(0.4, function()
@@ -493,8 +421,6 @@ local function OnQuestAccepted(questID)
     end
     if isWQ and not addon.GetDB("showWorldQuests", true) then
         addon.focus.nearbyQuestCacheDirty = true
-        addon.focus.nearbyQuestCache = nil
-        addon.focus.nearbyTaskQuestCache = nil
     end
 
     ScheduleRefresh()
@@ -565,32 +491,22 @@ local function OnZoneChanged(event)
     addon.focus.zoneJustChanged = true
     addon.focus.lastPlayerMapID = nil
     addon.focus.lastZoneMapID = nil
-    -- Nearby WQ cache is gated on zoneMapID inside GetNearbyQuestIDs — if the zoneMapID
-    -- actually changes, the next call rebuilds; if it didn't (common during flight across
-    -- subzones of the same zone), the cache stays warm and the expensive multi-map scan is
-    -- skipped entirely.
-    -- Clear Current Quest / Current Event transition memory from the previous zone; otherwise
-    -- FullLayout treats rows as moving into CURRENT/CURRENT_EVENT, skips PopulateEntry, and returns
-    -- early—wrong visuals until reload (see FocusLayout categoryChangeSkipKeys / category-change branch).
+    -- Nearby WQ cache self-invalidates via zoneMapID compare in GetNearbyQuestIDs.
+    -- Without wiping prevGroupKey, FullLayout treats rows as moving into CURRENT/CURRENT_EVENT
+    -- and returns early, leaving stale visuals until reload.
     if addon.focus.categoryChange and addon.focus.categoryChange.prevGroupKey then
         wipe(addon.focus.categoryChange.prevGroupKey)
     end
-    -- Clear quest timer cache so zone-specific WQ timers get fresh anchors in the new zone.
     if addon.focus.questTimerCache then wipe(addon.focus.questTimerCache) end
     RunMplusHeightTransitionCheck()
-    -- Only clear right-click suppression on major area change (return to main zone), not on subzone change—unless option is "suppress until reload".
     if event == "ZONE_CHANGED_NEW_AREA" then
         if not addon.GetDB("suppressUntrackedUntilReload", false) then
             if addon.focus.recentlyUntrackedWorldQuests then wipe(addon.focus.recentlyUntrackedWorldQuests) end
             addon.SetDB("sessionSuppressedQuests", nil)
         end
-        -- Clear the cached delve name so the next delve doesn't inherit a stale name.
         if addon.ClearDelveNameCache then addon.ClearDelveNameCache() end
     end
     if addon.zoneTaskQuestCache then wipe(addon.zoneTaskQuestCache) end
-    -- Debounced immediate refresh collapses flight-subzone bursts. Late-retry timers catch
-    -- late API updates (map pins, WQ propagation) and are cancelled-and-restarted on each
-    -- zone change so a flight path fires them once after the last zone settles, not per zone.
     ScheduleZoneChangeDebouncedRefresh()
     ScheduleZoneLateRetries()
 end
@@ -611,8 +527,6 @@ local eventHandlers = {
                 or (C_QuestLog and C_QuestLog.IsWorldQuest and C_QuestLog.IsWorldQuest(questID))
             if isWQ then
                 addon.focus.nearbyQuestCacheDirty = true
-                addon.focus.nearbyQuestCache = nil
-                addon.focus.nearbyTaskQuestCache = nil
             end
         end
         ScheduleRefresh()
@@ -627,31 +541,20 @@ local eventHandlers = {
     VIGNETTE_MINIMAP_UPDATED = function() end,
     VIGNETTES_UPDATED        = OnVignettesUpdated,
     -- AREA_POIS_UPDATED: fires when zone events/POIs update (e.g. entering area with bonus objective).
-    -- Invalidate nearby cache so GetTasksTable/GetNearbyQuestIDs picks up newly available content.
-    -- Defer ScheduleRefresh to avoid taint chain with Blizzard map pin acquisition (SetPropagateMouseClicks).
     AREA_POIS_UPDATED        = function()
         if not addon.focus.enabled then return end
         addon.focus.nearbyQuestCacheDirty = true
-        addon.focus.nearbyQuestCache = nil
-        addon.focus.nearbyTaskQuestCache = nil
-        -- Debounced to coalesce POI storms (fires in bursts when zones spawn/despawn POIs).
         ScheduleNearbyPoiDebouncedRefresh()
     end,
     QUEST_POI_UPDATE         = function() end,
-    -- TASK_PROGRESS_UPDATE: fires when the player enters or leaves a WQ/task area (proximity).
-    -- Invalidate the WQ cache so the next layout picks up the newly-in-range or out-of-range quest.
-    -- Deferred 0.5s refresh catches leave scenarios where the API may lag.
+    -- 0.5s follow-up catches WQ-leave cases where C_TaskQuest.IsActive lags behind leaving the area.
     TASK_PROGRESS_UPDATE     = function()
         if not addon.focus.enabled then return end
         addon.focus.nearbyQuestCacheDirty = true
-        addon.focus.nearbyQuestCache = nil
-        addon.focus.nearbyTaskQuestCache = nil
         ScheduleNearbyPoiDebouncedRefresh()
         C_Timer.After(0.5, function()
             if not addon.focus.enabled then return end
             addon.focus.nearbyQuestCacheDirty = true
-            addon.focus.nearbyQuestCache = nil
-            addon.focus.nearbyTaskQuestCache = nil
             ScheduleRefresh()
         end)
     end,
@@ -679,13 +582,10 @@ local eventHandlers = {
         if addon.InvalidateScenarioEntriesCache then addon.InvalidateScenarioEntriesCache() end
         ScheduleRefresh()
     end,
-    -- Bonus objective became visible (e.g. entered zone/area). Invalidate nearby cache so GetTasksTable is re-read.
     SCENARIO_BONUS_VISIBILITY_UPDATE  = function()
         if not addon.focus.enabled then return end
         if addon.InvalidateScenarioEntriesCache then addon.InvalidateScenarioEntriesCache() end
         addon.focus.nearbyQuestCacheDirty = true
-        addon.focus.nearbyQuestCache = nil
-        addon.focus.nearbyTaskQuestCache = nil
         ScheduleRefresh()
     end,
     CRITERIA_COMPLETE        = function() ScheduleRefresh() end,

--- a/modules/Focus/FocusEvents.lua
+++ b/modules/Focus/FocusEvents.lua
@@ -79,6 +79,18 @@ local updateWidgetDebounceTimer
 local SCENARIO_CRITERIA_DEBOUNCE = 0.12
 local scenarioCriteriaDebounceTimer
 
+-- Coalesce bursts of QUEST_WATCH_UPDATE / QUEST_LOG_UPDATE / UNIT_QUEST_LOG_CHANGED.
+-- These events fire on every objective tick; the flash check still runs immediately, only
+-- the FullLayout request is deferred so closely-spaced updates produce one layout pass.
+local QUEST_UPDATE_DEBOUNCE = 0.08
+local questUpdateDebounceTimer
+
+-- Coalesce bursts of AREA_POIS_UPDATED / TASK_PROGRESS_UPDATE. These events invalidate the
+-- nearby-WQ cache; debouncing the refresh prevents a full GetNearbyQuestIDs rebuild per event
+-- during a POI storm. The cache is marked dirty immediately so correctness is preserved.
+local NEARBY_POI_DEBOUNCE = 0.2
+local nearbyPoiDebounceTimer
+
 -- OnUpdate dirty flag breaks taint chain from event-driven C_QuestLog calls.
 local layoutDirtyFrame = CreateFrame("Frame")
 layoutDirtyFrame:Hide()
@@ -138,6 +150,36 @@ local function ScheduleScenarioCriteriaDebouncedRefresh()
         end)
     else
         C_Timer.After(SCENARIO_CRITERIA_DEBOUNCE, function()
+            if addon.focus.enabled then ScheduleRefresh() end
+        end)
+    end
+end
+
+local function ScheduleQuestUpdateDebouncedRefresh()
+    if not addon.focus.enabled then return end
+    if questUpdateDebounceTimer then questUpdateDebounceTimer:Cancel() end
+    if C_Timer and C_Timer.NewTimer then
+        questUpdateDebounceTimer = C_Timer.NewTimer(QUEST_UPDATE_DEBOUNCE, function()
+            questUpdateDebounceTimer = nil
+            if addon.focus.enabled then ScheduleRefresh() end
+        end)
+    else
+        C_Timer.After(QUEST_UPDATE_DEBOUNCE, function()
+            if addon.focus.enabled then ScheduleRefresh() end
+        end)
+    end
+end
+
+local function ScheduleNearbyPoiDebouncedRefresh()
+    if not addon.focus.enabled then return end
+    if nearbyPoiDebounceTimer then nearbyPoiDebounceTimer:Cancel() end
+    if C_Timer and C_Timer.NewTimer then
+        nearbyPoiDebounceTimer = C_Timer.NewTimer(NEARBY_POI_DEBOUNCE, function()
+            nearbyPoiDebounceTimer = nil
+            if addon.focus.enabled then ScheduleRefresh() end
+        end)
+    else
+        C_Timer.After(NEARBY_POI_DEBOUNCE, function()
             if addon.focus.enabled then ScheduleRefresh() end
         end)
     end
@@ -365,7 +407,7 @@ local function OnQuestWatchUpdate(questID)
     if questID then
         CheckQuestObjectiveChangeAndFlash(questID)
     end
-    ScheduleRefresh()
+    ScheduleQuestUpdateDebouncedRefresh()
 end
 
 local function OnQuestAccepted(questID)
@@ -395,7 +437,7 @@ end
 local function OnQuestLogUpdate()
     if not addon.focus.enabled then ScheduleRefresh(); return end
     CheckAllWatchedQuestChanges()
-    ScheduleRefresh()
+    ScheduleQuestUpdateDebouncedRefresh()
 end
 
 local function OnUnitQuestLogChanged(_, unitToken)
@@ -403,7 +445,7 @@ local function OnUnitQuestLogChanged(_, unitToken)
     if unitToken == "player" then
         CheckAllWatchedQuestChanges()
     end
-    ScheduleRefresh()
+    ScheduleQuestUpdateDebouncedRefresh()
 end
 
 local function OnQuestWatchListChanged(questID, added)
@@ -530,9 +572,8 @@ local eventHandlers = {
         addon.focus.nearbyQuestCacheDirty = true
         addon.focus.nearbyQuestCache = nil
         addon.focus.nearbyTaskQuestCache = nil
-        C_Timer.After(0, function()
-            if addon.focus.enabled then ScheduleRefresh() end
-        end)
+        -- Debounced to coalesce POI storms (fires in bursts when zones spawn/despawn POIs).
+        ScheduleNearbyPoiDebouncedRefresh()
     end,
     QUEST_POI_UPDATE         = function() end,
     -- TASK_PROGRESS_UPDATE: fires when the player enters or leaves a WQ/task area (proximity).
@@ -543,7 +584,7 @@ local eventHandlers = {
         addon.focus.nearbyQuestCacheDirty = true
         addon.focus.nearbyQuestCache = nil
         addon.focus.nearbyTaskQuestCache = nil
-        ScheduleRefresh()
+        ScheduleNearbyPoiDebouncedRefresh()
         C_Timer.After(0.5, function()
             if not addon.focus.enabled then return end
             addon.focus.nearbyQuestCacheDirty = true

--- a/modules/Focus/FocusEvents.lua
+++ b/modules/Focus/FocusEvents.lua
@@ -565,10 +565,10 @@ local function OnZoneChanged(event)
     addon.focus.zoneJustChanged = true
     addon.focus.lastPlayerMapID = nil
     addon.focus.lastZoneMapID = nil
-    -- Invalidate the nearby WQ scan cache so the next layout re-scans for the new zone.
-    addon.focus.nearbyQuestCacheDirty = true
-    addon.focus.nearbyQuestCache = nil
-    addon.focus.nearbyTaskQuestCache = nil
+    -- Nearby WQ cache is gated on zoneMapID inside GetNearbyQuestIDs — if the zoneMapID
+    -- actually changes, the next call rebuilds; if it didn't (common during flight across
+    -- subzones of the same zone), the cache stays warm and the expensive multi-map scan is
+    -- skipped entirely.
     -- Clear Current Quest / Current Event transition memory from the previous zone; otherwise
     -- FullLayout treats rows as moving into CURRENT/CURRENT_EVENT, skips PopulateEntry, and returns
     -- early—wrong visuals until reload (see FocusLayout categoryChangeSkipKeys / category-change branch).

--- a/modules/Focus/FocusEvents.lua
+++ b/modules/Focus/FocusEvents.lua
@@ -91,6 +91,18 @@ local questUpdateDebounceTimer
 local NEARBY_POI_DEBOUNCE = 0.2
 local nearbyPoiDebounceTimer
 
+-- ZONE_CHANGED / ZONE_CHANGED_NEW_AREA / ZONE_CHANGED_INDOORS all fire during flight (often
+-- in bursts of 3-5 within a second as the player crosses subzones). The original handler ran
+-- an immediate ScheduleRefresh plus 0.4s/1.5s/2.5s late retries per event, which stacked into
+-- 12+ FullLayouts during a flight path. We now debounce the immediate refresh and keep a
+-- single set of cancellable late-retry timers that are restarted on each zone change — so
+-- retries fire once, after the last zone change in the burst settles.
+local ZONE_CHANGE_DEBOUNCE = 0.15
+local zoneChangeDebounceTimer
+local zoneLateRetry04Timer
+local zoneLateRetry15Timer
+local zoneLateRetry25Timer
+
 -- OnUpdate dirty flag breaks taint chain from event-driven C_QuestLog calls.
 local layoutDirtyFrame = CreateFrame("Frame")
 layoutDirtyFrame:Hide()
@@ -180,6 +192,60 @@ local function ScheduleNearbyPoiDebouncedRefresh()
         end)
     else
         C_Timer.After(NEARBY_POI_DEBOUNCE, function()
+            if addon.focus.enabled then ScheduleRefresh() end
+        end)
+    end
+end
+
+local RunMplusHeightTransitionCheck  -- forward declaration; defined below
+
+local function CancelZoneLateRetries()
+    if zoneLateRetry04Timer then zoneLateRetry04Timer:Cancel(); zoneLateRetry04Timer = nil end
+    if zoneLateRetry15Timer then zoneLateRetry15Timer:Cancel(); zoneLateRetry15Timer = nil end
+    if zoneLateRetry25Timer then zoneLateRetry25Timer:Cancel(); zoneLateRetry25Timer = nil end
+end
+
+-- Schedule the three late-retry refreshes after a zone change, cancelling any retries still
+-- pending from a previous zone change in the same burst. These retries catch late-updating
+-- APIs (map pin acquisition, WQ list propagation) after the zone settles.
+local function ScheduleZoneLateRetries()
+    CancelZoneLateRetries()
+    if not (C_Timer and C_Timer.NewTimer) then
+        C_Timer.After(0.4, function()
+            if not addon.focus.enabled then return end
+            if RunMplusHeightTransitionCheck then RunMplusHeightTransitionCheck() end
+            ScheduleRefresh()
+        end)
+        C_Timer.After(1.5, function() if addon.focus.enabled then ScheduleRefresh() end end)
+        C_Timer.After(2.5, function() if addon.focus.enabled then ScheduleRefresh() end end)
+        return
+    end
+    zoneLateRetry04Timer = C_Timer.NewTimer(0.4, function()
+        zoneLateRetry04Timer = nil
+        if not addon.focus.enabled then return end
+        if RunMplusHeightTransitionCheck then RunMplusHeightTransitionCheck() end
+        ScheduleRefresh()
+    end)
+    zoneLateRetry15Timer = C_Timer.NewTimer(1.5, function()
+        zoneLateRetry15Timer = nil
+        if addon.focus.enabled then ScheduleRefresh() end
+    end)
+    zoneLateRetry25Timer = C_Timer.NewTimer(2.5, function()
+        zoneLateRetry25Timer = nil
+        if addon.focus.enabled then ScheduleRefresh() end
+    end)
+end
+
+local function ScheduleZoneChangeDebouncedRefresh()
+    if not addon.focus.enabled then return end
+    if zoneChangeDebounceTimer then zoneChangeDebounceTimer:Cancel() end
+    if C_Timer and C_Timer.NewTimer then
+        zoneChangeDebounceTimer = C_Timer.NewTimer(ZONE_CHANGE_DEBOUNCE, function()
+            zoneChangeDebounceTimer = nil
+            if addon.focus.enabled then ScheduleRefresh() end
+        end)
+    else
+        C_Timer.After(ZONE_CHANGE_DEBOUNCE, function()
             if addon.focus.enabled then ScheduleRefresh() end
         end)
     end
@@ -475,7 +541,7 @@ end
 
 --- Handles M+ dungeon enter/exit: snapshot overworld height on enter, restore on exit.
 local MIN_SNAPSHOT_HEIGHT = 200
-local function RunMplusHeightTransitionCheck()
+RunMplusHeightTransitionCheck = function()
     if not addon.GetDB or not addon.IsInMythicDungeon then return end
     local inMplus = addon.IsInMythicDungeon()
     if addon.focus.wasInMplusDungeon and not inMplus then
@@ -521,16 +587,12 @@ local function OnZoneChanged(event)
         -- Clear the cached delve name so the next delve doesn't inherit a stale name.
         if addon.ClearDelveNameCache then addon.ClearDelveNameCache() end
     end
-    -- 2.5s delayed refresh for all zone events; catches late API updates when leaving event areas.
-    C_Timer.After(2.5, function() if addon.focus.enabled then ScheduleRefresh() end end)
     if addon.zoneTaskQuestCache then wipe(addon.zoneTaskQuestCache) end
-    ScheduleRefresh()
-    C_Timer.After(0.4, function()
-        if not addon.focus.enabled then return end
-        RunMplusHeightTransitionCheck()
-        ScheduleRefresh()
-    end)
-    C_Timer.After(1.5, function() if addon.focus.enabled then ScheduleRefresh() end end)
+    -- Debounced immediate refresh collapses flight-subzone bursts. Late-retry timers catch
+    -- late API updates (map pins, WQ propagation) and are cancelled-and-restarted on each
+    -- zone change so a flight path fires them once after the last zone settles, not per zone.
+    ScheduleZoneChangeDebouncedRefresh()
+    ScheduleZoneLateRetries()
 end
 
 local eventHandlers = {

--- a/modules/Focus/FocusLayout.lua
+++ b/modules/Focus/FocusLayout.lua
@@ -1537,19 +1537,56 @@ addon.GetPlayerCurrentZoneName = GetPlayerCurrentZoneName
 addon.AcquireEntry        = AcquireEntry
 
 -- Opt-in FullLayout profiler. Off by default; toggle with `/hsperf`. When on, any FullLayout
--- that takes longer than FOCUS_LAYOUT_SPIKE_MS is logged to chat so the user can attach real
--- timing numbers to reported stutters. The wrapper is one branch when disabled so the steady-
--- state cost is negligible.
+-- that takes longer than FOCUS_LAYOUT_SPIKE_MS is logged with a phase breakdown so the
+-- expensive phase is visible in the log line itself (agg / group / render).
 local FOCUS_LAYOUT_SPIKE_MS = 20
 addon.focus._layoutProfileEnabled = addon.focus._layoutProfileEnabled or false
+addon.focus._layoutProfile = addon.focus._layoutProfile or { agg = 0, group = 0 }
+
+-- Wrap ReadTrackedQuests / SortAndGroupQuests so their elapsed time accrues to the per-
+-- layout counters. Re-entrant calls (if any) don't double-count — the wrapper just records
+-- total time spent, which is what we want.
+local function InstallPhaseTimers()
+    if addon.focus._phaseTimersInstalled then return end
+    addon.focus._phaseTimersInstalled = true
+    local origRead = addon.ReadTrackedQuests
+    if origRead then
+        addon.ReadTrackedQuests = function(...)
+            if not addon.focus._layoutProfileEnabled or not debugprofilestop then
+                return origRead(...)
+            end
+            local t0 = debugprofilestop()
+            local a, b, c, d = origRead(...)
+            addon.focus._layoutProfile.agg = addon.focus._layoutProfile.agg + (debugprofilestop() - t0)
+            return a, b, c, d
+        end
+    end
+    local origGroup = addon.SortAndGroupQuests
+    if origGroup then
+        addon.SortAndGroupQuests = function(...)
+            if not addon.focus._layoutProfileEnabled or not debugprofilestop then
+                return origGroup(...)
+            end
+            local t0 = debugprofilestop()
+            local a, b, c, d = origGroup(...)
+            addon.focus._layoutProfile.group = addon.focus._layoutProfile.group + (debugprofilestop() - t0)
+            return a, b, c, d
+        end
+    end
+end
 
 local function FullLayoutProfiled()
     if not addon.focus._layoutProfileEnabled then return FullLayout() end
+    InstallPhaseTimers()
+    local prof = addon.focus._layoutProfile
+    prof.agg, prof.group = 0, 0
     local t0 = (debugprofilestop and debugprofilestop()) or 0
     FullLayout()
     local elapsed = ((debugprofilestop and debugprofilestop()) or 0) - t0
     if elapsed >= FOCUS_LAYOUT_SPIKE_MS and addon.HSPrint then
-        addon.HSPrint(("[focus] FullLayout: %.1f ms"):format(elapsed))
+        local render = elapsed - prof.agg - prof.group
+        addon.HSPrint(("[focus] FullLayout: %.1f ms (agg=%.1f group=%.1f render=%.1f)"):format(
+            elapsed, prof.agg, prof.group, render))
     end
 end
 

--- a/modules/Focus/FocusLayout.lua
+++ b/modules/Focus/FocusLayout.lua
@@ -1535,4 +1535,34 @@ end
 
 addon.GetPlayerCurrentZoneName = GetPlayerCurrentZoneName
 addon.AcquireEntry        = AcquireEntry
-addon.FullLayout          = FullLayout
+
+-- Opt-in FullLayout profiler. Off by default; toggle with `/hsperf`. When on, any FullLayout
+-- that takes longer than FOCUS_LAYOUT_SPIKE_MS is logged to chat so the user can attach real
+-- timing numbers to reported stutters. The wrapper is one branch when disabled so the steady-
+-- state cost is negligible.
+local FOCUS_LAYOUT_SPIKE_MS = 20
+addon.focus._layoutProfileEnabled = addon.focus._layoutProfileEnabled or false
+
+local function FullLayoutProfiled()
+    if not addon.focus._layoutProfileEnabled then return FullLayout() end
+    local t0 = (debugprofilestop and debugprofilestop()) or 0
+    FullLayout()
+    local elapsed = ((debugprofilestop and debugprofilestop()) or 0) - t0
+    if elapsed >= FOCUS_LAYOUT_SPIKE_MS and addon.HSPrint then
+        addon.HSPrint(("[focus] FullLayout: %.1f ms"):format(elapsed))
+    end
+end
+
+addon.FullLayout = FullLayoutProfiled
+
+-- /hsperf — toggles the FullLayout profiler. Registered here (not in FocusSlash) so the
+-- wrapper stays self-contained and the setup can be disabled by commenting out this block.
+SLASH_HSFOCUSPERF1 = "/hsperf"
+SlashCmdList.HSFOCUSPERF = function()
+    addon.focus._layoutProfileEnabled = not addon.focus._layoutProfileEnabled
+    if addon.HSPrint then
+        addon.HSPrint(("[focus] layout profiler %s (spike threshold %d ms)"):format(
+            addon.focus._layoutProfileEnabled and "ON" or "OFF",
+            FOCUS_LAYOUT_SPIKE_MS))
+    end
+end

--- a/modules/Focus/FocusLayout.lua
+++ b/modules/Focus/FocusLayout.lua
@@ -951,10 +951,8 @@ local function FullLayout()
                 addon.categoryChangeFadeOutCount = nil
                 addon.focus.categoryChange.slideUpStarts = categoryChangeSlideUpStartsNow
                 addon.focus.categoryChange.slideUpStartsSec = categoryChangeSlideUpStartsSecNow
-                -- Invalidate nearby cache so reflow picks up Events in Zone and other fresh data.
+                -- Force rebuild so reflow picks up Events in Zone and other fresh data.
                 addon.focus.nearbyQuestCacheDirty = true
-                addon.focus.nearbyQuestCache = nil
-                addon.focus.nearbyTaskQuestCache = nil
                 if addon.ScheduleRefresh then addon.ScheduleRefresh() end
             end
             -- Hide section headers for groups that are now empty so they don't linger during fade.
@@ -1536,62 +1534,52 @@ end
 addon.GetPlayerCurrentZoneName = GetPlayerCurrentZoneName
 addon.AcquireEntry        = AcquireEntry
 
--- Opt-in FullLayout profiler. Off by default; toggle with `/hsperf`. When on, any FullLayout
--- that takes longer than FOCUS_LAYOUT_SPIKE_MS is logged with a phase breakdown so the
--- expensive phase is visible in the log line itself (agg / group / render).
+-- Opt-in FullLayout profiler, toggled by /hsperf. Any layout above the spike threshold
+-- is logged with a phase breakdown (agg / group / render [populate]).
 local FOCUS_LAYOUT_SPIKE_MS = 20
-addon.focus._layoutProfileEnabled = addon.focus._layoutProfileEnabled or false
-addon.focus._layoutProfile = addon.focus._layoutProfile or { agg = 0, group = 0, populate = 0, populateCount = 0 }
+local profileEnabled = false
+local profileInstalled = false
+local prof = { agg = 0, group = 0, populate = 0, populateCount = 0 }
 
--- Wrap ReadTrackedQuests / SortAndGroupQuests / PopulateEntry so their elapsed time accrues
--- to the per-layout counters. The populate counter is summed across every entry painted in
--- the layout so we can see both total populate cost and per-entry cost in the log line.
 local function InstallPhaseTimers()
-    if addon.focus._phaseTimersInstalled then return end
-    addon.focus._phaseTimersInstalled = true
+    if profileInstalled then return end
+    profileInstalled = true
     local origRead = addon.ReadTrackedQuests
     if origRead then
         addon.ReadTrackedQuests = function(...)
-            if not addon.focus._layoutProfileEnabled or not debugprofilestop then
-                return origRead(...)
-            end
+            if not profileEnabled or not debugprofilestop then return origRead(...) end
             local t0 = debugprofilestop()
             local a, b, c, d = origRead(...)
-            addon.focus._layoutProfile.agg = addon.focus._layoutProfile.agg + (debugprofilestop() - t0)
+            prof.agg = prof.agg + (debugprofilestop() - t0)
             return a, b, c, d
         end
     end
     local origGroup = addon.SortAndGroupQuests
     if origGroup then
         addon.SortAndGroupQuests = function(...)
-            if not addon.focus._layoutProfileEnabled or not debugprofilestop then
-                return origGroup(...)
-            end
+            if not profileEnabled or not debugprofilestop then return origGroup(...) end
             local t0 = debugprofilestop()
             local a, b, c, d = origGroup(...)
-            addon.focus._layoutProfile.group = addon.focus._layoutProfile.group + (debugprofilestop() - t0)
+            prof.group = prof.group + (debugprofilestop() - t0)
             return a, b, c, d
         end
     end
     local origPopulate = addon.PopulateEntry
     if origPopulate then
         addon.PopulateEntry = function(...)
-            if not addon.focus._layoutProfileEnabled or not debugprofilestop then
-                return origPopulate(...)
-            end
+            if not profileEnabled or not debugprofilestop then return origPopulate(...) end
             local t0 = debugprofilestop()
             local a, b, c, d = origPopulate(...)
-            addon.focus._layoutProfile.populate = addon.focus._layoutProfile.populate + (debugprofilestop() - t0)
-            addon.focus._layoutProfile.populateCount = addon.focus._layoutProfile.populateCount + 1
+            prof.populate = prof.populate + (debugprofilestop() - t0)
+            prof.populateCount = prof.populateCount + 1
             return a, b, c, d
         end
     end
 end
 
 local function FullLayoutProfiled()
-    if not addon.focus._layoutProfileEnabled then return FullLayout() end
+    if not profileEnabled then return FullLayout() end
     InstallPhaseTimers()
-    local prof = addon.focus._layoutProfile
     prof.agg, prof.group, prof.populate, prof.populateCount = 0, 0, 0, 0
     local t0 = (debugprofilestop and debugprofilestop()) or 0
     FullLayout()
@@ -1606,14 +1594,11 @@ end
 
 addon.FullLayout = FullLayoutProfiled
 
--- /hsperf — toggles the FullLayout profiler. Registered here (not in FocusSlash) so the
--- wrapper stays self-contained and the setup can be disabled by commenting out this block.
 SLASH_HSFOCUSPERF1 = "/hsperf"
 SlashCmdList.HSFOCUSPERF = function()
-    addon.focus._layoutProfileEnabled = not addon.focus._layoutProfileEnabled
+    profileEnabled = not profileEnabled
     if addon.HSPrint then
         addon.HSPrint(("[focus] layout profiler %s (spike threshold %d ms)"):format(
-            addon.focus._layoutProfileEnabled and "ON" or "OFF",
-            FOCUS_LAYOUT_SPIKE_MS))
+            profileEnabled and "ON" or "OFF", FOCUS_LAYOUT_SPIKE_MS))
     end
 end

--- a/modules/Focus/FocusLayout.lua
+++ b/modules/Focus/FocusLayout.lua
@@ -1541,11 +1541,11 @@ addon.AcquireEntry        = AcquireEntry
 -- expensive phase is visible in the log line itself (agg / group / render).
 local FOCUS_LAYOUT_SPIKE_MS = 20
 addon.focus._layoutProfileEnabled = addon.focus._layoutProfileEnabled or false
-addon.focus._layoutProfile = addon.focus._layoutProfile or { agg = 0, group = 0 }
+addon.focus._layoutProfile = addon.focus._layoutProfile or { agg = 0, group = 0, populate = 0, populateCount = 0 }
 
--- Wrap ReadTrackedQuests / SortAndGroupQuests so their elapsed time accrues to the per-
--- layout counters. Re-entrant calls (if any) don't double-count — the wrapper just records
--- total time spent, which is what we want.
+-- Wrap ReadTrackedQuests / SortAndGroupQuests / PopulateEntry so their elapsed time accrues
+-- to the per-layout counters. The populate counter is summed across every entry painted in
+-- the layout so we can see both total populate cost and per-entry cost in the log line.
 local function InstallPhaseTimers()
     if addon.focus._phaseTimersInstalled then return end
     addon.focus._phaseTimersInstalled = true
@@ -1573,20 +1573,34 @@ local function InstallPhaseTimers()
             return a, b, c, d
         end
     end
+    local origPopulate = addon.PopulateEntry
+    if origPopulate then
+        addon.PopulateEntry = function(...)
+            if not addon.focus._layoutProfileEnabled or not debugprofilestop then
+                return origPopulate(...)
+            end
+            local t0 = debugprofilestop()
+            local a, b, c, d = origPopulate(...)
+            addon.focus._layoutProfile.populate = addon.focus._layoutProfile.populate + (debugprofilestop() - t0)
+            addon.focus._layoutProfile.populateCount = addon.focus._layoutProfile.populateCount + 1
+            return a, b, c, d
+        end
+    end
 end
 
 local function FullLayoutProfiled()
     if not addon.focus._layoutProfileEnabled then return FullLayout() end
     InstallPhaseTimers()
     local prof = addon.focus._layoutProfile
-    prof.agg, prof.group = 0, 0
+    prof.agg, prof.group, prof.populate, prof.populateCount = 0, 0, 0, 0
     local t0 = (debugprofilestop and debugprofilestop()) or 0
     FullLayout()
     local elapsed = ((debugprofilestop and debugprofilestop()) or 0) - t0
     if elapsed >= FOCUS_LAYOUT_SPIKE_MS and addon.HSPrint then
         local render = elapsed - prof.agg - prof.group
-        addon.HSPrint(("[focus] FullLayout: %.1f ms (agg=%.1f group=%.1f render=%.1f)"):format(
-            elapsed, prof.agg, prof.group, render))
+        local renderOther = render - prof.populate
+        addon.HSPrint(("[focus] FullLayout: %.1f ms (agg=%.1f group=%.1f render=%.1f [populate=%.1f/%d other=%.1f])"):format(
+            elapsed, prof.agg, prof.group, render, prof.populate, prof.populateCount, renderOther))
     end
 end
 

--- a/modules/Focus/FocusLayout.lua
+++ b/modules/Focus/FocusLayout.lua
@@ -1154,14 +1154,21 @@ local function FullLayout()
                             SafeEntryFadeIn(entry, entryIndex - 1)
                         end
                     end
-                    entry:ClearAllPoints()
-                    entry:SetPoint("TOPLEFT", scrollChild, "TOPLEFT", entryX, yOff)
+                    -- Skip anchor churn when the entry's position hasn't changed since
+                    -- the previous FullLayout. Cleared in FocusEntryPool reset on pool-release.
+                    if entry._lastEntryX ~= entryX or entry._lastEntryY ~= yOff then
+                        entry:ClearAllPoints()
+                        entry:SetPoint("TOPLEFT", scrollChild, "TOPLEFT", entryX, yOff)
+                        entry._lastEntryX = entryX
+                        entry._lastEntryY = yOff
+                    end
 
                     local sfLeftInset = (blockFrame and blockPos == "top") and addon.GetScaledPadding() or 0
                     local sfVisibleW = addon.GetPanelWidth() - sfLeftInset
                     local entryW = sfVisibleW - entryX - addon.GetScaledContentRightPadding()
-                    if entryW > 0 then
+                    if entryW > 0 and entry._lastEntryWidth ~= entryW then
                         entry:SetWidth(entryW)
+                        entry._lastEntryWidth = entryW
                     end
 
                     -- Keep questTypeIcon anchored to the entry frame so it scrolls/clips correctly.

--- a/modules/Focus/FocusRares.lua
+++ b/modules/Focus/FocusRares.lua
@@ -26,9 +26,7 @@ local RARES_BY_MAP = {
     },
 }
 
---- Classifies a vignette atlas name as rare ("rare") or treasure ("treasure"), else nil.
---- The lowercased atlas name is computed once; the original per-call IsNpc/IsTreasure
---- helpers each called :lower() separately, allocating a new string per vignette.
+--- Classifies a vignette atlas name as "rare", "treasure", or nil.
 local function ClassifyVignetteAtlas(atlasName)
     if not atlasName or atlasName == "" then return nil end
     local lower = atlasName:lower()
@@ -43,21 +41,13 @@ local function ClassifyVignetteAtlas(atlasName)
     return nil
 end
 
--- ----------------------------------------------------------------------------
--- SCAN CACHE
--- Rare + treasure lists are built in one shared vignette pass, then cached.
--- Invalidated on VIGNETTES_UPDATED (new rare/treasure spawned or despawned) and
--- on ZONE_CHANGED / PLAYER_ENTERING_WORLD (zone switch). The invalidation frame
--- fires regardless of focus.enabled so Presence (which also consumes these APIs)
--- sees fresh data even when the Focus module is disabled.
--- ----------------------------------------------------------------------------
-
+-- Scan cache: rare + treasure lists built in one vignette pass, invalidated by a dedicated
+-- event frame so Presence (which also calls GetRaresOnMap) sees fresh data when Focus is off.
 local scanCacheValid = false
 local scanCacheRares = nil
 local scanCacheTreasures = nil
 
--- Parent-map hierarchy cache for RARES_BY_MAP fallback lookups.
--- The previous code walked up to 20 parents on every call; we memoise per mapID.
+-- Parent-map hierarchy lookup, memoised per mapID.
 local mapLookupMapID = nil
 local mapLookupRares = nil
 local mapLookupZoneName = nil
@@ -99,9 +89,8 @@ local function ResolveMapRares(mapID)
     return rares, mapLookupZoneName
 end
 
---- Single shared vignette pass that populates both rare and treasure output lists.
---- Player mapID is resolved once per build (was previously per-vignette) and shared
---- with GetVignettePosition and the treasure zone-name lookup.
+--- One vignette pass that populates both rare and treasure lists. Player mapID is resolved
+--- once per build and shared across GetVignettePosition calls and the treasure zone lookup.
 local function BuildScan()
     local rareColor     = addon.GetQuestColor("RARE")
     local rareLootColor = (addon.GetQuestColor and addon.GetQuestColor("RARE_LOOT")) or addon.GetQuestColor("RARE")
@@ -119,8 +108,6 @@ local function BuildScan()
                 if vi and vi.name and vi.name ~= "" then
                     local kind = ClassifyVignetteAtlas(vi.atlasName)
                     if kind then
-                        -- Position lookup is shared between rare + treasure paths. GetVignettePosition
-                        -- requires a uiMapID, which we resolved once above.
                         local vX, vY
                         if mapID and C_VignetteInfo.GetVignettePosition then
                             local ok, pos = pcall(C_VignetteInfo.GetVignettePosition, vignetteGUID, mapID)
@@ -201,8 +188,7 @@ local function BuildScan()
         end
     end
 
-    -- Hardcoded RARES_BY_MAP fallback: only when the vignette pass found no rares.
-    -- Preserves the original precedence (vignette data wins over hardcoded list).
+    -- Vignette data wins over the hardcoded list; fall back only when no vignettes matched.
     if #rares == 0 and mapID then
         local mappedRares, zoneName = ResolveMapRares(mapID)
         if mappedRares then
@@ -252,8 +238,7 @@ end
 addon.GetRaresOnMap = GetRaresOnMap
 addon.GetTreasuresOnMap = GetTreasuresOnMap
 
--- Always-on invalidation frame. Runs regardless of focus.enabled so Presence, which
--- calls GetRaresOnMap independently, always sees a fresh scan after zone/vignette changes.
+-- Always-on: Presence calls GetRaresOnMap even when the Focus module is disabled.
 local invalidationFrame = CreateFrame("Frame")
 invalidationFrame:RegisterEvent("VIGNETTES_UPDATED")
 invalidationFrame:RegisterEvent("ZONE_CHANGED")
@@ -263,8 +248,6 @@ invalidationFrame:RegisterEvent("PLAYER_ENTERING_WORLD")
 invalidationFrame:SetScript("OnEvent", function(_, event)
     InvalidateScanCache()
     if event ~= "VIGNETTES_UPDATED" then
-        -- Zone boundary: the player's mapID may have changed, so the parent-map
-        -- hierarchy cache must also be invalidated.
         InvalidateMapLookup()
     end
 end)

--- a/modules/Focus/FocusRares.lua
+++ b/modules/Focus/FocusRares.lua
@@ -26,78 +26,172 @@ local RARES_BY_MAP = {
     },
 }
 
-local function IsNpcVignetteAtlas(atlasName)
-    if not atlasName or atlasName == "" then return false end
+--- Classifies a vignette atlas name as rare ("rare") or treasure ("treasure"), else nil.
+--- The lowercased atlas name is computed once; the original per-call IsNpc/IsTreasure
+--- helpers each called :lower() separately, allocating a new string per vignette.
+local function ClassifyVignetteAtlas(atlasName)
+    if not atlasName or atlasName == "" then return nil end
     local lower = atlasName:lower()
-    if lower:find("loot") or lower:find("treasure") or lower:find("container") or lower:find("chest") or lower:find("object") then
-        return false
+    if lower:find("loot") or lower:find("treasure") or lower:find("container")
+        or lower:find("chest") or lower:find("object") then
+        return "treasure"
     end
-    if lower:find("rare") or lower:find("elite") or lower:find("npc") or lower:find("vignettekill") then
-        return true
+    if lower:find("rare") or lower:find("elite") or lower:find("npc")
+        or lower:find("vignettekill") then
+        return "rare"
     end
-    return false
+    return nil
 end
 
-local function IsTreasureVignetteAtlas(atlasName)
-    if not atlasName or atlasName == "" then return false end
-    local lower = atlasName:lower()
-    return lower:find("loot") or lower:find("treasure") or lower:find("container") or lower:find("chest") or lower:find("object")
+-- ----------------------------------------------------------------------------
+-- SCAN CACHE
+-- Rare + treasure lists are built in one shared vignette pass, then cached.
+-- Invalidated on VIGNETTES_UPDATED (new rare/treasure spawned or despawned) and
+-- on ZONE_CHANGED / PLAYER_ENTERING_WORLD (zone switch). The invalidation frame
+-- fires regardless of focus.enabled so Presence (which also consumes these APIs)
+-- sees fresh data even when the Focus module is disabled.
+-- ----------------------------------------------------------------------------
+
+local scanCacheValid = false
+local scanCacheRares = nil
+local scanCacheTreasures = nil
+
+-- Parent-map hierarchy cache for RARES_BY_MAP fallback lookups.
+-- The previous code walked up to 20 parents on every call; we memoise per mapID.
+local mapLookupMapID = nil
+local mapLookupRares = nil
+local mapLookupZoneName = nil
+
+local function InvalidateScanCache()
+    scanCacheValid = false
 end
 
-local function GetRaresOnMap()
-    local out = {}
-    local rareColor = addon.GetQuestColor("RARE")
+local function InvalidateMapLookup()
+    mapLookupMapID = nil
+    mapLookupRares = nil
+    mapLookupZoneName = nil
+end
+
+addon.InvalidateRareScanCache = InvalidateScanCache
+
+--- Resolve RARES_BY_MAP entries for mapID, walking the parent-map hierarchy.
+--- Cached per-mapID; zone changes invalidate the cache.
+local function ResolveMapRares(mapID)
+    if not mapID then return nil, nil end
+    if mapLookupMapID == mapID then
+        return mapLookupRares, mapLookupZoneName
+    end
+    local rares = RARES_BY_MAP[mapID]
+    if not rares and C_Map and C_Map.GetMapInfo then
+        local current = mapID
+        for _ = 1, 20 do
+            local parentInfo = C_Map.GetMapInfo(current)
+            if not parentInfo or not parentInfo.parentMapID or parentInfo.parentMapID == 0 then break end
+            current = parentInfo.parentMapID
+            rares = RARES_BY_MAP[current]
+            if rares then break end
+        end
+    end
+    local info = C_Map and C_Map.GetMapInfo and C_Map.GetMapInfo(mapID) or nil
+    mapLookupMapID = mapID
+    mapLookupRares = rares
+    mapLookupZoneName = info and info.name or nil
+    return rares, mapLookupZoneName
+end
+
+--- Single shared vignette pass that populates both rare and treasure output lists.
+--- Player mapID is resolved once per build (was previously per-vignette) and shared
+--- with GetVignettePosition and the treasure zone-name lookup.
+local function BuildScan()
+    local rareColor     = addon.GetQuestColor("RARE")
+    local rareLootColor = (addon.GetQuestColor and addon.GetQuestColor("RARE_LOOT")) or addon.GetQuestColor("RARE")
+
+    local rares, treasures = {}, {}
+    local mapID = (C_Map and C_Map.GetBestMapForUnit) and C_Map.GetBestMapForUnit("player") or nil
+    local treasureZoneName  -- lazy-populated once on first treasure hit
 
     if C_VignetteInfo and C_VignetteInfo.GetVignettes and C_VignetteInfo.GetVignetteInfo then
         local vignettes = C_VignetteInfo.GetVignettes()
         if vignettes then
-            local seen = {}
+            local seenRares, seenTreasures = {}, {}
             for _, vignetteGUID in ipairs(vignettes) do
                 local vi = C_VignetteInfo.GetVignetteInfo(vignetteGUID)
-                if vi and (vi.name and vi.name ~= "") then
-                    if IsNpcVignetteAtlas(vi.atlasName) then
-                        local creatureID = vi.npcID or vi.creatureID
-                        if not creatureID and vi.objectGUID then
-                            local _, _, _, _, _, id, _ = strsplit("-", vi.objectGUID)
-                            creatureID = tonumber(id)
+                if vi and vi.name and vi.name ~= "" then
+                    local kind = ClassifyVignetteAtlas(vi.atlasName)
+                    if kind then
+                        -- Position lookup is shared between rare + treasure paths. GetVignettePosition
+                        -- requires a uiMapID, which we resolved once above.
+                        local vX, vY
+                        if mapID and C_VignetteInfo.GetVignettePosition then
+                            local ok, pos = pcall(C_VignetteInfo.GetVignettePosition, vignetteGUID, mapID)
+                            if ok and pos then
+                                vX = pos.x or (pos.GetXY and select(1, pos:GetXY()))
+                                vY = pos.y or (pos.GetXY and select(2, pos:GetXY()))
+                            end
                         end
-                        if creatureID then
-                            local dedupeKey = creatureID and ("c:" .. tostring(creatureID)) or ("n:" .. (vi.name or ""))
-                            if seen[dedupeKey] then
-                                -- skip duplicate (same creature from multiple vignette GUIDs)
-                            else
-                                seen[dedupeKey] = true
-                                -- Get vignette position for waypoint support. GetVignettePosition requires uiMapID.
-                                local vX, vY, vMapID
-                                if C_Map and C_Map.GetBestMapForUnit then
-                                    vMapID = C_Map.GetBestMapForUnit("player")
+
+                        if kind == "rare" then
+                            local creatureID = vi.npcID or vi.creatureID
+                            if not creatureID and vi.objectGUID then
+                                local _, _, _, _, _, id, _ = strsplit("-", vi.objectGUID)
+                                creatureID = tonumber(id)
+                            end
+                            if creatureID then
+                                local dedupeKey = "c:" .. tostring(creatureID)
+                                if not seenRares[dedupeKey] then
+                                    seenRares[dedupeKey] = true
+                                    rares[#rares + 1] = {
+                                        entryKey       = "vignette:" .. tostring(vignetteGUID),
+                                        questID        = nil,
+                                        title          = vi.name or "Unknown",
+                                        objectives     = {},
+                                        color          = rareColor,
+                                        category       = "RARE",
+                                        isComplete     = false,
+                                        isSuperTracked = false,
+                                        isNearby       = true,
+                                        zoneName       = nil,
+                                        itemLink       = nil,
+                                        itemTexture    = nil,
+                                        isRare         = true,
+                                        creatureID     = creatureID,
+                                        vignetteGUID   = vignetteGUID,
+                                        vignetteMapID  = mapID,
+                                        vignetteX      = vX,
+                                        vignetteY      = vY,
+                                    }
                                 end
-                                if vMapID and C_VignetteInfo.GetVignettePosition then
-                                    local ok, pos = pcall(C_VignetteInfo.GetVignettePosition, vignetteGUID, vMapID)
-                                    if ok and pos then
-                                        vX = pos.x or (pos.GetXY and select(1, pos:GetXY()))
-                                        vY = pos.y or (pos.GetXY and select(2, pos:GetXY()))
-                                    end
+                            end
+                        else -- treasure
+                            local dedupeKey = (mapID and vX and vY)
+                                and ("p:%s:%.2f:%.2f"):format(tostring(mapID), vX or 0, vY or 0)
+                                or (vi.vignetteID and ("v:" .. tostring(vi.vignetteID)) or ("n:" .. (vi.name or "")))
+                            if not seenTreasures[dedupeKey] then
+                                seenTreasures[dedupeKey] = true
+                                if not treasureZoneName and mapID and C_Map and C_Map.GetMapInfo then
+                                    local info = C_Map.GetMapInfo(mapID)
+                                    treasureZoneName = info and info.name or nil
                                 end
-                                out[#out + 1] = {
-                                    entryKey    = "vignette:" .. tostring(vignetteGUID),
-                                    questID     = nil,
-                                    title       = vi.name or "Unknown",
-                                    objectives  = {},
-                                    color       = rareColor,
-                                    category    = "RARE",
-                                    isComplete  = false,
+                                treasures[#treasures + 1] = {
+                                    entryKey       = "vignette:" .. tostring(vignetteGUID),
+                                    questID        = nil,
+                                    title          = vi.name or "Unknown",
+                                    objectives     = {},
+                                    color          = rareLootColor,
+                                    category       = "RARE_LOOT",
+                                    isComplete     = false,
                                     isSuperTracked = false,
-                                    isNearby    = true,
-                                    zoneName    = nil,
-                                    itemLink    = nil,
-                                    itemTexture = nil,
-                                    isRare      = true,
-                                    creatureID  = creatureID,
-                                    vignetteGUID = vignetteGUID,
-                                    vignetteMapID = vMapID,
-                                    vignetteX   = vX,
-                                    vignetteY   = vY,
+                                    isNearby       = true,
+                                    zoneName       = treasureZoneName,
+                                    itemLink       = nil,
+                                    itemTexture    = nil,
+                                    isRareLoot     = true,
+                                    vignetteGUID   = vignetteGUID,
+                                    vignetteID     = vi.vignetteID,
+                                    vignetteMapID  = mapID,
+                                    vignetteX      = vX,
+                                    vignetteY      = vY,
+                                    questTypeAtlas = vi.atlasName,
                                 }
                             end
                         end
@@ -105,119 +199,75 @@ local function GetRaresOnMap()
                 end
             end
         end
-        if #out > 0 then
-            return out
-        end
     end
 
-    if not C_Map or not C_Map.GetBestMapForUnit then return out end
-    local mapID = C_Map.GetBestMapForUnit("player")
-    if not mapID then return out end
-
-    local rares = RARES_BY_MAP[mapID]
-    if not rares and C_Map.GetMapInfo then
-        local current = mapID
-        for _ = 1, 20 do
-            local parentInfo = C_Map.GetMapInfo(current)
-            if not parentInfo or not parentInfo.parentMapID then break end
-            current = parentInfo.parentMapID
-            rares = RARES_BY_MAP[current]
-            if rares then break end
-        end
-    end
-    if not rares then return out end
-
-    local mapInfo = C_Map.GetMapInfo and C_Map.GetMapInfo(mapID)
-    local zoneName = mapInfo and mapInfo.name or nil
-    for _, t in ipairs(rares) do
-        local creatureID, name = t[1], t[2]
-        if creatureID and name then
-            out[#out + 1] = {
-                entryKey   = "rare:" .. tostring(creatureID),
-                questID    = nil,
-                title      = name,
-                objectives = {},
-                color      = rareColor,
-                category   = "RARE",
-                isComplete = false,
-                isSuperTracked = false,
-                isNearby   = true,
-                zoneName   = zoneName,
-                itemLink   = nil,
-                itemTexture = nil,
-                isRare     = true,
-                creatureID = creatureID,
-            }
-        end
-    end
-    return out
-end
-
-local function GetTreasuresOnMap()
-    local out = {}
-    local rareLootColor = addon.GetQuestColor and addon.GetQuestColor("RARE_LOOT") or addon.GetQuestColor("RARE")
-
-    if C_VignetteInfo and C_VignetteInfo.GetVignettes and C_VignetteInfo.GetVignetteInfo then
-        local vignettes = C_VignetteInfo.GetVignettes()
-        if vignettes then
-            local seen = {}
-            for _, vignetteGUID in ipairs(vignettes) do
-                local vi = C_VignetteInfo.GetVignetteInfo(vignetteGUID)
-                if vi and (vi.name and vi.name ~= "") and IsTreasureVignetteAtlas(vi.atlasName) then
-                    local vX, vY, vMapID
-                    if C_Map and C_Map.GetBestMapForUnit then
-                        vMapID = C_Map.GetBestMapForUnit("player")
-                    end
-                    if vMapID and C_VignetteInfo.GetVignettePosition then
-                        local ok, pos = pcall(C_VignetteInfo.GetVignettePosition, vignetteGUID, vMapID)
-                        if ok and pos then
-                            vX = pos.x or (pos.GetXY and select(1, pos:GetXY()))
-                            vY = pos.y or (pos.GetXY and select(2, pos:GetXY()))
-                        end
-                    end
-                    local dedupeKey = (vMapID and vX and vY)
-                        and ("p:%s:%.2f:%.2f"):format(tostring(vMapID), vX or 0, vY or 0)
-                        or (vi.vignetteID and ("v:" .. tostring(vi.vignetteID)) or ("n:" .. (vi.name or "")))
-                    if seen[dedupeKey] then
-                        -- skip duplicate (same treasure from multiple vignette GUIDs)
-                    else
-                        seen[dedupeKey] = true
-                    local zoneName
-                    if vMapID and C_Map and C_Map.GetMapInfo then
-                        local info = C_Map.GetMapInfo(vMapID)
-                        zoneName = info and info.name or nil
-                    end
-                    out[#out + 1] = {
-                        entryKey       = "vignette:" .. tostring(vignetteGUID),
+    -- Hardcoded RARES_BY_MAP fallback: only when the vignette pass found no rares.
+    -- Preserves the original precedence (vignette data wins over hardcoded list).
+    if #rares == 0 and mapID then
+        local mappedRares, zoneName = ResolveMapRares(mapID)
+        if mappedRares then
+            for _, t in ipairs(mappedRares) do
+                local creatureID, name = t[1], t[2]
+                if creatureID and name then
+                    rares[#rares + 1] = {
+                        entryKey       = "rare:" .. tostring(creatureID),
                         questID        = nil,
-                        title          = vi.name or "Unknown",
+                        title          = name,
                         objectives     = {},
-                        color          = rareLootColor,
-                        category       = "RARE_LOOT",
+                        color          = rareColor,
+                        category       = "RARE",
                         isComplete     = false,
                         isSuperTracked = false,
                         isNearby       = true,
                         zoneName       = zoneName,
                         itemLink       = nil,
                         itemTexture    = nil,
-                        isRareLoot     = true,
-                        vignetteGUID   = vignetteGUID,
-                        vignetteID     = vi.vignetteID,
-                        vignetteMapID  = vMapID,
-                        vignetteX      = vX,
-                        vignetteY      = vY,
-                        questTypeAtlas = vi.atlasName,
+                        isRare         = true,
+                        creatureID     = creatureID,
                     }
-                    end
                 end
             end
         end
     end
-    return out
+
+    scanCacheRares     = rares
+    scanCacheTreasures = treasures
+    scanCacheValid     = true
+end
+
+local function EnsureScan()
+    if not scanCacheValid then BuildScan() end
+end
+
+local function GetRaresOnMap()
+    EnsureScan()
+    return scanCacheRares or {}
+end
+
+local function GetTreasuresOnMap()
+    EnsureScan()
+    return scanCacheTreasures or {}
 end
 
 addon.GetRaresOnMap = GetRaresOnMap
 addon.GetTreasuresOnMap = GetTreasuresOnMap
+
+-- Always-on invalidation frame. Runs regardless of focus.enabled so Presence, which
+-- calls GetRaresOnMap independently, always sees a fresh scan after zone/vignette changes.
+local invalidationFrame = CreateFrame("Frame")
+invalidationFrame:RegisterEvent("VIGNETTES_UPDATED")
+invalidationFrame:RegisterEvent("ZONE_CHANGED")
+invalidationFrame:RegisterEvent("ZONE_CHANGED_NEW_AREA")
+pcall(function() invalidationFrame:RegisterEvent("ZONE_CHANGED_INDOORS") end)
+invalidationFrame:RegisterEvent("PLAYER_ENTERING_WORLD")
+invalidationFrame:SetScript("OnEvent", function(_, event)
+    InvalidateScanCache()
+    if event ~= "VIGNETTES_UPDATED" then
+        -- Zone boundary: the player's mapID may have changed, so the parent-map
+        -- hierarchy cache must also be invalidated.
+        InvalidateMapLookup()
+    end
+end)
 
 -- ============================================================================
 -- RARE BOSS WAYPOINT

--- a/modules/Focus/FocusWorldQuests.lua
+++ b/modules/Focus/FocusWorldQuests.lua
@@ -138,6 +138,9 @@ local function GetNearbyQuestIDs()
     end
 
     local showWQ = addon.GetDB("showWorldQuests", true)
+    -- Track which mapIDs have already been queried via GetTaskQuestsForMap so the quest-hub
+    -- fallback below cannot re-query a map already handled in the main loop.
+    local queriedTaskMaps = {}
 
     for _, checkMapID in ipairs(mapIDsToCheck) do
         -- C_QuestLog.GetQuestsOnMap: regular quest map pins (accepted quests with POI locations).
@@ -172,7 +175,8 @@ local function GetNearbyQuestIDs()
 
         -- C_TaskQuest.GetQuestsOnMap: authoritative source for active task/world quests.
         -- Only run when showWorldQuests is on; this is the expensive per-zone WQ scan.
-        if showWQ and addon.GetTaskQuestsForMap then
+        if showWQ and addon.GetTaskQuestsForMap and not queriedTaskMaps[checkMapID] then
+            queriedTaskMaps[checkMapID] = true
             local taskPOIs = addon.GetTaskQuestsForMap(checkMapID, checkMapID) or addon.GetTaskQuestsForMap(checkMapID)
             if taskPOIs then
                 for _, poi in ipairs(taskPOIs) do
@@ -196,7 +200,8 @@ local function GetNearbyQuestIDs()
                 local okInfo, poiInfo = pcall(C_AreaPoiInfo.GetAreaPOIInfo, ctx.zoneMapID, areaPoiID)
                 local linkedMapID = okInfo and poiInfo and poiInfo.linkedUiMapID or nil
                 -- If the hub links to a map and that map exposes task quests, query it.
-                if linkedMapID and addon.GetTaskQuestsForMap then
+                if linkedMapID and addon.GetTaskQuestsForMap and not queriedTaskMaps[linkedMapID] then
+                    queriedTaskMaps[linkedMapID] = true
                     local taskPOIs = addon.GetTaskQuestsForMap(linkedMapID, linkedMapID) or addon.GetTaskQuestsForMap(linkedMapID)
                     if taskPOIs then
                         for _, poi in ipairs(taskPOIs) do

--- a/modules/Focus/FocusWorldQuests.lua
+++ b/modules/Focus/FocusWorldQuests.lua
@@ -80,25 +80,36 @@ local function IsTaskQuestOnPlayerMaps(questID, mapIDSet)
 end
 
 --- Build sets of quest IDs visible on the player's current map(s) and from task/WQ APIs.
--- Results are cached until addon.focus.nearbyQuestCacheDirty is set (done on zone change).
+-- Cache invalidation:
+--   Fast path: cache is reusable when the player's zoneMapID matches the zoneMapID the cache
+--   was built for AND no "hard dirty" event fired since. Subzone / ZONE_CHANGED events during
+--   flight that don't actually change zoneMapID hit this path — the expensive multi-map scan
+--   is skipped entirely.
+--   Hard-dirty path: events that can change the nearby-task set without zoneMapID moving
+--   (TASK_PROGRESS_UPDATE, AREA_POIS_UPDATED, WQ accept/remove, SCENARIO_BONUS_VISIBILITY_UPDATE)
+--   set addon.focus.nearbyQuestCacheDirty = true and force a rebuild.
 -- When showWorldQuests is off the WQ map scan is skipped entirely; only bonus-objective task
 -- quests (non-WQ) are still included because they are zone-entered, not zone-scanned.
 -- @return table nearbySet Set of questID -> true for quests on player map or parent/children
 -- @return table taskQuestOnlySet Set of questID -> true for quests coming only from task/WQ map APIs
 local function GetNearbyQuestIDs()
-    -- Return cached result if the zone hasn't changed since the last scan.
-    if not addon.focus.nearbyQuestCacheDirty
-        and addon.focus.nearbyQuestCache
-        and addon.focus.nearbyTaskQuestCache then
+    -- Resolve map context up front so we can compare zoneMapID on the fast path.
+    local ctx = addon.ResolvePlayerMapContext and addon.ResolvePlayerMapContext("player") or nil
+    local currentZoneMapID = (ctx and ctx.zoneMapID) or -1
+
+    if addon.focus.nearbyQuestCache
+        and addon.focus.nearbyTaskQuestCache
+        and addon.focus.nearbyQuestCacheZoneID == currentZoneMapID
+        and not addon.focus.nearbyQuestCacheDirty then
         return addon.focus.nearbyQuestCache, addon.focus.nearbyTaskQuestCache
     end
     addon.focus.nearbyQuestCacheDirty = nil
+    addon.focus.nearbyQuestCacheZoneID = currentZoneMapID
     local nearbySet = {}
     local taskQuestOnlySet = {}
 
     -- Build mapIDsToCheck first so we can filter by current map.
     -- This prevents stale WQs from the previous zone (e.g. after hearth) from staying in the tracker.
-    local ctx = addon.ResolvePlayerMapContext and addon.ResolvePlayerMapContext("player") or nil
     local mapIDsToCheck = (ctx and ctx.mapIDsToQuery and #ctx.mapIDsToQuery > 0) and ctx.mapIDsToQuery or nil
     local mapIDSet = {}
     if mapIDsToCheck then

--- a/modules/Focus/FocusWorldQuests.lua
+++ b/modules/Focus/FocusWorldQuests.lua
@@ -80,24 +80,20 @@ local function IsTaskQuestOnPlayerMaps(questID, mapIDSet)
 end
 
 --- Build sets of quest IDs visible on the player's current map(s) and from task/WQ APIs.
--- Cache invalidation:
---   Fast path: cache is reusable when the player's zoneMapID matches the zoneMapID the cache
---   was built for AND no "hard dirty" event fired since. Subzone / ZONE_CHANGED events during
---   flight that don't actually change zoneMapID hit this path — the expensive multi-map scan
---   is skipped entirely.
---   Hard-dirty path: events that can change the nearby-task set without zoneMapID moving
---   (TASK_PROGRESS_UPDATE, AREA_POIS_UPDATED, WQ accept/remove, SCENARIO_BONUS_VISIBILITY_UPDATE)
---   set addon.focus.nearbyQuestCacheDirty = true and force a rebuild.
--- When showWorldQuests is off the WQ map scan is skipped entirely; only bonus-objective task
--- quests (non-WQ) are still included because they are zone-entered, not zone-scanned.
+-- Fast path reuses the cached sets when the player's zoneMapID matches the one the cache
+-- was built for and no hard-dirty event fired. Hard-dirty events (TASK_PROGRESS_UPDATE,
+-- AREA_POIS_UPDATED, WQ accept/remove, SCENARIO_BONUS_VISIBILITY_UPDATE) set
+-- nearbyQuestCacheDirty and force a rebuild regardless of zoneMapID.
 -- @return table nearbySet Set of questID -> true for quests on player map or parent/children
 -- @return table taskQuestOnlySet Set of questID -> true for quests coming only from task/WQ map APIs
 local function GetNearbyQuestIDs()
-    -- Resolve map context up front so we can compare zoneMapID on the fast path.
     local ctx = addon.ResolvePlayerMapContext and addon.ResolvePlayerMapContext("player") or nil
-    local currentZoneMapID = (ctx and ctx.zoneMapID) or -1
+    local currentZoneMapID = ctx and ctx.zoneMapID or nil
 
-    if addon.focus.nearbyQuestCache
+    -- Only hit the fast path when we have a real zoneMapID; otherwise force rebuild so a
+    -- login/transition state with an unresolved context can't pin the cache on a sentinel.
+    if currentZoneMapID
+        and addon.focus.nearbyQuestCache
         and addon.focus.nearbyTaskQuestCache
         and addon.focus.nearbyQuestCacheZoneID == currentZoneMapID
         and not addon.focus.nearbyQuestCacheDirty then
@@ -108,8 +104,6 @@ local function GetNearbyQuestIDs()
     local nearbySet = {}
     local taskQuestOnlySet = {}
 
-    -- Build mapIDsToCheck first so we can filter by current map.
-    -- This prevents stale WQs from the previous zone (e.g. after hearth) from staying in the tracker.
     local mapIDsToCheck = (ctx and ctx.mapIDsToQuery and #ctx.mapIDsToQuery > 0) and ctx.mapIDsToQuery or nil
     local mapIDSet = {}
     if mapIDsToCheck then


### PR DESCRIPTION
## Summary

Targeted performance sweep across `modules/Focus/` after the user flagged the rare scanner as a suspected hot spot. Audit confirmed rare scanner issues plus larger wins in quest-event debouncing and FullLayout work. No SavedVariables schema change, no Interface version change, no public API break.

## Changes by phase

### Phase 1 — event debouncing
- `QUEST_WATCH_UPDATE` / `QUEST_LOG_UPDATE` / `UNIT_QUEST_LOG_CHANGED` now go through `ScheduleQuestUpdateDebouncedRefresh` (80 ms). Flash check still runs immediately; only the FullLayout request is debounced so objective-tick storms collapse into one layout pass.
- `AREA_POIS_UPDATED` / `TASK_PROGRESS_UPDATE` route through `ScheduleNearbyPoiDebouncedRefresh` (200 ms). Cache invalidation stays synchronous so correctness is preserved.
- `GetNearbyQuestIDs` dedups `GetTaskQuestsForMap` calls so the quest-hub fallback can't re-query a map already scanned by the main loop.
- `RunMapCheck` (driven by `PLAYER_MAP_CHANGED`) routes its refresh through a 100 ms debounce; rapid subzone→zone→continent transitions collapse to one FullLayout.

### Phase 2 — rare/treasure scanner consolidation
- Merged `GetRaresOnMap` + `GetTreasuresOnMap` into a single `BuildScan` that walks `C_VignetteInfo.GetVignettes` once and classifies atlases in one pass.
- `C_Map.GetBestMapForUnit(\"player\")` is called once per scan (was per-vignette — HIGH-severity finding).
- Rare/treasure output is now cached. A dedicated always-on event frame invalidates on `VIGNETTES_UPDATED` / `ZONE_CHANGED*` / `PLAYER_ENTERING_WORLD` so Presence (which also consumes `GetRaresOnMap`) stays correct even when the Focus module is disabled.
- Parent-map hierarchy walk (RARES_BY_MAP fallback) is cached per mapID.
- Atlas-name lowercasing now happens once per vignette.

### Phase 3 — aggregator caching
- New `QuestAncestorMatchesZone` memoises the parent-map walk shared by `IsQuestOnPlayerZoneMap` and `questMapMatchesPlayer`; keyed on the player's current `zoneMapID`, cleared when the zone changes.

### Phase 4 — layout anchor skip
- `FullLayout` now skips `entry:ClearAllPoints` / `SetPoint` / `SetWidth` when the computed position matches the previously-applied one. Cached `_lastEntryX/Y/Width` fields are cleared on pool release.

### Phase 5 — WQT ticker cleanup
- Replaced the 1 s WQT suppression ticker with a `HookScript(\"OnShow\")` guard on `WorldQuestTrackerScreenPanel`.
- Collapsed the nested `C_Timer.After(0.1)` → `C_Timer.After(0.2, FullLayout)` chain in the `AddQuestToTracker` hook into a single `ScheduleRefresh`.

## Test plan

- [ ] Busy quest area: tracker still updates on objective ticks; flash animation still fires.
- [ ] Zone transition (hearth, portal, flight): tracker repopulates correctly for the new zone; no stale WQs from the old zone.
- [ ] Zone with many rares/treasure vignettes (current-patch open-world zones): rares and treasures appear in the tracker; spawn/despawn within the existing 0.5 s vignette debounce.
- [ ] Fallback zones for hardcoded `RARES_BY_MAP` (Waking Shores 2112, Zaralek Cavern 2133, Siren Isle 2198): rares still appear when no vignettes present.
- [ ] Presence module rare-defeated toasts still fire when a rare vignette disappears during combat.
- [ ] Active Delve / scenario: timer bars still update at 0.5 s cadence; no stuck state.
- [ ] M+ dungeon enter/exit: tracker-height snapshot and restore still work.
- [ ] World Quest Tracker addon loaded: panel stays hidden when WQT tries to show it (OnShow hook).
- [ ] `/timetest` or in-game profiler (`/console scriptprofile 1`) before/after in a busy WQ hub to confirm frame-time improvement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)