### PR TITLE
Add SLUG font outline options

### DIFF
--- a/localisation/horizon/enUS.lua
+++ b/localisation/horizon/enUS.lua
@@ -1254,6 +1254,9 @@ L["PRESENCE_FONT_SIZE_SMALL_NOTIFICATION_SUBTITLES"]          = "Font size for s
 -- =====================================================================
 L["FOCUS_OUTLINE_NONE"]                                       = "None"
 L["FOCUS_THICK_OUTLINE"]                                      = "Thick Outline"
+L["FOCUS_SLUG"]                                               = "SLUG"
+L["FOCUS_SLUG_OUTLINE"]                                       = "SLUG Outline"
+L["FOCUS_SLUG_THICK_OUTLINE"]                                 = "SLUG Thick Outline"
 
 -- =====================================================================
 -- OptionsData.lua Dropdown options — Highlight style

--- a/options/OptionsData.lua
+++ b/options/OptionsData.lua
@@ -775,6 +775,17 @@ local OUTLINE_OPTIONS = {
     { L["FOCUS_OUTLINE_NONE"], "" },
     { L["FOCUS_OUTLINE"], "OUTLINE" },
     { L["FOCUS_THICK_OUTLINE"], "THICKOUTLINE" },
+    { L["FOCUS_SLUG"] or "SLUG", "SLUG" },
+    { L["FOCUS_SLUG_OUTLINE"] or "SLUG Outline", "OUTLINE, SLUG" },
+    { L["FOCUS_SLUG_THICK_OUTLINE"] or "SLUG Thick Outline", "THICKOUTLINE, SLUG" },
+}
+local VALID_OUTLINE_VALUES = {
+    [""] = true,
+    OUTLINE = true,
+    THICKOUTLINE = true,
+    SLUG = true,
+    ["OUTLINE, SLUG"] = true,
+    ["THICKOUTLINE, SLUG"] = true,
 }
 local HIGHLIGHT_OPTIONS = {
     { L["FOCUS_HIGHLIGHT_BAR_LEFT_EDGE"], "bar-left" },
@@ -999,9 +1010,10 @@ local OptionCategories = {
                 desc = L["DASHBOARD_TYPO_OUTLINE_DESC"] or "Outline style for dashboard text.",
                 dbKey = "dashboardTextOutline",
                 options = OUTLINE_OPTIONS,
+                preserveOrder = true,
                 get = function()
                     local v = getDB("dashboardTextOutline", 1)
-                    if v == "" or v == "OUTLINE" or v == "THICKOUTLINE" then return v end
+                    if VALID_OUTLINE_VALUES[v] then return v end
                     if v == true then return "OUTLINE" end
                     if v == false then return "" end
                     local n = tonumber(v)
@@ -2007,7 +2019,7 @@ local OptionCategories = {
             { type = "slider", name = L["FOCUS_PROGRESS_BAR_TEXT_SIZE"], desc = L["FONT_SIZE_BAR_LABEL_BAR_HEIGHT"], dbKey = "progressBarFontSize", min = 7, max = 18, get = function() return getDB("progressBarFontSize", 10) end, set = function(v) setDB("progressBarFontSize", v) end, tooltip = L["AFFECTS_SCENARIO_PROGRESS_TIMER_BARS"] },
             { type = "slider", name = L["FOCUS_TIMER_TEXT_SIZE"], desc = L["FOCUS_TIMER_TEXT_FONT_SIZE"], dbKey = "timerFontSize", min = 8, max = 24, get = function() return getDB("timerFontSize", 13) end, set = function(v) setDB("timerFontSize", v) end },
             { type = "slider", name = L["FOCUS_OPTIONS_TEXT_SIZE"], desc = L["FOCUS_OPTIONS_TEXT_FONT_SIZE"], dbKey = "optionsFontSize", min = 8, max = 20, get = function() return getDB("optionsFontSize", 11) end, set = function(v) setDB("optionsFontSize", v) end },
-            { type = "dropdown", name = L["FOCUS_OUTLINE"], desc = L["FOCUS_FONT_OUTLINE_STYLE"], dbKey = "fontOutline", options = OUTLINE_OPTIONS, get = function() return getDB("fontOutline", "OUTLINE") end, set = function(v) setDB("fontOutline", v) end },
+            { type = "dropdown", name = L["FOCUS_OUTLINE"], desc = L["FOCUS_FONT_OUTLINE_STYLE"], dbKey = "fontOutline", options = OUTLINE_OPTIONS, preserveOrder = true, get = function() return getDB("fontOutline", "OUTLINE") end, set = function(v) setDB("fontOutline", v) end },
             { type = "section", name = L["FOCUS_TEXT_CASE"] },
             { type = "dropdown", name = L["FOCUS_HEADER_TEXT_CASE"], desc = L["FOCUS_DISPLAY_CASE_HEADER"], dbKey = "headerTextCase", options = TEXT_CASE_OPTIONS, get = function() local v = getDB("headerTextCase", "upper"); return (v == "default") and "upper" or v end, set = function(v) setDB("headerTextCase", v) end },
             { type = "dropdown", name = L["FOCUS_SECTION_HEADER_CASE"], desc = L["FOCUS_DISPLAY_CASE_CATEGORY_LABELS"], dbKey = "sectionHeaderTextCase", options = TEXT_CASE_OPTIONS, get = function() local v = getDB("sectionHeaderTextCase", "proper"); return (v == "default") and "proper" or v end, set = function(v) setDB("sectionHeaderTextCase", v) end },

--- a/options/OptionsPanel.lua
+++ b/options/OptionsPanel.lua
@@ -1329,7 +1329,7 @@ local function BuildCategory(tab, tabIndex, options, refreshers, optionFrames)
                     tooltip = resetBtn.tooltip,
                 }
             end
-            local w = OptionsWidgets_CreateCustomDropdown(cardContent, opt.name, opt.desc or opt.tooltip, opt.options or {}, opt.get, setFn, opt.displayFn, searchable, opt.disabled, opt.tooltip, resetBtn, opt.fontPreviewInList)
+            local w = OptionsWidgets_CreateCustomDropdown(cardContent, opt.name, opt.desc or opt.tooltip, opt.options or {}, opt.get, setFn, opt.displayFn, searchable, opt.disabled, opt.tooltip, resetBtn, opt.fontPreviewInList, opt.preserveOrder)
             w:SetPoint("TOPLEFT", contentAnchor, "BOTTOMLEFT", 0, -OptionGap)
             w:SetPoint("RIGHT", currentCard, "RIGHT", -CardPadding, 0)
             currentCard.contentAnchor = w

--- a/options/OptionsWidgets.lua
+++ b/options/OptionsWidgets.lua
@@ -593,7 +593,7 @@ local DROPDOWN_FONT_GLOBAL_SENTINEL = "__global__"
 -- When searchable is true, adds an EditBox above the list to filter options by name (e.g. font dropdown).
 -- resetButton: optional table { onClick, tooltip } — adds a small reset-arrow icon button to the left of the dropdown.
 -- fontPreviewInList: when true, each list row (and closed button when a font path is selected) uses ResolveFontPath(value) for SetFont.
-function _G.OptionsWidgets_CreateCustomDropdown(parent, labelText, description, options, get, set, displayFn, searchable, disabledFn, tooltip, resetButton, fontPreviewInList)
+function _G.OptionsWidgets_CreateCustomDropdown(parent, labelText, description, options, get, set, displayFn, searchable, disabledFn, tooltip, resetButton, fontPreviewInList, preserveOrder)
     local labelFn = type(labelText) == "function" and labelText or nil
     local resolvedLabel = labelFn and labelFn() or labelText
     local row = CreateFrame("Frame", nil, parent)
@@ -851,13 +851,15 @@ function _G.OptionsWidgets_CreateCustomDropdown(parent, labelText, description, 
                 out[#out + 1] = { k, v }
             end
         end
-        table.sort(out, function(a, b)
-            local aVal = a and a[2]
-            local bVal = b and b[2]
-            if aVal == "__global__" then return true end
-            if bVal == "__global__" then return false end
-            return tostring(a and a[1] or "") < tostring(b and b[1] or "")
-        end)
+        if not preserveOrder then
+            table.sort(out, function(a, b)
+                local aVal = a and a[2]
+                local bVal = b and b[2]
+                if aVal == "__global__" then return true end
+                if bVal == "__global__" then return false end
+                return tostring(a and a[1] or "") < tostring(b and b[1] or "")
+            end)
+        end
         return out
     end
 

--- a/options/dashboard/DashboardDetailView.lua
+++ b/options/dashboard/DashboardDetailView.lua
@@ -1162,7 +1162,7 @@ function addon.DashboardDetailView_Init(env)
                             tooltip = resetBtn.tooltip,
                         }
                     end
-                    widget = _G.OptionsWidgets_CreateCustomDropdown(currentCard.settingsContainer, displayName, opt.desc or "", opt.options, g, s, opt.displayFn, opt.searchable, opt.disabled, opt.tooltip, resetBtn, opt.fontPreviewInList)
+                    widget = _G.OptionsWidgets_CreateCustomDropdown(currentCard.settingsContainer, displayName, opt.desc or "", opt.options, g, s, opt.displayFn, opt.searchable, opt.disabled, opt.tooltip, resetBtn, opt.fontPreviewInList, opt.preserveOrder)
                     if widget and widget.Refresh then detailOptionFrames[optId] = widget end
                 elseif opt.type == "color" then
                     widget = _G.OptionsWidgets_CreateColorSwatch(currentCard.settingsContainer, displayName, opt.desc or "", g, s, opt.hasAlpha, opt.tooltip)

--- a/options/dashboard/DashboardUtil.lua
+++ b/options/dashboard/DashboardUtil.lua
@@ -131,21 +131,40 @@ function addon.Dashboard_EffectiveDashboardFontSize(base)
     return math.max(DASHBOARD_TYPO_MIN_PX, math.floor(body + ((tonumber(base) or 13) - 13) + 0.5))
 end
 
+--- Parse stored dashboardTextOutline value into (level, slug) pair.
+--- Levels: 0 off, 1 OUTLINE, 2 THICKOUTLINE. SLUG is an independent SDF flag.
+local function parseOutlineValue(v)
+    if v == "" then return 0, false end
+    if v == "OUTLINE" then return 1, false end
+    if v == "THICKOUTLINE" then return 2, false end
+    if v == "SLUG" then return 0, true end
+    if v == "OUTLINE, SLUG" then return 1, true end
+    if v == "THICKOUTLINE, SLUG" then return 2, true end
+    -- Legacy boolean migration
+    if v == true then return 1, false end
+    if v == false then return 0, false end
+    local n = tonumber(v)
+    if not n then return 1, false end
+    return math.max(0, math.min(2, math.floor(n + 0.5))), false
+end
+
+local function readOutlineConfig()
+    if not addon.GetDB then return 1, false end
+    return parseOutlineValue(addon.GetDB("dashboardTextOutline", 1))
+end
+
 --- Saved outline level: 0 off, 1 OUTLINE, 2 THICKOUTLINE. Handles legacy booleans and new string values from dropdown.
 --- @return integer 0–2
 function addon.Dashboard_GetTextOutlineLevel()
-    if not addon.GetDB then return 1 end
-    local v = addon.GetDB("dashboardTextOutline", 1)
-    -- New string values from dropdown
-    if v == "" then return 0 end
-    if v == "OUTLINE" then return 1 end
-    if v == "THICKOUTLINE" then return 2 end
-    -- Legacy boolean migration
-    if v == true then return 1 end
-    if v == false then return 0 end
-    local n = tonumber(v)
-    if not n then return 1 end
-    return math.max(0, math.min(2, math.floor(n + 0.5)))
+    local lev = readOutlineConfig()
+    return lev
+end
+
+--- Whether the SLUG (SDF) flag is enabled for dashboard text.
+--- @return boolean
+function addon.Dashboard_HasTextSlugFlag()
+    local _, slug = readOutlineConfig()
+    return slug
 end
 
 --- Saved shadow strength 0–100 (opacity %; migrates legacy boolean on=true → 65).
@@ -172,34 +191,38 @@ function addon.Dashboard_ShouldUseTextShadow()
     return addon.Dashboard_GetTextShadowStrength() > 0
 end
 
+local function composeFlags(outline, slug)
+    if slug then
+        if outline == "" then return "SLUG" end
+        return outline .. ", SLUG"
+    end
+    return outline
+end
+
 --- Font outline flags for widget-style dashboard chrome from outline level.
 --- @return string
 function addon.Dashboard_GetWidgetOutlineFlags()
-    local lev = addon.Dashboard_GetTextOutlineLevel()
+    local lev, slug = readOutlineConfig()
+    local outline = ""
     if lev >= 2 then
-        return "THICKOUTLINE"
+        outline = "THICKOUTLINE"
+    elseif lev >= 1 then
+        outline = "OUTLINE"
     end
-    if lev >= 1 then
-        return "OUTLINE"
-    end
-    return ""
+    return composeFlags(outline, slug)
 end
 
 --- Outline for dashboard chrome after offset (≥14px when level > 0; thick at level 2).
+--- SLUG is preserved at all sizes since SDF rendering benefits small text most.
 --- @param effSize number
 --- @return string
 function addon.Dashboard_OutlineFlagsForSize(effSize)
-    local lev = addon.Dashboard_GetTextOutlineLevel()
-    if lev <= 0 then
-        return ""
+    local lev, slug = readOutlineConfig()
+    local outline = ""
+    if lev > 0 and effSize >= 14 then
+        outline = (lev >= 2) and "THICKOUTLINE" or "OUTLINE"
     end
-    if effSize < 14 then
-        return ""
-    end
-    if lev >= 2 then
-        return "THICKOUTLINE"
-    end
-    return "OUTLINE"
+    return composeFlags(outline, slug)
 end
 
 --- Apply or clear drop shadow from strength 0–100 (no-op for non–FontString types).


### PR DESCRIPTION
## Summary
- Add SLUG, SLUG Outline, and SLUG Thick Outline choices to the shared outline dropdown options
- Preserve outline dropdown ordering so regular Outline/Thick Outline stay above SLUG variants
- Allow dashboard text outline validation to accept SLUG values

Closes #184

## Testing
- Verified `git diff --check` passes
- Manually tested the outline dropdown ordering in-game during development