### PR TITLE
chore(toc): bump interface to 120005 for 12.0.5

### DIFF
--- a/HorizonSuite.toc
+++ b/HorizonSuite.toc
@@ -1,4 +1,4 @@
-## Interface: 120001
+## Interface: 120005
 ## Title: Horizon Suite
 ## Notes: Core addon with pluggable modules.
 ## Author: Crystilac

--- a/HorizonSuiteBeta.toc
+++ b/HorizonSuiteBeta.toc
@@ -1,4 +1,4 @@
-## Interface: 120001
+## Interface: 120005
 ## Title: Horizon Suite (Beta)
 ## Notes: Core addon with pluggable modules. Focus (objective tracker) is the first module.
 ## Author: Crystilac


### PR DESCRIPTION
## Summary

Aligns both TOCs with WoW 12.0.5 so the addon is no longer flagged out-of-date for users on the latest client.

## Changes

- `HorizonSuite.toc` — `## Interface: 120001` → `120005`
- `HorizonSuiteBeta.toc` — `## Interface: 120001` → `120005`

## Test plan

- Confirmed both TOCs are the only Horizon-owned files referencing `120001` (vendored `LibSharedMedia-3.0.toc` already lists `120001` alongside other clients and is left untouched).
- Diff is two single-line metadata changes; no Lua, no API surface, no behavioural delta.

---

## Reviewer checklist

- [ ] Load the live client (12.0.5) with the addon installed and confirm Horizon Suite no longer shows as out-of-date in the AddOns list.
- [ ] Load both flavours — release (`HorizonSuite.toc`) and beta (`HorizonSuiteBeta.toc`) — and confirm each loads without an interface-mismatch warning when "Load out of date AddOns" is unchecked.
- [ ] Judgment call: are we comfortable shipping `120005` flat (rather than e.g. `120000, 120005`) given Blizzard generally accepts the highest patch number for the current major?
