### PR TITLE
fix(focus): split daily recurring quests out of weekly category

### DIFF
--- a/Utilities.lua
+++ b/Utilities.lua
@@ -1190,6 +1190,13 @@ function addon.GetQuestBaseCategory(questID)
         if qc == Enum.QuestClassification.Campaign then return "CAMPAIGN" end
         if qc == Enum.QuestClassification.Recurring then
             if IsPreyQuest(questID) then return "PREY" end
+            -- Recurring covers both daily and weekly quests; disambiguate via frequency.
+            local freq = addon.GetQuestFrequency(questID)
+            if freq == (Enum.QuestFrequency and Enum.QuestFrequency.Daily)
+                or freq == 1
+                or (LE_QUEST_FREQUENCY_DAILY and freq == LE_QUEST_FREQUENCY_DAILY) then
+                return "DAILY"
+            end
             return "WEEKLY"
         end
         if qc == Enum.QuestClassification.Meta then


### PR DESCRIPTION
Closes #116

## Summary
`addon.GetQuestBaseCategory` in `Utilities.lua` mapped
`Enum.QuestClassification.Recurring` unconditionally to `WEEKLY`, so daily
recurring quests (e.g. quest 87475 *Sureki Incursion: Hold the Wall*) never
reached the frequency branch and were grouped under **Weekly** instead of
**Daily** in the Focus tracker.

## Implementation notes
Recurring classification now consults `addon.GetQuestFrequency(questID)` first:
Daily frequency → `DAILY`, otherwise → `WEEKLY`. The existing `IsPreyQuest`
check runs before the frequency check so Prey quests still land in `PREY`.
Meta classification is left as-is (meta recurring quests are weekly wrappers).
The standalone frequency fallback block lower in the function is unchanged.

All downstream DAILY wiring was already in place (`core/Config.lua` colours,
`addon.GROUP_ORDER`, section header `UI_DAILY_QUESTS`, icon atlas in
`FocusCategories.lua`, aggregator auto-surface, layout promotion tracking,
renderer styling) — this is a single-function classification fix.

## Test plan
1. **Primary repro** — accept quest 87475 *Sureki Incursion: Hold the Wall*; confirm it appears under the **Daily** section of Focus, not Weekly.
2. **Weekly regression** — accept a known weekly recurring quest (any Khaz Algar weekly); confirm it still appears under **Weekly**.
3. **Prey regression** — accept a Prey quest; confirm it still lands under **Prey**.
4. **Styling** — Daily entry icon is `quest-recurring-available` (cyan); category colour matches DAILY palette `{0.25, 0.88, 0.92}`.
5. **Complete toggle** — complete a daily; with "Show Complete group" ON it moves to **Complete**, with it OFF it stays under **Daily**.
6. **Layout/promotion** — open `/hs` options, toggle categories on/off; no Lua errors with `/console scriptErrors 1`.
7. **Presence** — accept/complete the daily with Presence enabled; the pop-in uses the DAILY colour (Presence reads `GetQuestBaseCategory` directly at `PresenceCore.lua:434`).