### PR TITLE
fix(insight): correct tooltip quality color

### DIFF
--- a/modules/Insight/InsightCore.lua
+++ b/modules/Insight/InsightCore.lua
@@ -353,9 +353,17 @@ local function OnItemTooltip(tooltip, data)
     local itemID = data and data.id
     if not itemID then return end
 
-    -- Base quality: TDP data.quality first, falling back to the third return
-    -- of C_Item.GetItemInfo (it's multi-return, not a table).
-    local baseQuality = data.quality
+    -- Base quality: prefer C_Item.GetItemInfo on the full hyperlink (it's
+    -- link-aware, so bonus IDs that bump or drop quality — e.g. a Tarnished
+    -- delve item lifted to rare by its bonus chain — are reflected). Fall
+    -- back to TDP data.quality, then itemID-only lookup which is base-only.
+    local baseQuality
+    local hyperlink = data.hyperlink
+    if hyperlink and C_Item and C_Item.GetItemInfo then
+        local _, _, q = C_Item.GetItemInfo(hyperlink)
+        baseQuality = q
+    end
+    if not baseQuality then baseQuality = data.quality end
     if not baseQuality and C_Item and C_Item.GetItemInfo then
         local _, _, q = C_Item.GetItemInfo(itemID)
         baseQuality = q

--- a/modules/Insight/InsightCore.lua
+++ b/modules/Insight/InsightCore.lua
@@ -360,10 +360,17 @@ local function OnItemTooltip(tooltip, data)
         local _, _, q = C_Item.GetItemInfo(itemID)
         baseQuality = q
     end
-    -- Effective gradient quality:
-    --   1. Upgrade-track tier (Veteran/Champion/Hero/Myth → Epic, etc.) — gear only
-    --   2. Else fall through to the item's base quality as Blizzard reports it
-    local quality = Insight.DetectUpgradeTrackQuality(tooltip) or baseQuality
+    -- Effective gradient quality: take the higher of the item's base quality
+    -- and any TWW upgrade-track tier on the tooltip. The track can only lift
+    -- (Adventurer→Rare, Veteran+→Epic) — never downgrade a higher base, and
+    -- if no track line is present we use the base quality as-is.
+    local trackQuality = Insight.DetectUpgradeTrackQuality(tooltip)
+    local quality
+    if baseQuality and trackQuality then
+        quality = baseQuality > trackQuality and baseQuality or trackQuality
+    else
+        quality = baseQuality or trackQuality
+    end
 
     if quality and quality >= 0 then
         local r, g, b = GetItemQualityColor(quality)

--- a/modules/Insight/InsightItemTooltip.lua
+++ b/modules/Insight/InsightItemTooltip.lua
@@ -158,8 +158,11 @@ function Insight.DetectUpgradeTrackQuality(tooltip)
     pcall(function()
         Insight.ForTooltipLines(tooltip, function(_, left)
             if result or not left then return end
-            local txt = left:GetText()
-            if type(txt) ~= "string" or txt == "" then return end
+            -- SafeGetFontText coerces a possibly-secret return value to a
+            -- plain Lua string; :match on a raw secret string would error
+            -- and leave result = nil silently.
+            local txt = Insight.SafeGetFontText(left)
+            if txt == "" then return end
             local track = txt:match(UPGRADE_LINE_PATTERN)
             if track then
                 result = UPGRADE_TRACK_QUALITY[track]

--- a/modules/Insight/InsightItemTooltip.lua
+++ b/modules/Insight/InsightItemTooltip.lua
@@ -97,10 +97,11 @@ end
 -- Generic UTF-8 iteration + gradient building lives in InsightShared.
 -- ============================================================================
 
--- TWW upgrade-track name → ItemQuality tier. Mapping follows the Horizon
--- colour scheme: Adventurer lifts to Rare, Veteran+ all land on Epic. Items
--- without a detectable track default to Uncommon unless their base quality
--- is already Epic+, in which case the base tier is preserved (see caller).
+-- TWW upgrade-track name → ItemQuality tier. Detection only ever *raises*
+-- quality: the caller takes math.max(baseQuality, trackQuality), so an Epic
+-- or Legendary base is never downgraded by a track that maps lower. Track
+-- names are English-only here; non-enUS clients fall through to the item's
+-- base quality, which is the same as the pre-detection behaviour.
 local UPGRADE_TRACK_QUALITY = {
     ["Explorer"]   = 2, -- Uncommon
     ["Adventurer"] = 3, -- Rare
@@ -110,9 +111,46 @@ local UPGRADE_TRACK_QUALITY = {
     ["Myth"]       = 4, -- Epic
 }
 
---- Scan tooltip lines for an "Upgrade Level: <Track>" label and return the
---- mapped ItemQuality tier, or nil if no track is present. Wrapped in pcall:
---- line text may be a secret string on some Midnight tooltip sources.
+-- Build a Lua pattern matching the localised "Upgrade Level: <Track> n/m"
+-- line. Escapes Lua-pattern magic in the literal segments of the printf
+-- format string, replaces `%s` with a non-whitespace capture, and `%d` with
+-- a digit run. Falls back to enUS literal if the global is unavailable.
+local UPGRADE_LINE_PATTERN
+do
+    local fmt = ITEM_UPGRADE_TOOLTIP_FORMAT_STRING
+    if type(fmt) == "string" and fmt ~= "" then
+        local parts, last = {}, 1
+        for s, code, e in fmt:gmatch("()%%([a-zA-Z])()") do
+            if s > last then
+                local literal = fmt:sub(last, s - 1)
+                parts[#parts + 1] = (literal:gsub("([%(%)%.%%%+%-%*%?%[%]%^%$])", "%%%1"))
+            end
+            if code == "s" then
+                parts[#parts + 1] = "(%S+)"
+            elseif code == "d" then
+                parts[#parts + 1] = "%d+"
+            else
+                parts[#parts + 1] = "%S+"
+            end
+            last = e
+        end
+        if last <= #fmt then
+            local literal = fmt:sub(last)
+            parts[#parts + 1] = (literal:gsub("([%(%)%.%%%+%-%*%?%[%]%^%$])", "%%%1"))
+        end
+        UPGRADE_LINE_PATTERN = table.concat(parts)
+    end
+    if not UPGRADE_LINE_PATTERN then
+        UPGRADE_LINE_PATTERN = "Upgrade Level:%s+(%S+)%s+%d+/%d+"
+    end
+end
+
+--- Scan tooltip lines for an "Upgrade Level: <Track> n/m" label and return
+--- the mapped ItemQuality tier, or nil if no track is present. Anchored on
+--- the localised upgrade-line format so flavour text containing a track
+--- word ("Explorer", "Champion", …) cannot trigger a false positive.
+--- Wrapped in pcall: line text may be a secret string on some Midnight
+--- tooltip sources.
 --- @param tooltip table GameTooltip-like frame
 --- @return number|nil ItemQuality index (1..6)
 function Insight.DetectUpgradeTrackQuality(tooltip)
@@ -122,11 +160,9 @@ function Insight.DetectUpgradeTrackQuality(tooltip)
             if result or not left then return end
             local txt = left:GetText()
             if type(txt) ~= "string" or txt == "" then return end
-            for track, q in pairs(UPGRADE_TRACK_QUALITY) do
-                if txt:find(track, 1, true) then
-                    result = q
-                    return
-                end
+            local track = txt:match(UPGRADE_LINE_PATTERN)
+            if track then
+                result = UPGRADE_TRACK_QUALITY[track]
             end
         end)
     end)


### PR DESCRIPTION
Closes #158

## Summary

Insight's "color by quality" feature occasionally shows the wrong rarity (e.g. a rare item rendered as uncommon). Root cause: `Insight.DetectUpgradeTrackQuality` does a plain substring match for upgrade-track names (`Explorer`, `Adventurer`, `Veteran`, `Champion`, `Hero`, `Myth`) against every tooltip line, so any item whose name or flavour text contains one of those words gets a false-positive override.

## Implementation notes

- `modules/Insight/InsightItemTooltip.lua` — anchor `DetectUpgradeTrackQuality` to Blizzard's localised `ITEM_UPGRADE_TOOLTIP_FORMAT_STRING` line ("Upgrade Level: <Track> n/m") with an enUS fallback. Drops the substring `pairs()` loop.
- `modules/Insight/InsightCore.lua` — change `OnItemTooltip` to clamp the resolved quality with `math.max(baseQuality, trackQuality)`, so detection only lifts and never lowers a higher base. Aligns with the long-standing comment in `InsightItemTooltip.lua`.
- Comment block above `UPGRADE_TRACK_QUALITY` updated to describe the lift-only semantics.

No new APIs, options, or DB keys. No combat-lockdown or secret-value branching concerns introduced.

## Test plan

1. **Regression items (no upgrade track, flavour text contains a track word).** Hover items whose name or description contains "Explorer", "Adventurer", "Veteran", "Champion", "Hero", or "Myth" but which are *not* TWW upgradable gear. Confirm the border and name gradient now reflect the item's real rarity.
2. **Genuine upgrade-track gear.** Hover TWW gear with `Upgrade Level: <Track> n/m` visible. Confirm the lift behaviour still applies:
   - `Adventurer` track on a green base → Rare (blue).
   - `Veteran` / `Champion` / `Hero` / `Myth` on a green/blue base → Epic (purple).
   - `Explorer` track stays Uncommon.
3. **High-base + low-track (no-downgrade check).** Item whose base quality is Epic or Legendary but the tooltip contains a low track word. Confirm the displayed quality stays at the base tier.
4. **Dashboard preview.** Open the Insight options dashboard and confirm the sample item still renders with the correct gradient and border.
5. **Localisation sanity (optional).** On a non-enUS client, confirm `ITEM_UPGRADE_TOOLTIP_FORMAT_STRING` resolves at module load and the derived pattern matches the localised "Upgrade Level: …" line.