### PR TITLE
fix(focus): quest-accept/abandon animations under grow-up

### DIFF
--- a/modules/Focus/FocusLayout.lua
+++ b/modules/Focus/FocusLayout.lua
@@ -815,6 +815,10 @@ local function FullLayout()
     local preInsertYSec = shouldAnimateQuestInsert and {} or nil
     if preInsertY then
         for k, e in pairs(activeMap) do
+            -- Only snapshot "active" entries. A "fadein" entry mid-animation already reads
+            -- finalY dynamically each tick, so displacing its finalY causes at most a
+            -- one-frame Y snap. Applying SetEntrySlideUp to a "fadein" entry would also
+            -- conflict with its horizontal slide (slideup uses finalX with no X offset).
             if e and e.animState == "active" and e.finalY ~= nil then
                 preInsertY[k] = e.finalY
             end

--- a/modules/Focus/FocusLayout.lua
+++ b/modules/Focus/FocusLayout.lua
@@ -903,7 +903,7 @@ local function FullLayout()
             addon.focus.promotion.prevDaily  = curPriority.DAILY  or {}
             for key in pairs(promotedKeys) do
                 local entry = activeMap[key]
-                if entry and (entry.animState == "active" or entry.animState == "fadein") and entry.finalX and entry.finalY then
+                if entry and entry.animState == "active" and entry.finalX and entry.finalY then
                     addon.SetEntryFadeOut(entry)
                     entry.promotionFadeOut = true
                     promotionFadeOutCount = promotionFadeOutCount + 1
@@ -1187,7 +1187,11 @@ local function FullLayout()
                         -- engine starts from the correct position on every layout call.
                         -- _lastEntryX/_lastEntryY are not cached so the final anchor is
                         -- re-evaluated once the entry transitions to "active".
+                        -- Re-assert alpha=0 so the entry stays invisible between FullLayout calls
+                        -- that fire while the animation is still in progress; the animation engine
+                        -- restores the correct alpha on the very next OnUpdate tick.
                         local slideInX = (addon.FOCUS_ANIM and addon.FOCUS_ANIM.slideInX) or 20
+                        entry:SetAlpha(0)
                         entry:ClearAllPoints()
                         entry:SetPoint("TOPLEFT", scrollChild, "TOPLEFT", entryX + slideInX, yOff)
                     elseif entry._lastEntryX ~= entryX or entry._lastEntryY ~= yOff then

--- a/modules/Focus/FocusLayout.lua
+++ b/modules/Focus/FocusLayout.lua
@@ -1182,14 +1182,14 @@ local function FullLayout()
                     end
                     -- Skip anchor churn when the entry's position hasn't changed since
                     -- the previous FullLayout. Cleared in FocusEntryPool reset on pool-release.
-                    if newlyAcquiredKeys[key] and entry.animState == "fadein" then
-                        -- New entry: start at the slide-in offset so the animation engine
-                        -- never has to jump position on its first tick.
+                    if entry.animState == "fadein" then
+                        -- Fadein entry: always anchor at the slide-in offset so the animation
+                        -- engine starts from the correct position on every layout call.
+                        -- _lastEntryX/_lastEntryY are not cached so the final anchor is
+                        -- re-evaluated once the entry transitions to "active".
                         local slideInX = (addon.FOCUS_ANIM and addon.FOCUS_ANIM.slideInX) or 20
                         entry:ClearAllPoints()
                         entry:SetPoint("TOPLEFT", scrollChild, "TOPLEFT", entryX + slideInX, yOff)
-                        -- Do not cache entryX/_lastEntryY here; force re-evaluation on the
-                        -- next FullLayout so the final anchor is restored correctly.
                     elseif entry._lastEntryX ~= entryX or entry._lastEntryY ~= yOff then
                         entry:ClearAllPoints()
                         entry:SetPoint("TOPLEFT", scrollChild, "TOPLEFT", entryX, yOff)
@@ -1300,6 +1300,12 @@ local function FullLayout()
                     local prevY = preInsertY[ekey]
                     if prevY and prevY ~= e.finalY then
                         addon.SetEntrySlideUp(e, prevY)
+                        -- Reset visual to animation start; the placement loop already set the
+                        -- anchor to finalY, so without this the anim engine would jump back.
+                        if e.finalX ~= nil then
+                            e:ClearAllPoints()
+                            e:SetPoint("TOPLEFT", scrollChild, "TOPLEFT", e.finalX, prevY)
+                        end
                     end
                 end
             end
@@ -1312,6 +1318,11 @@ local function FullLayout()
                     if prevY and prevY ~= s.finalY then
                         s.slideUpStartY  = prevY
                         s.slideUpAnimTime = 0
+                        -- Reset visual to animation start position.
+                        if s.finalX ~= nil then
+                            s:ClearAllPoints()
+                            s:SetPoint("TOPLEFT", scrollChild, "TOPLEFT", s.finalX, prevY)
+                        end
                     end
                 end
             end

--- a/modules/Focus/FocusLayout.lua
+++ b/modules/Focus/FocusLayout.lua
@@ -725,6 +725,7 @@ local function FullLayout()
         end
     end
     local toRemove = {}
+    local questRemoved = false
     for key, entry in pairs(activeMap) do
         if not currentIDs[key] then
             if onlyInstanceGroupShown and addon.ClearEntry then
@@ -733,6 +734,9 @@ local function FullLayout()
                 toRemove[#toRemove + 1] = { key = key, entry = entry }
             elseif entry.animState ~= "completing" and entry.animState ~= "fadeout" then
                 addon.SetEntryFadeOut(entry)
+                -- Trigger slide-up animation for remaining entries so they close the gap
+                -- smoothly (mirrors slide-down on quest-accept).
+                questRemoved = true
             end
             activeMap[key] = nil
         end
@@ -1294,8 +1298,12 @@ local function FullLayout()
     if useWQExpand and addon.ApplyGroupExpandSlideDown then
         addon.ApplyGroupExpandSlideDown()
     end
-    -- Slide existing entries that shifted downward to accommodate a newly-accepted quest.
-    if newEntryInserted and shouldAnimateQuestInsert then
+    -- Slide existing entries whose Y changed since the last layout:
+    --   * newEntryInserted → entries shift DOWN to make room for a new quest (slide-down).
+    --   * questRemoved     → entries shift UP to close the gap left by an abandoned/removed
+    --                        quest (slide-up, mirrors the slide-down choreography).
+    -- The slide animation interpolates slideUpStartY → finalY and handles both directions.
+    if (newEntryInserted or questRemoved) and shouldAnimateQuestInsert then
         if preInsertY and next(preInsertY) then
             for i = 1, addon.POOL_SIZE do
                 local e = pool[i]

--- a/modules/Focus/FocusLayout.lua
+++ b/modules/Focus/FocusLayout.lua
@@ -817,6 +817,11 @@ local function FullLayout()
         and not useWQCollapse and not useWQExpand and not isCategoryChangeReflow
     local preInsertY    = shouldAnimateQuestInsert and {} or nil
     local preInsertYSec = shouldAnimateQuestInsert and {} or nil
+    -- Capture the current scrollOffset alongside the Y snapshot. In grow-up mode the
+    -- scrollOffset shifts to pin the Objectives header on content-height changes; that
+    -- shift visually cancels the scrollChild-local Y delta, so the slide animation must
+    -- subtract the scroll delta from its start Y to avoid an on-screen jump.
+    local preInsertScrollOffset = shouldAnimateQuestInsert and (addon.focus.layout.scrollOffset or 0) or 0
     if preInsertY then
         for k, e in pairs(activeMap) do
             -- Only snapshot "active" entries. A "fadein" entry mid-animation already reads
@@ -1298,49 +1303,6 @@ local function FullLayout()
     if useWQExpand and addon.ApplyGroupExpandSlideDown then
         addon.ApplyGroupExpandSlideDown()
     end
-    -- Slide existing entries whose Y changed since the last layout:
-    --   * newEntryInserted → entries shift DOWN to make room for a new quest (slide-down).
-    --   * questRemoved     → entries shift UP to close the gap left by an abandoned/removed
-    --                        quest (slide-up, mirrors the slide-down choreography).
-    -- The slide animation interpolates slideUpStartY → finalY and handles both directions.
-    if (newEntryInserted or questRemoved) and shouldAnimateQuestInsert then
-        if preInsertY and next(preInsertY) then
-            for i = 1, addon.POOL_SIZE do
-                local e = pool[i]
-                if e and (e.questID or e.entryKey) and e.animState == "active" and e.finalY ~= nil then
-                    local ekey = e.questID or e.entryKey
-                    local prevY = preInsertY[ekey]
-                    if prevY and prevY ~= e.finalY then
-                        addon.SetEntrySlideUp(e, prevY)
-                        -- Reset visual to animation start; the placement loop already set the
-                        -- anchor to finalY, so without this the anim engine would jump back.
-                        if e.finalX ~= nil then
-                            e:ClearAllPoints()
-                            e:SetPoint("TOPLEFT", scrollChild, "TOPLEFT", e.finalX, prevY)
-                        end
-                    end
-                end
-            end
-        end
-        if preInsertYSec and next(preInsertYSec) then
-            for i = 1, addon.SECTION_POOL_SIZE do
-                local s = sectionPool[i]
-                if s and s.active and s.groupKey and s.finalY ~= nil then
-                    local prevY = preInsertYSec[s.groupKey]
-                    if prevY and prevY ~= s.finalY then
-                        s.slideUpStartY  = prevY
-                        s.slideUpAnimTime = 0
-                        -- Reset visual to animation start position.
-                        if s.finalX ~= nil then
-                            s:ClearAllPoints()
-                            s:SetPoint("TOPLEFT", scrollChild, "TOPLEFT", s.finalX, prevY)
-                        end
-                    end
-                end
-            end
-        end
-    end
-
     if isCategoryChangeReflow and addon.GetDB("animations", true) then
         addon.focus.categoryChange.slideUpRemaining = slideUpCount
         addon.focus.categoryChange.onSlideUpComplete = function()
@@ -1394,6 +1356,62 @@ local function FullLayout()
     addon.focus.layout.scrollBottomOffset = math.max(0, maxScr - addon.focus.layout.scrollOffset)
     addon.ApplyScrollOffset(addon.focus.layout.scrollOffset)
     if addon.UpdateScrollIndicators then addon.UpdateScrollIndicators() end
+
+    -- Slide existing entries whose Y changed since the last layout:
+    --   * newEntryInserted → entries shift DOWN to make room for a new quest (slide-down).
+    --   * questRemoved     → entries shift UP to close the gap left by an abandoned/removed
+    --                        quest (slide-up, mirrors the slide-down choreography).
+    -- The slide animation interpolates slideUpStartY → finalY and handles both directions.
+    --
+    -- Run this AFTER scrollOffset is applied so we can adjust the start Y by the scroll
+    -- delta: in grow-up mode, scrollOffset shifts to pin the bottom, which in screen space
+    -- already cancels the scrollChild-local Y change. Subtracting the delta from prevY
+    -- keeps the animation start at the correct on-screen position (a no-op in grow-up with
+    -- bottom-pinned content, a normal slide in grow-down or when scroll cannot compensate).
+    if (newEntryInserted or questRemoved) and shouldAnimateQuestInsert then
+        local scrollDelta = (addon.focus.layout.scrollOffset or 0) - preInsertScrollOffset
+        if preInsertY and next(preInsertY) then
+            for i = 1, addon.POOL_SIZE do
+                local e = pool[i]
+                if e and (e.questID or e.entryKey) and e.animState == "active" and e.finalY ~= nil then
+                    local ekey = e.questID or e.entryKey
+                    local prevY = preInsertY[ekey]
+                    if prevY then
+                        local startY = prevY - scrollDelta
+                        if startY ~= e.finalY then
+                            addon.SetEntrySlideUp(e, startY)
+                            -- Reset visual to animation start; the placement loop already set the
+                            -- anchor to finalY, so without this the anim engine would jump back.
+                            if e.finalX ~= nil then
+                                e:ClearAllPoints()
+                                e:SetPoint("TOPLEFT", scrollChild, "TOPLEFT", e.finalX, startY)
+                            end
+                        end
+                    end
+                end
+            end
+        end
+        if preInsertYSec and next(preInsertYSec) then
+            for i = 1, addon.SECTION_POOL_SIZE do
+                local s = sectionPool[i]
+                if s and s.active and s.groupKey and s.finalY ~= nil then
+                    local prevY = preInsertYSec[s.groupKey]
+                    if prevY then
+                        local startY = prevY - scrollDelta
+                        if startY ~= s.finalY then
+                            s.slideUpStartY  = startY
+                            s.slideUpAnimTime = 0
+                            -- Reset visual to animation start position.
+                            if s.finalX ~= nil then
+                                s:ClearAllPoints()
+                                s:SetPoint("TOPLEFT", scrollChild, "TOPLEFT", s.finalX, startY)
+                            end
+                        end
+                    end
+                end
+            end
+        end
+    end
 
     local headerArea
     if addon.GetDB("hideObjectivesHeader", false) then

--- a/modules/Focus/FocusLayout.lua
+++ b/modules/Focus/FocusLayout.lua
@@ -806,6 +806,28 @@ local function FullLayout()
     -- groups are collapsed so we can skip acquiring entries for them entirely.
     local pcegForAcquire = collapsedFallThrough and addon.focus.collapsed
         and addon.focus.collapse and addon.focus.collapse.panelCollapsedExpandedGroups
+    -- Snapshot Y positions of currently-active entries so we can animate existing entries
+    -- downward when a new quest is inserted above them. Guard: skip when another animation
+    -- path (WQ collapse, WQ expand, category-change reflow) already owns the choreography.
+    local shouldAnimateQuestInsert = addon.GetDB("animations", true)
+        and not useWQCollapse and not useWQExpand and not isCategoryChangeReflow
+    local preInsertY    = shouldAnimateQuestInsert and {} or nil
+    local preInsertYSec = shouldAnimateQuestInsert and {} or nil
+    if preInsertY then
+        for k, e in pairs(activeMap) do
+            if e and e.animState == "active" and e.finalY ~= nil then
+                preInsertY[k] = e.finalY
+            end
+        end
+        for i = 1, addon.SECTION_POOL_SIZE do
+            local s = sectionPool[i]
+            if s and s.active and s.groupKey and s.finalY ~= nil then
+                preInsertYSec[s.groupKey] = s.finalY
+            end
+        end
+    end
+    local newlyAcquiredKeys = {}
+    local newEntryInserted  = false
     for _, grp in ipairs(grouped) do
         -- Skip entry acquisition for groups that are collapsed during panel-collapsed fall-through.
         if pcegForAcquire and not pcegForAcquire[grp.key] then
@@ -819,6 +841,8 @@ local function FullLayout()
                     if entry then
                         SafeEntryFadeIn(entry, 0)
                         activeMap[key] = entry
+                        newlyAcquiredKeys[key] = true
+                        newEntryInserted = true
                     end
                 elseif entry.animState == "idle" and not entry.questID and not entry.entryKey then
                     -- Zombie entry left over from a group collapse: reset it for fadein.
@@ -1154,7 +1178,15 @@ local function FullLayout()
                     end
                     -- Skip anchor churn when the entry's position hasn't changed since
                     -- the previous FullLayout. Cleared in FocusEntryPool reset on pool-release.
-                    if entry._lastEntryX ~= entryX or entry._lastEntryY ~= yOff then
+                    if newlyAcquiredKeys[key] and entry.animState == "fadein" then
+                        -- New entry: start at the slide-in offset so the animation engine
+                        -- never has to jump position on its first tick.
+                        local slideInX = (addon.FOCUS_ANIM and addon.FOCUS_ANIM.slideInX) or 20
+                        entry:ClearAllPoints()
+                        entry:SetPoint("TOPLEFT", scrollChild, "TOPLEFT", entryX + slideInX, yOff)
+                        -- Do not cache entryX/_lastEntryY here; force re-evaluation on the
+                        -- next FullLayout so the final anchor is restored correctly.
+                    elseif entry._lastEntryX ~= entryX or entry._lastEntryY ~= yOff then
                         entry:ClearAllPoints()
                         entry:SetPoint("TOPLEFT", scrollChild, "TOPLEFT", entryX, yOff)
                         entry._lastEntryX = entryX
@@ -1253,6 +1285,33 @@ local function FullLayout()
     end
     if useWQExpand and addon.ApplyGroupExpandSlideDown then
         addon.ApplyGroupExpandSlideDown()
+    end
+    -- Slide existing entries that shifted downward to accommodate a newly-accepted quest.
+    if newEntryInserted and shouldAnimateQuestInsert then
+        if preInsertY and next(preInsertY) then
+            for i = 1, addon.POOL_SIZE do
+                local e = pool[i]
+                if e and (e.questID or e.entryKey) and e.animState == "active" and e.finalY ~= nil then
+                    local ekey = e.questID or e.entryKey
+                    local prevY = preInsertY[ekey]
+                    if prevY and prevY ~= e.finalY then
+                        addon.SetEntrySlideUp(e, prevY)
+                    end
+                end
+            end
+        end
+        if preInsertYSec and next(preInsertYSec) then
+            for i = 1, addon.SECTION_POOL_SIZE do
+                local s = sectionPool[i]
+                if s and s.active and s.groupKey and s.finalY ~= nil then
+                    local prevY = preInsertYSec[s.groupKey]
+                    if prevY and prevY ~= s.finalY then
+                        s.slideUpStartY  = prevY
+                        s.slideUpAnimTime = 0
+                    end
+                end
+            end
+        end
     end
 
     if isCategoryChangeReflow and addon.GetDB("animations", true) then

--- a/modules/Focus/FocusLayout.lua
+++ b/modules/Focus/FocusLayout.lua
@@ -821,7 +821,9 @@ local function FullLayout()
     -- scrollOffset shifts to pin the Objectives header on content-height changes; that
     -- shift visually cancels the scrollChild-local Y delta, so the slide animation must
     -- subtract the scroll delta from its start Y to avoid an on-screen jump.
-    local preInsertScrollOffset = shouldAnimateQuestInsert and (addon.focus.layout.scrollOffset or 0) or 0
+    -- Capture unconditionally: the slide animation uses it (when shouldAnimateQuestInsert
+    -- is true), and the fadeout entries need it too for grow-up screen-position preservation.
+    local preInsertScrollOffset = addon.focus.layout.scrollOffset or 0
     if preInsertY then
         for k, e in pairs(activeMap) do
             -- Only snapshot "active" entries. A "fadein" entry mid-animation already reads
@@ -1356,6 +1358,22 @@ local function FullLayout()
     addon.focus.layout.scrollBottomOffset = math.max(0, maxScr - addon.focus.layout.scrollOffset)
     addon.ApplyScrollOffset(addon.focus.layout.scrollOffset)
     if addon.UpdateScrollIndicators then addon.UpdateScrollIndicators() end
+
+    -- Fading-out entries are anchored to scrollChild at their last finalY but are no
+    -- longer in activeMap, so the placement loop doesn't reposition them. When
+    -- scrollOffset shifts (grow-up content shrink/grow, or a grow-down scroll clamp),
+    -- the fadeout entry rides along with scrollChild and visually slides onto its
+    -- neighbour. Offsetting finalY by the inverse of the scroll delta pins the
+    -- fadeout to its original on-screen position.
+    local fadeoutScrollDelta = (addon.focus.layout.scrollOffset or 0) - preInsertScrollOffset
+    if fadeoutScrollDelta ~= 0 then
+        for i = 1, addon.POOL_SIZE do
+            local e = pool[i]
+            if e and e.animState == "fadeout" and e.finalY ~= nil then
+                e.finalY = e.finalY - fadeoutScrollDelta
+            end
+        end
+    end
 
     -- Slide existing entries whose Y changed since the last layout:
     --   * newEntryInserted → entries shift DOWN to make room for a new quest (slide-down).


### PR DESCRIPTION
## Summary

Fixes issue #144 and related grow-up animation glitches in the Focus quest list.

- Quest-accept slide-down animation: existing entries no longer flash or jump when a new quest is added above them. Fixes fadein X-flash and slide-down jump edge cases.
- Quest-removal slide-up animation: remaining entries close the gap smoothly mirroring the slide-down choreography.
- Prevent new-entry flash when the target category already has quests.
- **Grow-up mode**: slide animation now accounts for the scrollOffset delta that pins the Objectives header to the bottom. In grow-up with bottom-pinned content this correctly skips the slide (existing entries are already visually stationary). In grow-down the delta is zero so behaviour is unchanged.
- **Grow-up mode**: fading-out entries no longer drift down onto their neighbour when a quest is abandoned. The fadeout entry's `finalY` is offset by the inverse of the scroll delta so its on-screen position is preserved for the fadeout duration.

## Test plan

- [ ] Accept a quest in grow-down mode — existing entries slide down cleanly, new quest slides in from the right.
- [ ] Accept a quest in grow-up mode (scrolled to bottom) — existing entries stay put, new quest appears at the top.
- [ ] Accept a quest in grow-up mode with content smaller than the frame — entries still shift visually as expected.
- [ ] Abandon a quest in grow-down mode — remaining entries slide up to close the gap.
- [ ] Abandon a quest in grow-up mode — fadeout plays in place, remaining entries stay visually static.
- [ ] Turn in / complete a quest in both modes — no regression in completion choreography.
- [ ] Category-change reflow, WQ collapse/expand still animate correctly (mutually exclusive paths, should be unaffected).