### PR TITLE
Fix: Category shows blank space after rapid collapse then expand during animation

### DIFF
--- a/modules/Focus/FocusCollapse.lua
+++ b/modules/Focus/FocusCollapse.lua
@@ -228,6 +228,22 @@ local function StartGroupCollapse(groupKey)
     end
 end
 
+--- Cancels an in-progress group collapse animation. Removes the group from the collapse tracker
+--- and immediately clears any pool entries still animating out, so FullLayout() can run.
+--- @param groupKey string Category key (e.g. "NEARBY", "WEEKLY")
+local function CancelGroupCollapse(groupKey)
+    if not groupKey then return end
+    if addon.focus.collapse.groups then
+        addon.focus.collapse.groups[groupKey] = nil
+    end
+    for i = 1, addon.POOL_SIZE do
+        local e = pool[i]
+        if e.groupKey == groupKey and e.animState == "collapsing" then
+            addon.ClearEntry(e)
+        end
+    end
+end
+
 --- Same as StartGroupCollapse but visual-only: no FullLayout or SetCategoryCollapsed.
 --- @param groupKey string Category key
 local function StartGroupCollapseVisual(groupKey)
@@ -385,6 +401,7 @@ end
 
 addon.ToggleCollapse             = ToggleCollapse
 addon.StartGroupCollapse         = StartGroupCollapse
+addon.CancelGroupCollapse        = CancelGroupCollapse
 addon.StartGroupCollapseVisual   = StartGroupCollapseVisual
 addon.TriggerNearbyEntriesFadeIn = TriggerNearbyEntriesFadeIn
 addon.StartNearbyTurnOnTransition = StartNearbyTurnOnTransition

--- a/modules/Focus/FocusSectionHeaders.lua
+++ b/modules/Focus/FocusSectionHeaders.lua
@@ -184,6 +184,8 @@ local function AcquireSectionHeader(groupKey, focusedGroupKey)
                 addon.focus.collapse.headerSlideTime = 0
                 if addon.EnsureFocusUpdateRunning then addon.EnsureFocusUpdateRunning() end
             end
+            -- Cancel any in-progress collapse animation so the FullLayout guard is not triggered.
+            if addon.CancelGroupCollapse then addon.CancelGroupCollapse(key) end
             addon.FullLayout()
             if addon.ApplyGroupExpandSlideDown then addon.ApplyGroupExpandSlideDown() end
         else


### PR DESCRIPTION
Closes #142

## Summary
When collapsing a category and clicking expand before the collapse animation completes, FullLayout() was being silently skipped — causing the panel height to expand but no quest entries to render, leaving a blank space.

## Root cause
FocusLayout.lua has an early-return guard that skips layout while any group collapse animation is in progress. StartGroupCollapse registers the group key in collapse.groups before the animation starts. The expand OnClick path in FocusSectionHeaders.lua called FullLayout() without first removing that key, so the guard fired and layout was skipped.

## Fix
Added CancelGroupCollapse(groupKey) to FocusCollapse.lua. It removes the group from collapse.groups and clears any pool entries still in "collapsing" state for that group. The call is placed in FocusSectionHeaders.lua immediately before FullLayout() in the category expand path.

## Test plan
- Open the Focus panel with at least one category containing visible quests
- Click the collapse toggle on a category to start the collapse animation
- Before the animation completes, click the toggle again to expand
- Expected: quests render immediately with no blank space
- Also verify a normal uninterrupted collapse still works correctly
