### PR TITLE
v4.17.3 — fix non-English clients seeing English fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ All notable changes to Horizon Suite are documented here.
 
 ---
 
+## [4.17.3] – 2026-05-02
+
+### 🐛 Fixes
+
+- **Localisation** — Non-English clients (German, Spanish, French, Korean, Brazilian Portuguese, Simplified Chinese) once again display in the player's selected language instead of falling back to English. A file load order regression in 4.17.2 caused English strings to overwrite every translation at startup.
+
+---
+
 ## [4.17.2] – 2026-05-02
 
 ### 🔧 Improvements

--- a/HorizonSuite.toc
+++ b/HorizonSuite.toc
@@ -2,7 +2,7 @@
 ## Title: Horizon Suite
 ## Notes: Core addon with pluggable modules.
 ## Author: Crystilac
-## Version: 4.17.2
+## Version: 4.17.3
 ## SavedVariables: HorizonDB
 ## OptionalDeps: Auctionator, IconBrowser
 ## IconTexture: Interface\AddOns\HorizonSuite\HorizonLogo
@@ -11,8 +11,8 @@
 
 HorizonSuite.lua
 localisation/LocaleCore.lua
-localisation/horizon/deDE.lua
 localisation/horizon/enUS.lua
+localisation/horizon/deDE.lua
 localisation/horizon/esES.lua
 localisation/horizon/frFR.lua
 localisation/horizon/koKR.lua

--- a/HorizonSuiteBeta.toc
+++ b/HorizonSuiteBeta.toc
@@ -9,8 +9,8 @@
 
 HorizonSuite.lua
 localisation/LocaleCore.lua
-localisation/horizon/deDE.lua
 localisation/horizon/enUS.lua
+localisation/horizon/deDE.lua
 localisation/horizon/esES.lua
 localisation/horizon/frFR.lua
 localisation/horizon/koKR.lua

--- a/core/PatchNotesData.lua
+++ b/core/PatchNotesData.lua
@@ -15,6 +15,16 @@ local addon = _G._HorizonSuite_Loading or _G.HorizonSuiteBeta or _G.HorizonSuite
 
 addon.PATCH_NOTES = {
 
+    ["4.17.3"] = {
+        date = "2026-05-02",
+        {
+            section = "Fixes",
+            bullets = {
+                "Localisation: non-English clients now display in the player's selected language again instead of falling back to English (regression introduced in 4.17.2).",
+            },
+        },
+    },
+
     ["4.17.2"] = {
         date = "2026-05-02",
         {


### PR DESCRIPTION
## Summary

Hotfix for #182 — non-English clients (deDE / esES / frFR / koKR / ptBR / zhCN) regressed to English-only display in 4.17.2. Bumps to **v4.17.3**.

## Root cause

PR #180 reordered the localisation files in both TOCs alphabetically, which moved `deDE.lua` ahead of `enUS.lua`. The locale system relies on `enUS.lua` loading **first** because each non-English file does:

```lua
local L = setmetatable({}, { __index = addon.L })
addon.L = L
```

i.e. it wraps the previous `addon.L` (expected to be enUS) so missing keys fall back to English. With alphabetical order:

1. `deDE.lua` runs first → replaces `addon.L` with a fresh deDE table whose `__index` points to the empty bootstrap table.
2. `enUS.lua` runs → `local L = addon.L` grabs the **deDE table**, then writes ~1,000 English strings into it, overwriting every German translation that was set in step 1.

Net effect: every non-English locale ends up holding pure English strings.

## What changed

- `HorizonSuite.toc` and `HorizonSuiteBeta.toc`: moved `localisation/horizon/enUS.lua` to be the first locale entry, before the others.
- Bumped `## Version` to `4.17.3`.
- Added 4.17.3 entry to `CHANGELOG.md` and `core/PatchNotesData.lua`.

## Test plan

- [ ] Set client language to Deutsch, `/reload`, confirm options panel and module UI show German strings.
- [ ] Repeat for one more locale (e.g. frFR) to confirm the chain works for all wrappers.
- [ ] Confirm enUS clients still see English (no regression in the default path).
- [ ] Confirm in-game patch notes popup shows the 4.17.3 entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)