### PR TITLE
fix(Focus): restore v4.14.0 baseline + apply populate-cache-bypass Nemesis fix

### DIFF
--- a/modules/Focus/FocusEntryRenderer.lua
+++ b/modules/Focus/FocusEntryRenderer.lua
@@ -2384,8 +2384,39 @@ local function BuildEntrySignature(qData, groupKey)
 end
 
 local origPopulateEntry = PopulateEntry
+
+--- Some questData values are dynamic in ways `BuildEntrySignature` doesn't (and
+--- can't reasonably) fingerprint — notably Delve scenario-main data: the Nemesis
+--- chest count / checkmark are fetched inside `PopulateEntry` via the widget read
+--- in `FocusScenarioDelve`, which happens AFTER the signature is built, and the
+--- delve affix names are resolved inside `PopulateEntry` via `addon.GetDelvesAffixes()`
+--- rather than being attached to the entry beforehand.
+---
+--- Without this bypass, once a delve scenario-main entry is first drawn with
+--- incomplete widget data (common on initial delve entry — Blizzard populates the
+--- ScenarioHeaderDelves widget's spells array a few seconds after the entry shows),
+--- the signature stays identical across every subsequent refresh (ScheduleRefresh,
+--- UPDATE_UI_WIDGET, SCENARIO_UPDATE, etc.) and the cache short-circuits before the
+--- widget is re-read. The Nemesis badge and affix row then stay stuck until something
+--- perturbs a fingerprinted field — a life loss, a criteria change, a /reload, or a
+--- manual collapse/expand of the objective tracker.
+---
+--- Cost: one full populate per layout for the single scenario-main entry in a delve —
+--- layouts already run at single-digit Hz, so the overhead is immaterial.
+local function EntryBypassesPopulateCache(questData)
+    if questData.category == "DELVES" then return true end
+    if questData.isScenarioMain then return true end
+    return false
+end
+
 local function PopulateEntryCached(entry, questData, groupKey)
     if not entry or not questData then return origPopulateEntry(entry, questData, groupKey) end
+    if EntryBypassesPopulateCache(questData) then
+        -- Clear any stale signature on the pooled entry so a later non-bypassing
+        -- quest landing on the same slot doesn't hit a false cache hit.
+        entry._populateSig = nil
+        return origPopulateEntry(entry, questData, groupKey)
+    end
     local sig = BuildEntrySignature(questData, groupKey)
     if sig and entry._populateSig == sig then
         return entry.entryHeight

--- a/modules/Focus/FocusEvents.lua
+++ b/modules/Focus/FocusEvents.lua
@@ -53,15 +53,6 @@ pcall(function() eventFrame:RegisterEvent("PERKS_ACTIVITIES_TRACKED_LIST_CHANGED
 pcall(function() eventFrame:RegisterEvent("ACTIVE_DELVE_DATA_UPDATE") end)
 pcall(function() eventFrame:RegisterEvent("WALK_IN_DATA_UPDATE") end)
 pcall(function() eventFrame:RegisterEvent("UPDATE_UI_WIDGET") end)
--- UPDATE_ALL_UI_WIDGETS fires when Blizzard wholesale-initializes a widget set (e.g. on
--- scenario entry). Individual UPDATE_UI_WIDGET events may not fire quickly enough on
--- initial delve load to catch the scenario header widget before Focus has built a stale
--- read; listening to the bulk signal lets the Nemesis banner pick up real data immediately.
-pcall(function() eventFrame:RegisterEvent("UPDATE_ALL_UI_WIDGETS") end)
--- SPELL_DATA_LOAD_RESULT fires asynchronously after C_Spell.RequestLoadSpellData once the
--- server returns the description. The Delve Nemesis affix embeds "remaining: N" in its
--- description; a refresh here catches the count the moment the description arrives.
-pcall(function() eventFrame:RegisterEvent("SPELL_DATA_LOAD_RESULT") end)
 pcall(function() eventFrame:RegisterEvent("INITIATIVE_TASKS_TRACKED_UPDATED") end)
 pcall(function() eventFrame:RegisterEvent("INITIATIVE_TASKS_TRACKED_LIST_CHANGED") end)
 pcall(function() eventFrame:RegisterEvent("TRACKING_TARGET_INFO_UPDATE") end)
@@ -614,21 +605,6 @@ local eventHandlers = {
     -- Replaces the recursive instance-state poll for the M+ case.
     CHALLENGE_MODE_START     = function() OnInstanceEntered() end,
     UPDATE_UI_WIDGET         = function() OnUpdateUiWidgetDebounced() end,
-    -- UPDATE_ALL_UI_WIDGETS: wholesale widget-set init. Refresh only when a scenario is
-    -- actually active (same gate as OnUpdateUiWidgetDebounced) to avoid overworld churn.
-    UPDATE_ALL_UI_WIDGETS    = function()
-        if not addon.focus.enabled then return end
-        if not ((addon.IsDelveActive and addon.IsDelveActive()) or (addon.IsScenarioActive and addon.IsScenarioActive())) then return end
-        ScheduleUpdateUiWidgetDebouncedRefresh()
-    end,
-    -- SPELL_DATA_LOAD_RESULT: async description-ready signal for affix spells (Delve Nemesis).
-    -- Only refresh if the delve/scenario is active; `success=false` never carries useful data.
-    SPELL_DATA_LOAD_RESULT   = function(_, _, success)
-        if success == false then return end
-        if not addon.focus.enabled then return end
-        if not ((addon.IsDelveActive and addon.IsDelveActive()) or (addon.IsScenarioActive and addon.IsScenarioActive())) then return end
-        ScheduleUpdateUiWidgetDebouncedRefresh()
-    end,
     INITIATIVE_TASKS_TRACKED_UPDATED = function() ScheduleRefresh() end,
     INITIATIVE_TASKS_TRACKED_LIST_CHANGED = function() ScheduleRefresh() end,
     TRACKING_TARGET_INFO_UPDATE = function() ScheduleRefresh() end,

--- a/modules/Focus/FocusEvents.lua
+++ b/modules/Focus/FocusEvents.lua
@@ -352,24 +352,15 @@ local function OnPlayerRegenEnabled()
     end
 end
 
--- When entering a Delve/dungeon, APIs can lag by several seconds on the first session
--- entry after a relog: `C_PartyInfo.IsDelveInProgress` takes a moment to flip true, spell
--- descriptions for affix spells arrive asynchronously from the server, and `UPDATE_UI_WIDGET`
--- events that fire during that sync window get dropped by the IsDelveActive gate (since it
--- hasn't returned true yet). Event-driven refreshes alone therefore can't catch first-login
--- delve entry reliably. Multi-stage retries re-poll through the sync window regardless of
--- per-event gating; on subsequent entries (state cached) the first retry picks up data and
--- the later ones are cheap no-ops.
-local INSTANCE_ENTER_RETRY_DELAYS = { 0.2, 0.5, 1.0, 2.0, 4.0 }
-
+-- When entering a Delve/dungeon, APIs can lag by one frame.
+-- ACTIVE_DELVE_DATA_UPDATE, WALK_IN_DATA_UPDATE, and CHALLENGE_MODE_START
+-- fire at the exact right moment, so we just need a single short defer.
 local function OnInstanceEntered()
     if not addon.focus.enabled then return end
-    for _, delay in ipairs(INSTANCE_ENTER_RETRY_DELAYS) do
-        C_Timer.After(delay, function()
-            if not addon.focus.enabled then return end
-            ScheduleRefresh()
-        end)
-    end
+    C_Timer.After(0.2, function()
+        if not addon.focus.enabled then return end
+        ScheduleRefresh()
+    end)
 end
 
 local function OnPlayerLoginOrEnteringWorld()

--- a/modules/Focus/FocusEvents.lua
+++ b/modules/Focus/FocusEvents.lua
@@ -343,15 +343,22 @@ local function OnPlayerRegenEnabled()
     end
 end
 
--- When entering a Delve/dungeon, APIs can lag by one frame.
--- ACTIVE_DELVE_DATA_UPDATE, WALK_IN_DATA_UPDATE, and CHALLENGE_MODE_START
--- fire at the exact right moment, so we just need a single short defer.
+-- When entering a Delve/dungeon, ACTIVE_DELVE_DATA_UPDATE fires at the right moment
+-- but Blizzard's scenario-header widget data (notably the delve's affix spells) takes
+-- a further few hundred ms to populate. A short retry ladder catches the populate
+-- window without waiting on the next unrelated refresh trigger — visible impact is the
+-- Nemesis badge appearing ~0.5s after entry instead of ~1s+. Subsequent ScheduleRefresh
+-- calls coalesce via the pending flag so the ladder costs at most one extra layout.
+local INSTANCE_ENTER_RETRY_DELAYS = { 0.2, 0.5, 1.0 }
+
 local function OnInstanceEntered()
     if not addon.focus.enabled then return end
-    C_Timer.After(0.2, function()
-        if not addon.focus.enabled then return end
-        ScheduleRefresh()
-    end)
+    for _, delay in ipairs(INSTANCE_ENTER_RETRY_DELAYS) do
+        C_Timer.After(delay, function()
+            if not addon.focus.enabled then return end
+            ScheduleRefresh()
+        end)
+    end
 end
 
 local function OnPlayerLoginOrEnteringWorld()

--- a/modules/Focus/scenarios/FocusDelves.lua
+++ b/modules/Focus/scenarios/FocusDelves.lua
@@ -2,10 +2,7 @@
     Horizon Suite - Focus - Delve Provider
     ScenarioHeaderDelvesWidget (tierText, currencies, spells), C_PartyInfo.IsDelveInProgress, C_QuestLog.GetQuestTagInfo (QuestTag.Delve).
     Lives remaining: parsed from widget currencies (per-slot textEnabledState or numeric text).
-    Nemesis enemy groups: sole source is widgetInfo.spells[i].stackDisplay plus the
-        "remaining: N" description pattern (triggered via C_Spell.RequestLoadSpellData +
-        SPELL_DATA_LOAD_RESULT). The identified Nemesis spellID is cached for the run so
-        `stack == 0` on the same spell is a direct, unambiguous completion signal.
+    Nemesis enemy groups priority: affix spell stackDisplay / description "remaining: N" -> currency runs -> FillUpFrames / DiscreteProgress / IconAndText / TextWithState siblings in the same widget set.
 ]]
 
 local addon = _G._HorizonSuite_Loading or _G.HorizonSuiteBeta or _G.HorizonSuite
@@ -21,32 +18,7 @@ local NEMESIS_GROUPS_MAX = 30
 -- scenario and synthesize `isComplete = true` while the delve is still active.
 -- `runLive` gates the "treat as complete" fallback: only true after we have seen at least one live
 -- group count this run, so a stale seenMax from a previous run (same map ID) cannot show the tick.
--- `lastLiveRemaining` records the most recent live `remaining > 0` value we observed this
--- run. It gates `isComplete` acceptance: Blizzard can report stackDisplay=0 on the Nemesis
--- spell transiently during widget reload / delve entry / `/reload`, and the only reliable
--- "this is real completion" signal is that we already saw the natural final decrement
--- (remaining==1). `latchedRemaining` keeps the last known live count rendered across
--- transient data gaps so the banner doesn't flicker to nothing mid-run.
-local nemesisCache = {
-    key = nil, seenMax = 0, completed = false, runLive = false,
-    lastLiveRemaining = 0,
-    latchedRemaining = nil, latchedTotal = nil,
-    -- Identified Nemesis spellID for this run. Once set, the spells parser looks it up
-    -- directly so `stackDisplay == 0` on the same spell is a direct completion signal
-    -- (rather than inferred from fallback widgets, which can false-positive).
-    nemesisSpellID = nil,
-}
-
-local function ResetNemesisCache(key)
-    nemesisCache.key = key
-    nemesisCache.seenMax = 0
-    nemesisCache.completed = false
-    nemesisCache.runLive = false
-    nemesisCache.lastLiveRemaining = 0
-    nemesisCache.latchedRemaining = nil
-    nemesisCache.latchedTotal = nil
-    nemesisCache.nemesisSpellID = nil
-end
+local nemesisCache = { key = nil, seenMax = 0, completed = false, runLive = false }
 
 -- Zone transitions (including delve entry/exit) always invalidate the Nemesis cache.
 -- C_Map.GetBestMapForUnit returns the same ID for two runs of the same delve type, so the
@@ -54,7 +26,10 @@ end
 local nemesisCacheResetFrame = CreateFrame("Frame")
 nemesisCacheResetFrame:RegisterEvent("PLAYER_ENTERING_WORLD")
 nemesisCacheResetFrame:SetScript("OnEvent", function()
-    ResetNemesisCache(nil)
+    nemesisCache.key = nil
+    nemesisCache.seenMax = 0
+    nemesisCache.completed = false
+    nemesisCache.runLive = false
 end)
 
 --- Get spell name and icon; supports both legacy GetSpellInfo and C_Spell.GetSpellInfo.
@@ -215,85 +190,246 @@ local function GetDelveLivesIconFileID(widgetInfo)
     return first
 end
 
---- Nemesis Strongbox / bonus-chest count rendered as a stack badge on an affix spell icon.
---- Sole authoritative source: `widgetInfo.spells[i].stackDisplay`, with `C_Spell.GetSpellDescription`
---- "remaining: N" as a co-equal identifier (Blizzard formats the same count into the description,
---- and the description arrives asynchronously on initial delve entry).
----
---- The Nemesis spell keeps its slot in `spells` across the entire run; Blizzard decrements
---- `stackDisplay` as packs die and drops it to 0 on completion before the spell icon is
---- removed from the widget. Once we've identified which spellID is the Nemesis, we look
---- up that specific ID on every subsequent read — seeing it present with `stack == 0`
---- gives us a direct, zero-ambiguity completion signal (no inference from sibling widgets
---- that can fire false positives during initial widget reload).
----
---- `RequestLoadSpellData` triggers `SPELL_DATA_LOAD_RESULT` once the server returns the
---- description, which FocusEvents routes back to a refresh so the count appears as soon
---- as the description arrives instead of waiting for an unrelated widget tick.
+--- Contiguous runs in `currencies` grouped by iconFileID (nil/missing treated as sentinel -1 per slot).
+--- @param cur table
+--- @return table runs { startIdx, endIdx, iconFileID }[]
+local function PartitionCurrencyRunsByIcon(cur)
+    local runs = {}
+    if type(cur) ~= "table" or #cur < 1 then return runs end
+    local i = 1
+    local n = #cur
+    while i <= n do
+        local c = cur[i]
+        local iconKey = (type(c) == "table" and type(c.iconFileID) == "number" and c.iconFileID > 0)
+            and c.iconFileID or -1
+        local startIdx = i
+        i = i + 1
+        while i <= n do
+            local c2 = cur[i]
+            local ik = (type(c2) == "table" and type(c2.iconFileID) == "number" and c2.iconFileID > 0)
+                and c2.iconFileID or -1
+            if ik ~= iconKey then break end
+            i = i + 1
+        end
+        local endIdx = i - 1
+        local iconFileID = (iconKey ~= -1) and iconKey or nil
+        runs[#runs + 1] = { startIdx = startIdx, endIdx = endIdx, iconFileID = iconFileID }
+    end
+    return runs
+end
+
+--- Parse Nemesis / Nemesis-chest row: per-slot textEnabledState (Disabled = group defeated) or single-slot number / cur/max.
+--- @param startIdx number
+--- @param endIdx number
+--- @param cur table currency array
+--- @return table|nil { remaining, total, isComplete, hasData }
+local function ParseCurrencyRunNemesisLike(startIdx, endIdx, cur)
+    if type(cur) ~= "table" or startIdx > endIdx then return nil end
+    local Disabled = Enum and Enum.WidgetEnabledState and Enum.WidgetEnabledState.Disabled
+    local sawState, remaining, total = false, 0, 0
+    for idx = startIdx, endIdx do
+        local c = cur[idx]
+        if type(c) == "table" and c.textEnabledState ~= nil and Disabled ~= nil then
+            sawState = true
+            total = total + 1
+            if c.textEnabledState ~= Disabled then
+                remaining = remaining + 1
+            end
+        end
+    end
+    if sawState and total > 0 then
+        return { remaining = remaining, total = total, isComplete = (remaining == 0), hasData = true }
+    end
+    if startIdx == endIdx then
+        local c = cur[startIdx]
+        if type(c) == "table" then
+            local t = type(c.text) == "string" and c.text or ""
+            local trimmed = t:match("^%s*(.-)%s*$") or ""
+            local num = tonumber(trimmed)
+            if num ~= nil and num >= 0 and num <= NEMESIS_GROUPS_MAX then
+                return { remaining = num, total = nil, isComplete = (num == 0), hasData = true }
+            end
+            local curG, maxG = trimmed:match("^(%d+)/(%d+)$")
+            if curG and maxG then
+                local a, b = tonumber(curG), tonumber(maxG)
+                if a ~= nil and b ~= nil and b >= 1 and b <= NEMESIS_GROUPS_MAX then
+                    return { remaining = a, total = b, isComplete = (a == 0), hasData = true }
+                end
+            end
+        end
+    end
+    return nil
+end
+
+--- Nemesis Strongbox / bonus-chest count is usually rendered as a stack badge on an affix spell icon.
+--- Primary source: widgetInfo.spells[i].stackDisplay (same field zQuestLog uses).
+--- Fallback: parse the spell description for "remaining[^%d]+(%d+)" (Blizzard formats the count into the description).
 --- @param widgetInfo table ScenarioHeaderDelves widget visualization info
 --- @return table|nil { remaining, total, isComplete, hasData }
 local function ParseNemesisFromDelveSpells(widgetInfo)
     if not widgetInfo or type(widgetInfo.spells) ~= "table" or #widgetInfo.spells < 1 then return nil end
-
-    -- Trigger async description load for every affix spell. Cheap & idempotent; pairs with
-    -- FocusEvents' SPELL_DATA_LOAD_RESULT handler to re-read as descriptions arrive.
-    if C_Spell and C_Spell.RequestLoadSpellData then
-        for _, sp in ipairs(widgetInfo.spells) do
-            if type(sp) == "table" and type(sp.spellID) == "number" and sp.spellID > 0 then
-                pcall(C_Spell.RequestLoadSpellData, sp.spellID)
-            end
-        end
-    end
-
-    --- Extract the live count from a spell entry. Reads `stackDisplay` first, falls back
-    --- to the "remaining: N" pattern in the spell description (Blizzard uses a non-breaking
-    --- space between the label and the number, so `[^%d]+` is the correct separator class).
-    --- @param sp table One entry from widgetInfo.spells
-    --- @return number|nil stack
-    local function ReadStack(sp)
-        local stack = (type(sp.stackDisplay) == "number" and sp.stackDisplay) or nil
-        if (not stack or stack <= 0) and C_Spell and C_Spell.GetSpellDescription then
-            local dOk, desc = pcall(C_Spell.GetSpellDescription, sp.spellID)
-            if dOk and type(desc) == "string" then
-                local n = tonumber(desc:match("remaining[^%d]+(%d+)"))
-                if n and n >= 0 then stack = n end
-            end
-        end
-        return stack
-    end
-
-    -- Fast path: if we've already identified which spell is the Nemesis this run, look it
-    -- up directly. This is what lets stack==0 mean "complete" unambiguously.
-    local cachedID = nemesisCache.nemesisSpellID
-    if type(cachedID) == "number" and cachedID > 0 then
-        for _, sp in ipairs(widgetInfo.spells) do
-            if type(sp) == "table" and sp.spellID == cachedID then
-                local stack = ReadStack(sp) or 0
-                if stack > 0 and stack <= NEMESIS_GROUPS_MAX then
-                    return { remaining = stack, total = nil, isComplete = false, hasData = true }
-                end
-                -- Spell still present but stack dropped to 0: Blizzard's direct "complete" signal.
-                return { remaining = 0, total = nil, isComplete = true, hasData = true }
-            end
-        end
-        -- Cached ID vanished from the spell list — fall through to re-scan. If nothing
-        -- identifies as Nemesis in the new snapshot, GetDelveScenarioHeaderMetadata's
-        -- elseif block synthesizes completion once we've seen lastLiveRemaining<=1.
-    end
-
-    -- Discovery path: find a spell that identifies itself as the Nemesis. A spell counts
-    -- as Nemesis when either stackDisplay > 0 or the description carries the "remaining"
-    -- count. Once identified, cache its spellID so subsequent reads take the fast path.
     for _, sp in ipairs(widgetInfo.spells) do
         if type(sp) == "table" and type(sp.spellID) == "number" and sp.spellID > 0 then
-            local stack = ReadStack(sp)
-            if stack and stack > 0 and stack <= NEMESIS_GROUPS_MAX then
-                nemesisCache.nemesisSpellID = sp.spellID
+            local stack = (type(sp.stackDisplay) == "number" and sp.stackDisplay) or 0
+            if stack <= 0 and C_Spell and C_Spell.GetSpellDescription then
+                local dOk, desc = pcall(C_Spell.GetSpellDescription, sp.spellID)
+                if dOk and type(desc) == "string" then
+                    local n = tonumber(desc:match("remaining[^%d]+(%d+)"))
+                    if n and n > 0 then stack = n end
+                end
+            end
+            if stack > 0 and stack <= NEMESIS_GROUPS_MAX then
                 return { remaining = stack, total = nil, isComplete = false, hasData = true }
             end
         end
     end
+    return nil
+end
 
+--- Second+ icon run, or a single run that is not the same datum as lives (e.g. Nemesis-only row with one slot or chest icons).
+--- @param widgetInfo table
+--- @return table|nil
+local function ParseNemesisFromScenarioHeaderCurrencies(widgetInfo)
+    if not widgetInfo or type(widgetInfo.currencies) ~= "table" then return nil end
+    local cur = widgetInfo.currencies
+    if #cur < 1 then return nil end
+    local runs = PartitionCurrencyRunsByIcon(cur)
+    if #runs >= 2 then
+        for ri = 2, #runs do
+            local seg = runs[ri]
+            local parsed = ParseCurrencyRunNemesisLike(seg.startIdx, seg.endIdx, cur)
+            if parsed and parsed.hasData then return parsed end
+        end
+        return nil
+    end
+    -- Single icon run: only trustworthy as Nemesis when there are multiple slots (a row of chest/octagon entries).
+    -- A lone currency is Blizzard's lives aggregate (e.g. text="5", tooltip="Total deaths: N"), never Nemesis.
+    if #runs == 1 then
+        if #cur < 2 then return nil end
+        local seg = runs[1]
+        local parsed = ParseCurrencyRunNemesisLike(seg.startIdx, seg.endIdx, cur)
+        if not parsed or not parsed.hasData then return nil end
+        -- If this single run matches the lives remaining exactly, it's the hearts row, not Nemesis.
+        local livesRem = ParseDelveLivesRemaining(widgetInfo)
+        if livesRem ~= nil and parsed.remaining == livesRem and (parsed.total == nil or parsed.total == #cur) then
+            return nil
+        end
+        return parsed
+    end
+    return nil
+end
+
+-- Heuristic: tooltip text suggests Nemesis / bonus chest progress (avoid unrelated IconAndText numbers).
+local function TooltipLooksLikeNemesisGroups(tip, dtip)
+    local lower = ((tip or "") .. " " .. (dtip or "")):lower()
+    if lower:find("nemesis", 1, true) then return true end
+    if lower:find("enemy", 1, true) and lower:find("group", 1, true) then return true end
+    if lower:find("chest", 1, true) and (lower:find("bonus", 1, true) or lower:find("nemesis", 1, true)) then return true end
+    if lower:find("bountiful", 1, true) then return true end
+    if lower:find("pactsworn", 1, true) then return true end
+    if lower:find("wasteland", 1, true) then return true end
+    if lower:find("strongbox", 1, true) then return true end
+    if lower:find("coffer", 1, true) then return true end
+    return false
+end
+
+--- Fallback: other widgets in the delve scenario widget set (FillUpFrames, DiscreteProgress, IconAndText).
+--- @param setID number
+--- @return table|nil
+local function ScanDelveWidgetSetForNemesis(setID)
+    if not setID or not (C_UIWidgetManager and C_UIWidgetManager.GetAllWidgetsBySetID) then return nil end
+    local wOk, widgets = pcall(C_UIWidgetManager.GetAllWidgetsBySetID, setID)
+    if not wOk or type(widgets) ~= "table" then return nil end
+    local bestFill, bestDiscrete, bestIconText
+
+    for _, wInfo in pairs(widgets) do
+        local widgetID = (type(wInfo) == "table" and type(wInfo.widgetID) == "number") and wInfo.widgetID
+            or (type(wInfo) == "number" and wInfo > 0) and wInfo
+        local wType = type(wInfo) == "table" and wInfo.widgetType
+        if widgetID and (not wType or wType ~= WIDGET_TYPE_SCENARIO_HEADER_DELVES) then
+            if C_UIWidgetManager.GetFillUpFramesWidgetVisualizationInfo then
+                local ok, info = pcall(C_UIWidgetManager.GetFillUpFramesWidgetVisualizationInfo, widgetID)
+                if ok and info and type(info) == "table" and type(info.numTotalFrames) == "number"
+                    and info.numTotalFrames >= 1 and info.numTotalFrames <= NEMESIS_GROUPS_MAX then
+                    local full = type(info.numFullFrames) == "number" and info.numFullFrames or 0
+                    local total = info.numTotalFrames
+                    full = math.min(math.max(full, 0), total)
+                    local remaining = total - full
+                    bestFill = {
+                        remaining  = remaining,
+                        total      = total,
+                        isComplete = (remaining <= 0 and total > 0),
+                        hasData    = total > 0,
+                    }
+                end
+            end
+
+            if C_UIWidgetManager.GetDiscreteProgressStepsVisualizationInfo then
+                local ok, info = pcall(C_UIWidgetManager.GetDiscreteProgressStepsVisualizationInfo, widgetID)
+                if ok and info and type(info) == "table" and type(info.progressMax) == "number"
+                    and info.progressMax >= 1 and info.progressMax <= NEMESIS_GROUPS_MAX then
+                    local vmin = type(info.progressMin) == "number" and info.progressMin or 0
+                    local pv = type(info.progressVal) == "number" and info.progressVal or vmin
+                    local total = info.progressMax - vmin
+                    if total >= 1 then
+                        local completed = math.max(0, math.min(pv - vmin, total))
+                        local remaining = math.max(0, total - completed)
+                        local tip = TooltipLooksLikeNemesisGroups(info.tooltip, info.dynamicTooltip)
+                        if tip then
+                            bestDiscrete = {
+                                remaining  = remaining,
+                                total      = total,
+                                isComplete = (remaining <= 0 and total > 0),
+                                hasData    = true,
+                            }
+                        end
+                    end
+                end
+            end
+
+            if C_UIWidgetManager.GetIconAndTextWidgetVisualizationInfo then
+                local ok, info = pcall(C_UIWidgetManager.GetIconAndTextWidgetVisualizationInfo, widgetID)
+                if ok and info and type(info) == "table" and type(info.text) == "string" then
+                    local trimmed = info.text:match("^%s*(.-)%s*$") or ""
+                    local num = tonumber(trimmed)
+                    if num ~= nil and num >= 0 and num <= NEMESIS_GROUPS_MAX then
+                        local tipOk = TooltipLooksLikeNemesisGroups(info.tooltip, info.dynamicTooltip)
+                        if tipOk or num == 0 or (num >= 1 and num <= 15) then
+                            bestIconText = {
+                                remaining  = num,
+                                total      = nil,
+                                isComplete = (num == 0),
+                                hasData    = true,
+                            }
+                        end
+                    end
+                end
+            end
+
+            if not bestIconText and C_UIWidgetManager.GetTextWithStateWidgetVisualizationInfo then
+                local ok, info = pcall(C_UIWidgetManager.GetTextWithStateWidgetVisualizationInfo, widgetID)
+                if ok and info and type(info) == "table" and type(info.text) == "string" then
+                    local trimmed = info.text:match("^%s*(.-)%s*$") or ""
+                    local num = tonumber(trimmed)
+                    if num ~= nil and num >= 0 and num <= NEMESIS_GROUPS_MAX then
+                        local tipOk = TooltipLooksLikeNemesisGroups(info.tooltip, info.dynamicTooltip)
+                        if tipOk or num == 0 or (num >= 1 and num <= 15) then
+                            bestIconText = {
+                                remaining  = num,
+                                total      = nil,
+                                isComplete = (num == 0),
+                                hasData    = true,
+                            }
+                        end
+                    end
+                end
+            end
+        end
+    end
+
+    if bestFill and bestFill.hasData then return bestFill end
+    if bestDiscrete and bestDiscrete.hasData then return bestDiscrete end
+    if bestIconText and bestIconText.hasData then return bestIconText end
     return nil
 end
 
@@ -415,14 +551,14 @@ function addon.GetDelveScenarioHeaderMetadata()
     }
     if not ShouldReadDelveScenarioWidgets() then
         -- Left the delve: drop the completion cache so a re-entry starts clean.
-        ResetNemesisCache(nil)
+        nemesisCache.key, nemesisCache.seenMax, nemesisCache.completed, nemesisCache.runLive = nil, 0, false, false
         return result
     end
 
     -- Per-scenario key; reset cache when the player changes delve.
     local scenarioKey = (C_Map and C_Map.GetBestMapForUnit and C_Map.GetBestMapForUnit("player")) or 0
     if scenarioKey ~= nemesisCache.key then
-        ResetNemesisCache(scenarioKey)
+        nemesisCache.key, nemesisCache.seenMax, nemesisCache.completed, nemesisCache.runLive = scenarioKey, 0, false, false
     end
 
     local setIDs = GetAllDelveScenarioWidgetSetIDs()
@@ -438,33 +574,12 @@ function addon.GetDelveScenarioHeaderMetadata()
         end
     end
 
-    local function AcceptCompletion()
-        -- Nemesis groups die one at a time, so the natural kill sequence always passes
-        -- through `remaining == 1` before the spell flips to 0 / is removed. We require
-        -- that step to have been observed live before accepting any isComplete signal.
-        --
-        -- An earlier version also accepted after a 1.5s "stability window" regardless of
-        -- last-live value, but that turned out to be the exact path that produced the
-        -- spurious tick on delve entry / `/reload`: during widget reload Blizzard can
-        -- report `stackDisplay = 0` on the Nemesis spell for several seconds before the
-        -- real value syncs, which trips the age threshold and synthesizes a false tick.
-        -- Requiring `lastLiveRemaining <= 1` is the only signal we can trust.
-        --
-        -- Trade-off: if the player AoEs multiple groups in one swing and the widget skips
-        -- the remaining==1 update (a refresh debounce window missing the intermediate
-        -- state), the tick won't render until the next delve run. That's a rare visual
-        -- miss vs. a repeated, visible false-positive — accept the miss.
-        if not nemesisCache.runLive then return false end
-        return (nemesisCache.lastLiveRemaining or 0) <= 1
-    end
-
     local function adopt(parsed)
         if not parsed then return false end
-        -- Reject isComplete unless AcceptCompletion agrees we've seen the natural
-        -- remaining==1 step live. Blizzard can report stackDisplay=0 on the Nemesis
-        -- spell transiently during widget reload, and without this gate we'd flip the
-        -- banner to the tick state on delve entry / `/reload`.
-        if parsed.isComplete and not AcceptCompletion() then return false end
+        -- Blizzard widgets default to 0/disabled before server data arrives on initial load,
+        -- which makes every fallback parser return { isComplete = true, remaining = 0 } spuriously.
+        -- Only trust "complete" once we have seen live group data (runLive) this run.
+        if parsed.isComplete and not nemesisCache.runLive then return false end
         result.nemesisGroupsRemaining = parsed.remaining
         result.nemesisGroupsTotal = parsed.total
         result.nemesisIsComplete = parsed.isComplete
@@ -472,13 +587,19 @@ function addon.GetDelveScenarioHeaderMetadata()
         return true
     end
 
-    -- Sole source: the affix spell in widgetInfo.spells (stackDisplay or the "remaining: N"
-    -- description). Earlier builds tried currency runs and sibling widget-set scans as
-    -- fallbacks, but those paths cannot distinguish Blizzard's transient "all slots
-    -- disabled" state on initial widget reload from a genuine completion, and were the
-    -- structural cause of the spurious-tick / delayed-count on initial delve entry.
+    -- Priority: affix spell stackDisplay / "remaining: N" (zQuestLog pattern), then currency runs, then sibling widgets.
     for _, wi in ipairs(allHeaders) do
         if adopt(ParseNemesisFromDelveSpells(wi)) then break end
+    end
+    if not result.nemesisHasData then
+        for _, wi in ipairs(allHeaders) do
+            if adopt(ParseNemesisFromScenarioHeaderCurrencies(wi)) then break end
+        end
+    end
+    if not result.nemesisHasData then
+        for _, setID in ipairs(setIDs) do
+            if adopt(ScanDelveWidgetSetForNemesis(setID)) then break end
+        end
     end
 
     -- Remember progress so we can render the completed state after Blizzard drops the affix spell.
@@ -487,9 +608,6 @@ function addon.GetDelveScenarioHeaderMetadata()
         if type(rem) == "number" and rem > 0 then
             -- Live, non-complete data: this is a real run with groups still remaining.
             nemesisCache.runLive = true
-            nemesisCache.lastLiveRemaining = rem
-            nemesisCache.latchedRemaining = rem
-            nemesisCache.latchedTotal = result.nemesisGroupsTotal
             if rem > nemesisCache.seenMax then
                 nemesisCache.seenMax = rem
             end
@@ -498,22 +616,12 @@ function addon.GetDelveScenarioHeaderMetadata()
             nemesisCache.completed = true
         end
     elseif nemesisCache.runLive and nemesisCache.seenMax > 0 then
-        -- No parser adopted this read. Either the affix spell was removed (legit completion)
-        -- or Blizzard is transiently reloading widgets (initial entry, tracker hide/show).
-        -- AcceptCompletion gates the tick on lastLiveRemaining<=1 — the natural final step.
-        -- Otherwise keep rendering the latched live count so the banner doesn't flicker.
-        if AcceptCompletion() then
-            result.nemesisGroupsRemaining = 0
-            result.nemesisGroupsTotal = nemesisCache.seenMax
-            result.nemesisIsComplete = true
-            result.nemesisHasData = true
-            nemesisCache.completed = true
-        elseif type(nemesisCache.latchedRemaining) == "number" and nemesisCache.latchedRemaining > 0 then
-            result.nemesisGroupsRemaining = nemesisCache.latchedRemaining
-            result.nemesisGroupsTotal = nemesisCache.latchedTotal
-            result.nemesisIsComplete = false
-            result.nemesisHasData = true
-        end
+        -- Data vanished mid-scenario but we saw live Nemesis data earlier — treat as complete.
+        result.nemesisGroupsRemaining = 0
+        result.nemesisGroupsTotal = nemesisCache.seenMax
+        result.nemesisIsComplete = true
+        result.nemesisHasData = true
+        nemesisCache.completed = true
     end
 
     if not result.affixes then

--- a/modules/Focus/scenarios/FocusDelves.lua
+++ b/modules/Focus/scenarios/FocusDelves.lua
@@ -2,7 +2,9 @@
     Horizon Suite - Focus - Delve Provider
     ScenarioHeaderDelvesWidget (tierText, currencies, spells), C_PartyInfo.IsDelveInProgress, C_QuestLog.GetQuestTagInfo (QuestTag.Delve).
     Lives remaining: parsed from widget currencies (per-slot textEnabledState or numeric text).
-    Nemesis enemy groups priority: affix spell stackDisplay / description "remaining: N" -> currency runs -> FillUpFrames / DiscreteProgress / IconAndText / TextWithState siblings in the same widget set.
+    Nemesis enemy groups: sole source is the affix spell's `stackDisplay` with a
+        `"remaining: N"` description fallback. The post-completion tick comes from the
+        `nemesisCache` when Blizzard drops the affix spell from the widget.
 ]]
 
 local addon = _G._HorizonSuite_Loading or _G.HorizonSuiteBeta or _G.HorizonSuite
@@ -190,77 +192,6 @@ local function GetDelveLivesIconFileID(widgetInfo)
     return first
 end
 
---- Contiguous runs in `currencies` grouped by iconFileID (nil/missing treated as sentinel -1 per slot).
---- @param cur table
---- @return table runs { startIdx, endIdx, iconFileID }[]
-local function PartitionCurrencyRunsByIcon(cur)
-    local runs = {}
-    if type(cur) ~= "table" or #cur < 1 then return runs end
-    local i = 1
-    local n = #cur
-    while i <= n do
-        local c = cur[i]
-        local iconKey = (type(c) == "table" and type(c.iconFileID) == "number" and c.iconFileID > 0)
-            and c.iconFileID or -1
-        local startIdx = i
-        i = i + 1
-        while i <= n do
-            local c2 = cur[i]
-            local ik = (type(c2) == "table" and type(c2.iconFileID) == "number" and c2.iconFileID > 0)
-                and c2.iconFileID or -1
-            if ik ~= iconKey then break end
-            i = i + 1
-        end
-        local endIdx = i - 1
-        local iconFileID = (iconKey ~= -1) and iconKey or nil
-        runs[#runs + 1] = { startIdx = startIdx, endIdx = endIdx, iconFileID = iconFileID }
-    end
-    return runs
-end
-
---- Parse Nemesis / Nemesis-chest row: per-slot textEnabledState (Disabled = group defeated) or single-slot number / cur/max.
---- @param startIdx number
---- @param endIdx number
---- @param cur table currency array
---- @return table|nil { remaining, total, isComplete, hasData }
-local function ParseCurrencyRunNemesisLike(startIdx, endIdx, cur)
-    if type(cur) ~= "table" or startIdx > endIdx then return nil end
-    local Disabled = Enum and Enum.WidgetEnabledState and Enum.WidgetEnabledState.Disabled
-    local sawState, remaining, total = false, 0, 0
-    for idx = startIdx, endIdx do
-        local c = cur[idx]
-        if type(c) == "table" and c.textEnabledState ~= nil and Disabled ~= nil then
-            sawState = true
-            total = total + 1
-            if c.textEnabledState ~= Disabled then
-                remaining = remaining + 1
-            end
-        end
-    end
-    if sawState and total > 0 then
-        return { remaining = remaining, total = total, isComplete = (remaining == 0), hasData = true }
-    end
-    if startIdx == endIdx then
-        local c = cur[startIdx]
-        if type(c) == "table" then
-            local t = type(c.text) == "string" and c.text or ""
-            local trimmed = t:match("^%s*(.-)%s*$") or ""
-            local num = tonumber(trimmed)
-            if num ~= nil and num >= 0 and num <= NEMESIS_GROUPS_MAX then
-                return { remaining = num, total = nil, isComplete = (num == 0), hasData = true }
-            end
-            local curG, maxG = trimmed:match("^(%d+)/(%d+)$")
-            if curG and maxG then
-                local a, b = tonumber(curG), tonumber(maxG)
-                if a ~= nil and b ~= nil and b >= 1 and b <= NEMESIS_GROUPS_MAX then
-                    return { remaining = a, total = b, isComplete = (a == 0), hasData = true }
-                end
-            end
-        end
-    end
-    return nil
-end
-
 --- Nemesis Strongbox / bonus-chest count is usually rendered as a stack badge on an affix spell icon.
 --- Primary source: widgetInfo.spells[i].stackDisplay (same field zQuestLog uses).
 --- Fallback: parse the spell description for "remaining[^%d]+(%d+)" (Blizzard formats the count into the description).
@@ -283,153 +214,6 @@ local function ParseNemesisFromDelveSpells(widgetInfo)
             end
         end
     end
-    return nil
-end
-
---- Second+ icon run, or a single run that is not the same datum as lives (e.g. Nemesis-only row with one slot or chest icons).
---- @param widgetInfo table
---- @return table|nil
-local function ParseNemesisFromScenarioHeaderCurrencies(widgetInfo)
-    if not widgetInfo or type(widgetInfo.currencies) ~= "table" then return nil end
-    local cur = widgetInfo.currencies
-    if #cur < 1 then return nil end
-    local runs = PartitionCurrencyRunsByIcon(cur)
-    if #runs >= 2 then
-        for ri = 2, #runs do
-            local seg = runs[ri]
-            local parsed = ParseCurrencyRunNemesisLike(seg.startIdx, seg.endIdx, cur)
-            if parsed and parsed.hasData then return parsed end
-        end
-        return nil
-    end
-    -- Single icon run: only trustworthy as Nemesis when there are multiple slots (a row of chest/octagon entries).
-    -- A lone currency is Blizzard's lives aggregate (e.g. text="5", tooltip="Total deaths: N"), never Nemesis.
-    if #runs == 1 then
-        if #cur < 2 then return nil end
-        local seg = runs[1]
-        local parsed = ParseCurrencyRunNemesisLike(seg.startIdx, seg.endIdx, cur)
-        if not parsed or not parsed.hasData then return nil end
-        -- If this single run matches the lives remaining exactly, it's the hearts row, not Nemesis.
-        local livesRem = ParseDelveLivesRemaining(widgetInfo)
-        if livesRem ~= nil and parsed.remaining == livesRem and (parsed.total == nil or parsed.total == #cur) then
-            return nil
-        end
-        return parsed
-    end
-    return nil
-end
-
--- Heuristic: tooltip text suggests Nemesis / bonus chest progress (avoid unrelated IconAndText numbers).
-local function TooltipLooksLikeNemesisGroups(tip, dtip)
-    local lower = ((tip or "") .. " " .. (dtip or "")):lower()
-    if lower:find("nemesis", 1, true) then return true end
-    if lower:find("enemy", 1, true) and lower:find("group", 1, true) then return true end
-    if lower:find("chest", 1, true) and (lower:find("bonus", 1, true) or lower:find("nemesis", 1, true)) then return true end
-    if lower:find("bountiful", 1, true) then return true end
-    if lower:find("pactsworn", 1, true) then return true end
-    if lower:find("wasteland", 1, true) then return true end
-    if lower:find("strongbox", 1, true) then return true end
-    if lower:find("coffer", 1, true) then return true end
-    return false
-end
-
---- Fallback: other widgets in the delve scenario widget set (FillUpFrames, DiscreteProgress, IconAndText).
---- @param setID number
---- @return table|nil
-local function ScanDelveWidgetSetForNemesis(setID)
-    if not setID or not (C_UIWidgetManager and C_UIWidgetManager.GetAllWidgetsBySetID) then return nil end
-    local wOk, widgets = pcall(C_UIWidgetManager.GetAllWidgetsBySetID, setID)
-    if not wOk or type(widgets) ~= "table" then return nil end
-    local bestFill, bestDiscrete, bestIconText
-
-    for _, wInfo in pairs(widgets) do
-        local widgetID = (type(wInfo) == "table" and type(wInfo.widgetID) == "number") and wInfo.widgetID
-            or (type(wInfo) == "number" and wInfo > 0) and wInfo
-        local wType = type(wInfo) == "table" and wInfo.widgetType
-        if widgetID and (not wType or wType ~= WIDGET_TYPE_SCENARIO_HEADER_DELVES) then
-            if C_UIWidgetManager.GetFillUpFramesWidgetVisualizationInfo then
-                local ok, info = pcall(C_UIWidgetManager.GetFillUpFramesWidgetVisualizationInfo, widgetID)
-                if ok and info and type(info) == "table" and type(info.numTotalFrames) == "number"
-                    and info.numTotalFrames >= 1 and info.numTotalFrames <= NEMESIS_GROUPS_MAX then
-                    local full = type(info.numFullFrames) == "number" and info.numFullFrames or 0
-                    local total = info.numTotalFrames
-                    full = math.min(math.max(full, 0), total)
-                    local remaining = total - full
-                    bestFill = {
-                        remaining  = remaining,
-                        total      = total,
-                        isComplete = (remaining <= 0 and total > 0),
-                        hasData    = total > 0,
-                    }
-                end
-            end
-
-            if C_UIWidgetManager.GetDiscreteProgressStepsVisualizationInfo then
-                local ok, info = pcall(C_UIWidgetManager.GetDiscreteProgressStepsVisualizationInfo, widgetID)
-                if ok and info and type(info) == "table" and type(info.progressMax) == "number"
-                    and info.progressMax >= 1 and info.progressMax <= NEMESIS_GROUPS_MAX then
-                    local vmin = type(info.progressMin) == "number" and info.progressMin or 0
-                    local pv = type(info.progressVal) == "number" and info.progressVal or vmin
-                    local total = info.progressMax - vmin
-                    if total >= 1 then
-                        local completed = math.max(0, math.min(pv - vmin, total))
-                        local remaining = math.max(0, total - completed)
-                        local tip = TooltipLooksLikeNemesisGroups(info.tooltip, info.dynamicTooltip)
-                        if tip then
-                            bestDiscrete = {
-                                remaining  = remaining,
-                                total      = total,
-                                isComplete = (remaining <= 0 and total > 0),
-                                hasData    = true,
-                            }
-                        end
-                    end
-                end
-            end
-
-            if C_UIWidgetManager.GetIconAndTextWidgetVisualizationInfo then
-                local ok, info = pcall(C_UIWidgetManager.GetIconAndTextWidgetVisualizationInfo, widgetID)
-                if ok and info and type(info) == "table" and type(info.text) == "string" then
-                    local trimmed = info.text:match("^%s*(.-)%s*$") or ""
-                    local num = tonumber(trimmed)
-                    if num ~= nil and num >= 0 and num <= NEMESIS_GROUPS_MAX then
-                        local tipOk = TooltipLooksLikeNemesisGroups(info.tooltip, info.dynamicTooltip)
-                        if tipOk or num == 0 or (num >= 1 and num <= 15) then
-                            bestIconText = {
-                                remaining  = num,
-                                total      = nil,
-                                isComplete = (num == 0),
-                                hasData    = true,
-                            }
-                        end
-                    end
-                end
-            end
-
-            if not bestIconText and C_UIWidgetManager.GetTextWithStateWidgetVisualizationInfo then
-                local ok, info = pcall(C_UIWidgetManager.GetTextWithStateWidgetVisualizationInfo, widgetID)
-                if ok and info and type(info) == "table" and type(info.text) == "string" then
-                    local trimmed = info.text:match("^%s*(.-)%s*$") or ""
-                    local num = tonumber(trimmed)
-                    if num ~= nil and num >= 0 and num <= NEMESIS_GROUPS_MAX then
-                        local tipOk = TooltipLooksLikeNemesisGroups(info.tooltip, info.dynamicTooltip)
-                        if tipOk or num == 0 or (num >= 1 and num <= 15) then
-                            bestIconText = {
-                                remaining  = num,
-                                total      = nil,
-                                isComplete = (num == 0),
-                                hasData    = true,
-                            }
-                        end
-                    end
-                end
-            end
-        end
-    end
-
-    if bestFill and bestFill.hasData then return bestFill end
-    if bestDiscrete and bestDiscrete.hasData then return bestDiscrete end
-    if bestIconText and bestIconText.hasData then return bestIconText end
     return nil
 end
 
@@ -561,8 +345,7 @@ function addon.GetDelveScenarioHeaderMetadata()
         nemesisCache.key, nemesisCache.seenMax, nemesisCache.completed, nemesisCache.runLive = scenarioKey, 0, false, false
     end
 
-    local setIDs = GetAllDelveScenarioWidgetSetIDs()
-    local allHeaders = CollectVisibleDelveHeaders(setIDs)
+    local allHeaders = CollectVisibleDelveHeaders()
     local widgetInfo = allHeaders[1]
     if widgetInfo then
         result.livesRemaining = ParseDelveLivesRemaining(widgetInfo)
@@ -587,19 +370,15 @@ function addon.GetDelveScenarioHeaderMetadata()
         return true
     end
 
-    -- Priority: affix spell stackDisplay / "remaining: N" (zQuestLog pattern), then currency runs, then sibling widgets.
+    -- Sole source: the affix spell in widgetInfo.spells (stackDisplay or the
+    -- description's "remaining: N" pattern). Earlier builds layered currency-run and
+    -- sibling-widget-scan fallbacks on top, but those were only added to paper over
+    -- what turned out to be a rendering-cache bug (PopulateEntryCached's signature
+    -- didn't cover this entry's dynamic widget data) — with that fixed upstream, the
+    -- primary spells parser catches every valid state without the fallbacks' cost and
+    -- false-positive risk.
     for _, wi in ipairs(allHeaders) do
         if adopt(ParseNemesisFromDelveSpells(wi)) then break end
-    end
-    if not result.nemesisHasData then
-        for _, wi in ipairs(allHeaders) do
-            if adopt(ParseNemesisFromScenarioHeaderCurrencies(wi)) then break end
-        end
-    end
-    if not result.nemesisHasData then
-        for _, setID in ipairs(setIDs) do
-            if adopt(ScanDelveWidgetSetForNemesis(setID)) then break end
-        end
     end
 
     -- Remember progress so we can render the completed state after Blizzard drops the affix spell.


### PR DESCRIPTION
## Summary

Reset `main` functionally to **v4.14.0** (`7fa6395`) and apply the clean Nemesis-banner fix from `fix/delve-populate-cache-bypass`.

The two direct-to-main commits (`71ddbc9`, `60947ed`) were experimental fixes for the \"Nemesis banner blank / spurious tick on initial delve entry\" bug that never addressed the actual cause (see `443b7b3` for the diagnosis). They layered events, timers, polling, and cache gymnastics on top of a rendering-cache short-circuit that was silently discarding the correct data. Both commits are fully reverted here; net diff vs v4.14.0 is only the real fix + the follow-up cleanup.

Squash-merge recommended so `main`'s history shows a single \"restore baseline + apply populate-cache fix\" commit.

## Commits on this branch (pre-squash)

1. `b1188db` **Revert** \"fix(Focus): delve Nemesis banner — blank on first-session delve entry\"
2. `8521caf` **Revert** \"fix(Focus): delve Nemesis banner — spurious tick on entry / reload\"
3. `443b7b3` **fix(Focus): bypass populate-entry cache for delve scenario-main entries** — the actual fix. `PopulateEntryCached` was short-circuiting every re-render for the delve scenario-main entry because `BuildEntrySignature` didn't (and couldn't) fingerprint the Nemesis count / affix names resolved inside `PopulateEntry` via widget reads. Bypass the cache for \`category == \"DELVES\"\` and \`isScenarioMain\` entries; clear the cached signature on the bypass path so pooled entries don't false-hit later.
4. `19b0305` **refactor(Focus): drop delve Nemesis fallback parsers; shorten entry delay** — with the cache issue fixed, `ParseNemesisFromDelveSpells` is authoritative. Delete `ParseNemesisFromScenarioHeaderCurrencies`, `ScanDelveWidgetSetForNemesis`, `TooltipLooksLikeNemesisGroups`, `ParseCurrencyRunNemesisLike`, `PartitionCurrencyRunsByIcon`. Also add `0.5s` / `1.0s` retries to `OnInstanceEntered` to shave first-paint from ~1s to ~0.5s. Net −180 lines in `FocusDelves.lua`.

## Net diff vs v4.14.0

\`\`\`
modules/Focus/FocusEntryRenderer.lua    |  31 ++++
modules/Focus/FocusEvents.lua           |  21 ++-
modules/Focus/scenarios/FocusDelves.lua | 243 ++------------------------------
3 files changed, 56 insertions(+), 239 deletions(-)
\`\`\`

## Test plan

- [ ] Enter a Bountiful Delve fresh after relog — Nemesis \`(N)\` badge renders within ~0.5s, no manual tracker collapse/expand required.
- [ ] Enter a delve mid-session — badge renders immediately.
- [ ] `/reload` inside an active delve — badge re-renders immediately, no spurious tick.
- [ ] Kill the last Nemesis group — badge transitions to the green tick as Blizzard drops the affix spell.
- [ ] Leave delve, re-enter — cache resets, badge starts fresh.
- [ ] Enter a non-Bountiful delve — no Nemesis badge, no regressions to lives hearts or affix row.
- [ ] Safety tag `main-backup-pre-rollback` points at the pre-revert tip (`60947ed`) in case anything needs recovery.

## Notes

- Existing PR `fix/delve-affix-nemesis-strongbox` should be closed without merging (superseded by this PR plus the earlier experimental direction being abandoned).
- Existing branch `fix/delve-populate-cache-bypass` can be deleted after this merges — its two commits are preserved here as `443b7b3` and `19b0305`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)