### PR TITLE
feat(focus): static background size option

### DIFF
--- a/Localisation/deDE.lua
+++ b/Localisation/deDE.lua
@@ -104,6 +104,8 @@ L["DASH_FULL_CHANGELOG"]                                      = "Versionshistori
 L["DASH_WHATS_NEW_UNREAD_SUFFIX"]                             = " (Neu!)"
 L["DASH_PATCH_NOTES_HEAD_SUB"]                                = "Versionshistorie und aktuelle Änderungen"
 L["DASH_PATCH_NOTES_EMPTY"]                                   = "Keine Änderungshinweise verfügbar."
+-- L["DASH_PATCH_NOTES_DISMISS"]                              = "Dismiss"
+-- L["DASH_PATCH_NOTES_VIEW_ALL"]                             = "View all patch notes"
 L["DASH_WELCOME_TAB"]                                         = "Willkommen"
 L["DASH_NEWS_TAB"]                                            = "Neuigkeiten"
 L["DASH_SEARCH_TAB"]                                          = "Durchsuchen"
@@ -555,6 +557,10 @@ L["FOCUS_PANEL_WIDTH"]                                        = "Anzeigebreite"
 L["FOCUS_TRACKER_WIDTH_PIXELS"]                               = "Breite des Zielverfolgers"
 L["FOCUS_MAX_CONTENT_HEIGHT"]                                 = "Maximalhöhe"
 L["FOCUS_MAX_HEIGHT_OF_SCROLLABLE_LIST_PIXELS"]               = "Maximale Höhe der scrollbaren ZielverfolgerListe"
+-- L["FOCUS_STATIC_BACKGROUND"]                               = "Static Background Size"
+-- L["FOCUS_STATIC_BACKGROUND_DESC"]                          = "Lock the panel to a fixed height regardless of tracked content."
+-- L["FOCUS_STATIC_PANEL_HEIGHT"]                             = "Static Panel Height"
+-- L["FOCUS_STATIC_PANEL_HEIGHT_DESC"]                        = "Pixel height of the panel when static background is enabled."
 
 -- =====================================================================
 -- OptionsData.lua Visibility
@@ -1914,6 +1920,7 @@ L["ZONE_LABELS"]                                              = "Zonenbeschriftu
 L["ZONE_NAME_NEW_ZONE"]                                       = "Der Zonenname erscheint weiterhin beim Betreten einer neuen Zone."
 L["ZONE_TYPE_COLOURING"]                                      = "Färbung nach Zonentyp"
 L["FOCUS_COMPLETED_CHECKMARK"]                                = "|TInterface\\\\Buttons\\\\UI-CheckBox-Check:12:12:0:0|t anstelle von grüngefärbten abgeschlossenen Zielen."
+
 
 
 

--- a/Localisation/enUS.lua
+++ b/Localisation/enUS.lua
@@ -559,6 +559,10 @@ L["FOCUS_PANEL_WIDTH"]                                        = "Panel Width"
 L["FOCUS_TRACKER_WIDTH_PIXELS"]                               = "Tracker Width in Pixels."
 L["FOCUS_MAX_CONTENT_HEIGHT"]                                 = "Max Content Height"
 L["FOCUS_MAX_HEIGHT_OF_SCROLLABLE_LIST_PIXELS"]               = "Max height of the scrollable list (pixels)."
+L["FOCUS_STATIC_BACKGROUND"]                                  = "Static Background Size"
+L["FOCUS_STATIC_BACKGROUND_DESC"]                             = "Lock the panel to a fixed height regardless of tracked content."
+L["FOCUS_STATIC_PANEL_HEIGHT"]                                = "Static Panel Height"
+L["FOCUS_STATIC_PANEL_HEIGHT_DESC"]                           = "Pixel height of the panel when static background is enabled."
 
 -- =====================================================================
 -- OptionsData.lua Visibility
@@ -1918,6 +1922,7 @@ L["ZONE_LABELS"]                                              = "Zone Labels"
 L["ZONE_NAME_NEW_ZONE"]                                       = "Zone name still appears when entering a new zone."
 L["ZONE_TYPE_COLOURING"]                                      = "Zone Type Colouring"
 L["FOCUS_COMPLETED_CHECKMARK"]                                = "|TInterface\\\\Buttons\\\\UI-CheckBox-Check:12:12:0:0|t instead of green for done objectives."
+
 
 
 

--- a/Localisation/esES.lua
+++ b/Localisation/esES.lua
@@ -104,6 +104,8 @@ L["DASH_FULL_CHANGELOG"]                                      = "Full changelog"
 -- L["DASH_WHATS_NEW_UNREAD_SUFFIX"]                          = " (New!)"
 -- L["DASH_PATCH_NOTES_HEAD_SUB"]                             = "Release history and recent changes"
 -- L["DASH_PATCH_NOTES_EMPTY"]                                = "No notes available."
+-- L["DASH_PATCH_NOTES_DISMISS"]                              = "Dismiss"
+-- L["DASH_PATCH_NOTES_VIEW_ALL"]                             = "View all patch notes"
 -- L["DASH_WELCOME_TAB"]                                      = "Welcome"
 -- L["DASH_NEWS_TAB"]                                         = "News"
 -- L["DASH_SEARCH_TAB"]                                       = "Search"
@@ -553,6 +555,10 @@ L["FOCUS_PANEL_WIDTH"]                                        = "Ancho del panel
 L["FOCUS_TRACKER_WIDTH_PIXELS"]                               = "Ancho del rastreador de objetivos en píxeles."
 L["FOCUS_MAX_CONTENT_HEIGHT"]                                 = "Altura máxima del contenido"
 L["FOCUS_MAX_HEIGHT_OF_SCROLLABLE_LIST_PIXELS"]               = "Altura máxima de la lista desplazable (píxeles)."
+-- L["FOCUS_STATIC_BACKGROUND"]                               = "Static Background Size"
+-- L["FOCUS_STATIC_BACKGROUND_DESC"]                          = "Lock the panel to a fixed height regardless of tracked content."
+-- L["FOCUS_STATIC_PANEL_HEIGHT"]                             = "Static Panel Height"
+-- L["FOCUS_STATIC_PANEL_HEIGHT_DESC"]                        = "Pixel height of the panel when static background is enabled."
 
 -- =====================================================================
 -- OptionsData.lua Visibility
@@ -1912,6 +1918,7 @@ L["ZONE_LABELS"]                                              = "Zone labels"
 -- L["ZONE_NAME_NEW_ZONE"]                                    = "Zone name still appears when entering a new zone."
 L["ZONE_TYPE_COLOURING"]                                      = "Zone type colouring"
 -- L["FOCUS_COMPLETED_CHECKMARK"]                             = "|TInterface\\\\Buttons\\\\UI-CheckBox-Check:12:12:0:0|t instead of green for done objectives."
+
 
 
 

--- a/Localisation/frFR.lua
+++ b/Localisation/frFR.lua
@@ -104,6 +104,8 @@ L["DASH_FULL_CHANGELOG"]                                      = "Full changelog"
 -- L["DASH_WHATS_NEW_UNREAD_SUFFIX"]                          = " (New!)"
 -- L["DASH_PATCH_NOTES_HEAD_SUB"]                             = "Release history and recent changes"
 -- L["DASH_PATCH_NOTES_EMPTY"]                                = "No notes available."
+-- L["DASH_PATCH_NOTES_DISMISS"]                              = "Dismiss"
+-- L["DASH_PATCH_NOTES_VIEW_ALL"]                             = "View all patch notes"
 -- L["DASH_WELCOME_TAB"]                                      = "Welcome"
 -- L["DASH_NEWS_TAB"]                                         = "News"
 -- L["DASH_SEARCH_TAB"]                                       = "Search"
@@ -553,6 +555,10 @@ L["FOCUS_PANEL_WIDTH"]                                        = "Largeur du pann
 L["FOCUS_TRACKER_WIDTH_PIXELS"]                               = "Largeur du panneau d'objectifs en pixels."
 L["FOCUS_MAX_CONTENT_HEIGHT"]                                 = "Hauteur max du contenu"
 L["FOCUS_MAX_HEIGHT_OF_SCROLLABLE_LIST_PIXELS"]               = "Hauteur maximale de la liste défilable (pixels)."
+-- L["FOCUS_STATIC_BACKGROUND"]                               = "Static Background Size"
+-- L["FOCUS_STATIC_BACKGROUND_DESC"]                          = "Lock the panel to a fixed height regardless of tracked content."
+-- L["FOCUS_STATIC_PANEL_HEIGHT"]                             = "Static Panel Height"
+-- L["FOCUS_STATIC_PANEL_HEIGHT_DESC"]                        = "Pixel height of the panel when static background is enabled."
 
 -- =====================================================================
 -- OptionsData.lua Visibility
@@ -1912,6 +1918,7 @@ L["ZONE_LABELS"]                                              = "Zone labels"
 -- L["ZONE_NAME_NEW_ZONE"]                                    = "Zone name still appears when entering a new zone."
 L["ZONE_TYPE_COLOURING"]                                      = "Zone type colouring"
 -- L["FOCUS_COMPLETED_CHECKMARK"]                             = "|TInterface\\\\Buttons\\\\UI-CheckBox-Check:12:12:0:0|t instead of green for done objectives."
+
 
 
 

--- a/Localisation/koKR.lua
+++ b/Localisation/koKR.lua
@@ -104,6 +104,8 @@ L["DASH_FULL_CHANGELOG"]                                      = "Full changelog"
 -- L["DASH_WHATS_NEW_UNREAD_SUFFIX"]                          = " (New!)"
 -- L["DASH_PATCH_NOTES_HEAD_SUB"]                             = "Release history and recent changes"
 -- L["DASH_PATCH_NOTES_EMPTY"]                                = "No notes available."
+-- L["DASH_PATCH_NOTES_DISMISS"]                              = "Dismiss"
+-- L["DASH_PATCH_NOTES_VIEW_ALL"]                             = "View all patch notes"
 -- L["DASH_WELCOME_TAB"]                                      = "Welcome"
 -- L["DASH_NEWS_TAB"]                                         = "News"
 -- L["DASH_SEARCH_TAB"]                                       = "Search"
@@ -553,6 +555,10 @@ L["FOCUS_PANEL_WIDTH"]                                        = "패널 너비"
 L["FOCUS_TRACKER_WIDTH_PIXELS"]                               = "목록 너비 (픽셀)."
 L["FOCUS_MAX_CONTENT_HEIGHT"]                                 = "최대 콘텐츠 높이"
 L["FOCUS_MAX_HEIGHT_OF_SCROLLABLE_LIST_PIXELS"]               = "스크롤 목록의 최대 높이 (픽셀)."
+-- L["FOCUS_STATIC_BACKGROUND"]                               = "Static Background Size"
+-- L["FOCUS_STATIC_BACKGROUND_DESC"]                          = "Lock the panel to a fixed height regardless of tracked content."
+-- L["FOCUS_STATIC_PANEL_HEIGHT"]                             = "Static Panel Height"
+-- L["FOCUS_STATIC_PANEL_HEIGHT_DESC"]                        = "Pixel height of the panel when static background is enabled."
 
 -- =====================================================================
 -- OptionsData.lua Visibility
@@ -1912,6 +1918,7 @@ L["ZONE_LABELS"]                                              = "Zone labels"
 -- L["ZONE_NAME_NEW_ZONE"]                                    = "Zone name still appears when entering a new zone."
 L["ZONE_TYPE_COLOURING"]                                      = "Zone type colouring"
 -- L["FOCUS_COMPLETED_CHECKMARK"]                             = "|TInterface\\\\Buttons\\\\UI-CheckBox-Check:12:12:0:0|t instead of green for done objectives."
+
 
 
 

--- a/Localisation/locale_template.lua
+++ b/Localisation/locale_template.lua
@@ -563,6 +563,10 @@ L["FOCUS_PANEL_WIDTH"]                                        = "Panel Width"
 L["FOCUS_TRACKER_WIDTH_PIXELS"]                               = "Tracker Width in Pixels."
 L["FOCUS_MAX_CONTENT_HEIGHT"]                                 = "Max Content Height"
 L["FOCUS_MAX_HEIGHT_OF_SCROLLABLE_LIST_PIXELS"]               = "Max height of the scrollable list (pixels)."
+L["FOCUS_STATIC_BACKGROUND"]                                  = "Static Background Size"
+L["FOCUS_STATIC_BACKGROUND_DESC"]                             = "Lock the panel to a fixed height regardless of tracked content."
+L["FOCUS_STATIC_PANEL_HEIGHT"]                                = "Static Panel Height"
+L["FOCUS_STATIC_PANEL_HEIGHT_DESC"]                           = "Pixel height of the panel when static background is enabled."
 
 -- =====================================================================
 -- OptionsData.lua Visibility
@@ -1922,6 +1926,7 @@ L["ZONE_LABELS"]                                              = "Zone Labels"
 L["ZONE_NAME_NEW_ZONE"]                                       = "Zone name still appears when entering a new zone."
 L["ZONE_TYPE_COLOURING"]                                      = "Zone Type Colouring"
 L["FOCUS_COMPLETED_CHECKMARK"]                                = "|TInterface\\\\Buttons\\\\UI-CheckBox-Check:12:12:0:0|t instead of green for done objectives."
+
 
 
 

--- a/Localisation/ptBR.lua
+++ b/Localisation/ptBR.lua
@@ -104,6 +104,8 @@ L["DASH_FULL_CHANGELOG"]                                      = "Full changelog"
 -- L["DASH_WHATS_NEW_UNREAD_SUFFIX"]                          = " (New!)"
 -- L["DASH_PATCH_NOTES_HEAD_SUB"]                             = "Release history and recent changes"
 -- L["DASH_PATCH_NOTES_EMPTY"]                                = "No notes available."
+-- L["DASH_PATCH_NOTES_DISMISS"]                              = "Dismiss"
+-- L["DASH_PATCH_NOTES_VIEW_ALL"]                             = "View all patch notes"
 -- L["DASH_WELCOME_TAB"]                                      = "Welcome"
 -- L["DASH_NEWS_TAB"]                                         = "News"
 -- L["DASH_SEARCH_TAB"]                                       = "Search"
@@ -553,6 +555,10 @@ L["FOCUS_PANEL_WIDTH"]                                        = "Largura do Pain
 L["FOCUS_TRACKER_WIDTH_PIXELS"]                               = "Largura do rastreador em pixels."
 L["FOCUS_MAX_CONTENT_HEIGHT"]                                 = "Altura Máx. do Conteúdo"
 L["FOCUS_MAX_HEIGHT_OF_SCROLLABLE_LIST_PIXELS"]               = "Altura máxima da lista rolável (pixels)."
+-- L["FOCUS_STATIC_BACKGROUND"]                               = "Static Background Size"
+-- L["FOCUS_STATIC_BACKGROUND_DESC"]                          = "Lock the panel to a fixed height regardless of tracked content."
+-- L["FOCUS_STATIC_PANEL_HEIGHT"]                             = "Static Panel Height"
+-- L["FOCUS_STATIC_PANEL_HEIGHT_DESC"]                        = "Pixel height of the panel when static background is enabled."
 
 -- =====================================================================
 -- OptionsData.lua Visibility
@@ -1912,6 +1918,7 @@ L["ZONE_LABELS"]                                              = "Zone labels"
 -- L["ZONE_NAME_NEW_ZONE"]                                    = "Zone name still appears when entering a new zone."
 L["ZONE_TYPE_COLOURING"]                                      = "Zone type colouring"
 -- L["FOCUS_COMPLETED_CHECKMARK"]                             = "|TInterface\\\\Buttons\\\\UI-CheckBox-Check:12:12:0:0|t instead of green for done objectives."
+
 
 
 

--- a/Localisation/ruRU.lua
+++ b/Localisation/ruRU.lua
@@ -104,6 +104,8 @@ L["DASH_FULL_CHANGELOG"]                                      = "Full changelog"
 -- L["DASH_WHATS_NEW_UNREAD_SUFFIX"]                          = " (New!)"
 -- L["DASH_PATCH_NOTES_HEAD_SUB"]                             = "Release history and recent changes"
 -- L["DASH_PATCH_NOTES_EMPTY"]                                = "No notes available."
+-- L["DASH_PATCH_NOTES_DISMISS"]                              = "Dismiss"
+-- L["DASH_PATCH_NOTES_VIEW_ALL"]                             = "View all patch notes"
 -- L["DASH_WELCOME_TAB"]                                      = "Welcome"
 -- L["DASH_NEWS_TAB"]                                         = "News"
 -- L["DASH_SEARCH_TAB"]                                       = "Search"
@@ -553,6 +555,10 @@ L["FOCUS_PANEL_WIDTH"]                                        = "Ширина п
 L["FOCUS_TRACKER_WIDTH_PIXELS"]                               = "Ширина трекера в пикселях."
 L["FOCUS_MAX_CONTENT_HEIGHT"]                                 = "Макс. высота контента"
 L["FOCUS_MAX_HEIGHT_OF_SCROLLABLE_LIST_PIXELS"]               = "Максимальная высота прокручиваемого списка (пиксели)."
+-- L["FOCUS_STATIC_BACKGROUND"]                               = "Static Background Size"
+-- L["FOCUS_STATIC_BACKGROUND_DESC"]                          = "Lock the panel to a fixed height regardless of tracked content."
+-- L["FOCUS_STATIC_PANEL_HEIGHT"]                             = "Static Panel Height"
+-- L["FOCUS_STATIC_PANEL_HEIGHT_DESC"]                        = "Pixel height of the panel when static background is enabled."
 
 -- =====================================================================
 -- OptionsData.lua Visibility
@@ -1912,6 +1918,7 @@ L["ZONE_LABELS"]                                              = "Zone labels"
 -- L["ZONE_NAME_NEW_ZONE"]                                    = "Zone name still appears when entering a new zone."
 L["ZONE_TYPE_COLOURING"]                                      = "Zone type colouring"
 -- L["FOCUS_COMPLETED_CHECKMARK"]                             = "|TInterface\\\\Buttons\\\\UI-CheckBox-Check:12:12:0:0|t instead of green for done objectives."
+
 
 
 

--- a/Localisation/zhCN.lua
+++ b/Localisation/zhCN.lua
@@ -104,6 +104,8 @@ L["DASH_FULL_CHANGELOG"]                                      = "Full changelog"
 -- L["DASH_WHATS_NEW_UNREAD_SUFFIX"]                          = " (New!)"
 -- L["DASH_PATCH_NOTES_HEAD_SUB"]                             = "Release history and recent changes"
 -- L["DASH_PATCH_NOTES_EMPTY"]                                = "No notes available."
+-- L["DASH_PATCH_NOTES_DISMISS"]                              = "Dismiss"
+-- L["DASH_PATCH_NOTES_VIEW_ALL"]                             = "View all patch notes"
 -- L["DASH_WELCOME_TAB"]                                      = "Welcome"
 -- L["DASH_NEWS_TAB"]                                         = "News"
 -- L["DASH_SEARCH_TAB"]                                       = "Search"
@@ -554,6 +556,10 @@ L["FOCUS_PANEL_WIDTH"]                                        = "面板宽度"
 L["FOCUS_TRACKER_WIDTH_PIXELS"]                               = "追踪器宽度(像素)"
 L["FOCUS_MAX_CONTENT_HEIGHT"]                                 = "最大内容高度"
 L["FOCUS_MAX_HEIGHT_OF_SCROLLABLE_LIST_PIXELS"]               = "可滚动列表最大高度(像素)"
+-- L["FOCUS_STATIC_BACKGROUND"]                               = "Static Background Size"
+-- L["FOCUS_STATIC_BACKGROUND_DESC"]                          = "Lock the panel to a fixed height regardless of tracked content."
+-- L["FOCUS_STATIC_PANEL_HEIGHT"]                             = "Static Panel Height"
+-- L["FOCUS_STATIC_PANEL_HEIGHT_DESC"]                        = "Pixel height of the panel when static background is enabled."
 
 -- =====================================================================
 -- OptionsData.lua Visibility
@@ -1913,6 +1919,7 @@ L["ZONE_LABELS"]                                              = "Zone labels"
 -- L["ZONE_NAME_NEW_ZONE"]                                    = "Zone name still appears when entering a new zone."
 L["ZONE_TYPE_COLOURING"]                                      = "Zone type colouring"
 -- L["FOCUS_COMPLETED_CHECKMARK"]                             = "|TInterface\\\\Buttons\\\\UI-CheckBox-Check:12:12:0:0|t instead of green for done objectives."
+
 
 
 

--- a/core/Core.lua
+++ b/core/Core.lua
@@ -305,6 +305,16 @@ function addon.GetMaxContentHeight()
     return addon.Scaled(v)
 end
 
+function addon.IsStaticBackgroundEnabled()
+    return addon.GetDB("staticBackgroundEnabled", false) and true or false
+end
+
+function addon.GetStaticPanelHeight()
+    local v = tonumber(addon.GetDB("staticPanelHeight", 400)) or 400
+    if v < 50 then v = 50 elseif v > 1500 then v = 1500 end
+    return addon.Scaled(v)
+end
+
 --- Returns the header text color from DB or default.
 --- When Focus class colour is enabled, RGB uses the player class colour.
 --- @return table {r,g,b}

--- a/modules/Focus/FocusLayout.lua
+++ b/modules/Focus/FocusLayout.lua
@@ -572,7 +572,12 @@ local function FullLayout()
                 -- Grow-up already reserves the full footer/header stack in headerArea; adding
                 -- another trailing pad makes the panel nudge when toggling growUp off.
                 local trailingPad = useGrowUpScrollLayout and 0 or addon.GetScaledPadding()
-                local desiredH = math.max(addon.GetScaledMinHeight(), headerArea + visibleH + trailingPad + blockHeight)
+                local desiredH
+                if addon.IsStaticBackgroundEnabled and addon.IsStaticBackgroundEnabled() then
+                    desiredH = addon.GetStaticPanelHeight()
+                else
+                    desiredH = math.max(addon.GetScaledMinHeight(), headerArea + visibleH + trailingPad + blockHeight)
+                end
                 addon.focus.layout.targetHeight = math.min(desiredH, GetMaxPanelHeight())
             else
                 scrollFrame:Hide()
@@ -1444,7 +1449,12 @@ local function FullLayout()
     -- Grow-up already reserves the full footer/header stack in headerArea; adding
     -- another trailing pad makes the panel nudge when toggling growUp off.
     local trailingPad   = useGrowUpScrollLayout and 0 or addon.GetScaledPadding()
-    local desiredH      = math.max(addon.GetScaledMinHeight(), headerArea + visibleH + trailingPad + blockHeight)
+    local desiredH
+    if addon.IsStaticBackgroundEnabled and addon.IsStaticBackgroundEnabled() then
+        desiredH = addon.GetStaticPanelHeight()
+    else
+        desiredH = math.max(addon.GetScaledMinHeight(), headerArea + visibleH + trailingPad + blockHeight)
+    end
     addon.focus.layout.targetHeight  = math.min(desiredH, GetMaxPanelHeight())
 
     -- Header slide up: use expanded targetHeight for headerSlideEndY (set in ToggleCollapse before FullLayout had the new height)

--- a/options/OptionsData.lua
+++ b/options/OptionsData.lua
@@ -1651,6 +1651,8 @@ local OptionCategories = {
             { type = "section", name = L["FOCUS_DIMENSIONS"] },
             { type = "slider", name = L["FOCUS_PANEL_WIDTH"], desc = L["FOCUS_TRACKER_WIDTH_PIXELS"], dbKey = "panelWidth", min = 180, max = 800, get = function() return getDB("panelWidth", 260) end, set = function(v) setDB("panelWidth", math.max(180, math.min(800, v))) end },
             { type = "slider", name = L["FOCUS_MAX_CONTENT_HEIGHT"], desc = L["FOCUS_MAX_HEIGHT_OF_SCROLLABLE_LIST_PIXELS"], dbKey = "maxContentHeight", min = 200, max = 1500, get = function() return getDB("maxContentHeight", 480) end, set = function(v) setDB("maxContentHeight", math.max(200, math.min(1500, v))) end },
+            { type = "toggle", name = L["FOCUS_STATIC_BACKGROUND"], desc = L["FOCUS_STATIC_BACKGROUND_DESC"], dbKey = "staticBackgroundEnabled", get = function() return getDB("staticBackgroundEnabled", false) end, set = function(v) setDB("staticBackgroundEnabled", v); if addon.FullLayout then addon.FullLayout() end end, refreshIds = { "staticPanelHeight" } },
+            { type = "slider", name = L["FOCUS_STATIC_PANEL_HEIGHT"], desc = L["FOCUS_STATIC_PANEL_HEIGHT_DESC"], dbKey = "staticPanelHeight", min = 50, max = 1500, get = function() return math.max(50, math.min(1500, tonumber(getDB("staticPanelHeight", 400)) or 400)) end, set = function(v) setDB("staticPanelHeight", math.max(50, math.min(1500, v))); if addon.FullLayout then addon.FullLayout() end end, visibleWhen = function() return getDB("staticBackgroundEnabled", false) end },
             { type = "section", name = L["FOCUS_SPACING"] },
             { type = "dropdown", name = L["FOCUS_SPACING_PRESET"], dbKey = "compactMode",
                 options = {


### PR DESCRIPTION
Closes #164

## Summary
Adds a Focus → Layout option to lock the tracker panel to a fixed pixel height regardless of how many quests, scenarios, or M+ timers are being tracked. Useful for users whose surrounding UI relies on a stable, "seamless" anchor next to the tracker.

## Implementation notes
- New DB keys: `staticBackgroundEnabled` (bool, default false) and `staticPanelHeight` (number, scaled pixels, default 400, range 50–1500).
- Helpers in `core/Core.lua`: `addon.IsStaticBackgroundEnabled()` and `addon.GetStaticPanelHeight()`.
- The override applies only to the two content-driven `desiredH` calculations in `FocusLayout.lua`. Collapse paths (`GetCollapsedHeight()`) are deliberately left alone so click-to-collapse still shrinks to header-only height.
- Width remains controlled by the existing `panelWidth` slider; the new slider only affects height.
- Borders and the backdrop texture follow `HSFrame` automatically — no border/texture work needed.
- Locale strings added via `Localisation/enUS.lua` + `tools/restructure_locales.js` (other locales fall through to enUS).

## Test plan
- [ ] `/reload`. Open Options → Focus → Layout → Dimensions. New "Static Background Size" toggle appears below "Max Content Height".
- [ ] Enable the toggle. The "Static Panel Height" slider appears.
- [ ] Drag slider 50 → 1500. Panel resizes immediately, no flicker.
- [ ] Disable the toggle. Slider hides, panel reverts to dynamic sizing.
- [ ] With 1 quest tracked, panel stays at static height with empty backdrop below.
- [ ] With 10+ quests tracked, content scrolls inside fixed-height panel; background does not grow.
- [ ] Start an M+ run: M+ block fits inside the static panel; panel does not grow.
- [ ] In a scenario: scenario block fits inside static panel without resize.
- [ ] Click Objectives header to collapse: panel still collapses to header-only height. Expand restores to static height.
- [ ] Toggle `growUp` while static is on: anchoring updates correctly, height stays static.
- [ ] Change `panelWidth` while static is on: width updates, height stays static.