### PR TITLE
fix(focus): per-element font toggle revert to global

### DIFF
--- a/modules/Focus/FocusEntryPool.lua
+++ b/modules/Focus/FocusEntryPool.lua
@@ -647,17 +647,26 @@ local function UpdateFontObjectsFromDB()
     local sectionSz  = math.max(8, (tonumber(addon.GetDB("sectionFontSize", 10)) or 10) + fontOffset)
 
     local GLOBAL_SENTINEL = "__global__"
+    local usePer = addon.GetDB("usePerElementFonts", false)
     local titleFontRaw   = addon.GetDB("titleFontPath", GLOBAL_SENTINEL)
     local zoneFontRaw    = addon.GetDB("zoneFontPath", GLOBAL_SENTINEL)
     local objFontRaw     = addon.GetDB("objectiveFontPath", GLOBAL_SENTINEL)
     local sectionFontRaw = addon.GetDB("sectionFontPath", GLOBAL_SENTINEL)
     local progBarFontRaw = addon.GetDB("progressBarFontPath", GLOBAL_SENTINEL)
 
-    local titleFont   = (titleFontRaw and titleFontRaw ~= GLOBAL_SENTINEL) and (addon.ResolveFontPath and addon.ResolveFontPath(titleFontRaw) or titleFontRaw) or fontPath
-    local zoneFont    = (zoneFontRaw and zoneFontRaw ~= GLOBAL_SENTINEL) and (addon.ResolveFontPath and addon.ResolveFontPath(zoneFontRaw) or zoneFontRaw) or fontPath
-    local objFont     = (objFontRaw and objFontRaw ~= GLOBAL_SENTINEL) and (addon.ResolveFontPath and addon.ResolveFontPath(objFontRaw) or objFontRaw) or fontPath
-    local sectionFont = (sectionFontRaw and sectionFontRaw ~= GLOBAL_SENTINEL) and (addon.ResolveFontPath and addon.ResolveFontPath(sectionFontRaw) or sectionFontRaw) or fontPath
-    local progBarFont = (progBarFontRaw and progBarFontRaw ~= GLOBAL_SENTINEL) and (addon.ResolveFontPath and addon.ResolveFontPath(progBarFontRaw) or progBarFontRaw) or fontPath
+    local function ResolvePer(raw)
+        if not usePer then return fontPath end
+        if raw and raw ~= GLOBAL_SENTINEL then
+            return addon.ResolveFontPath and addon.ResolveFontPath(raw) or raw
+        end
+        return fontPath
+    end
+
+    local titleFont   = ResolvePer(titleFontRaw)
+    local zoneFont    = ResolvePer(zoneFontRaw)
+    local objFont     = ResolvePer(objFontRaw)
+    local sectionFont = ResolvePer(sectionFontRaw)
+    local progBarFont = ResolvePer(progBarFontRaw)
     local progBarSz   = math.max(7, (tonumber(addon.GetDB("progressBarFontSize", 10)) or 10) + fontOffset)
 
     addon.FONT_PATH = fontPath

--- a/options/OptionsData.lua
+++ b/options/OptionsData.lua
@@ -20,6 +20,7 @@ end
 
 local TYPOGRAPHY_KEYS = {
     fontPath = true,
+    usePerElementFonts = true,
     titleFontPath = true,
     presenceTitleFontPath = true,
     presenceSubtitleFontPath = true,


### PR DESCRIPTION
Closes #145

## Summary
When the Focus "Use per-element fonts" toggle is disabled, elements keep using the previously-picked per-element font instead of reverting to the global font. This PR gates per-element resolution on the toggle and wires the toggle into the typography refresh path.

## Implementation notes
- `modules/Focus/FocusEntryPool.lua` — `UpdateFontObjectsFromDB()` now checks `usePerElementFonts`. When off, all five Focus elements fall back to the global `fontPath`. Stored per-element picks are preserved in the DB so re-enabling the toggle restores them.
- `options/OptionsData.lua` — `usePerElementFonts` added to `TYPOGRAPHY_KEYS` so toggling it immediately triggers `UpdateFontObjectsFromDB()` (no `/reload` needed).
- Scope: Focus only. Presence/Insight per-element fonts have no master toggle and are unchanged.

## Test plan
- [ ] `/reload` with the fix applied.
- [ ] Options → Focus → Typography: enable **Use per-element fonts**, pick a distinctive font for each of the five pickers (quest title, zone, objective, section header, progress bar). Verify each element updates live.
- [ ] Disable **Use per-element fonts**. Expected: all five revert to the global font immediately, no `/reload`.
- [ ] Re-enable the toggle. Expected: previously-picked per-element fonts come back as stored.
- [ ] `/reload` with toggle off; confirm global font persists on next login.
- [ ] Regression: Presence title/subtitle fonts and Insight tooltip font still respond to their pickers.