### PR TITLE
fix(axis): honour Dashboard Font on Welcome and News content

### DIFF
--- a/options/dashboard/DashboardUtil.lua
+++ b/options/dashboard/DashboardUtil.lua
@@ -88,6 +88,21 @@ local DASHBOARD_TEXT_SHADOW_OFFSET_X = 1
 local DASHBOARD_TEXT_SHADOW_OFFSET_Y = -1
 local DASHBOARD_TEXT_SHADOW_ALPHA_MAX = 0.85
 
+--- Detect CJK / Hangul / Kana via UTF-8 leading-byte scan (0xE3..0xED). Trail bytes for those
+--- sequences are 0x80..0xBF, which doesn't overlap, so the scan is exact for Lua 5.1 strings.
+--- @param text string|nil
+--- @return boolean
+function addon.Dashboard_TextNeedsExtendedScript(text)
+    if type(text) ~= "string" or text == "" then return false end
+    for i = 1, #text do
+        local b = string.byte(text, i)
+        if b and b >= 0xE3 and b <= 0xED then
+            return true
+        end
+    end
+    return false
+end
+
 --- Default font when dashboardFontPath is unset (matches Focus/options widget default).
 --- @return string
 function addon.Dashboard_GetDefaultDashboardFontPath()
@@ -302,12 +317,14 @@ function addon.ApplyDashboardTypography()
             if fs and fs.SetFont then
                 local eff = math.max(DASHBOARD_TYPO_MIN_PX, math.floor(body + ((e.base or 13) - 13) + 0.5))
                 if e.extendedScriptFont then
-                    local okExt = pcall(function()
-                        fs:SetFont(DASHBOARD_WELCOME_EXTENDED_SCRIPT_FONT, eff, "")
+                    local needsExt = addon.Dashboard_TextNeedsExtendedScript(fs:GetText())
+                    local target = needsExt and DASHBOARD_WELCOME_EXTENDED_SCRIPT_FONT or path
+                    local ok = pcall(function()
+                        fs:SetFont(target, eff, "")
                     end)
-                    if not okExt then
+                    if not ok then
                         pcall(function()
-                            fs:SetFont(path, eff, "")
+                            fs:SetFont(DASHBOARD_WELCOME_EXTENDED_SCRIPT_FONT, eff, "")
                         end)
                     end
                 else
@@ -408,25 +425,36 @@ end
 --- @param reg table|nil Optional typography registry from dashboard frame build.
 --- @return FontString
 function addon.Dashboard_MakeWelcomeMixedScriptText(parent, text, size, r, g, b, justify, reg)
-    local path = addon.Dashboard_ResolveSavedDashboardFontPath(
-        (addon.GetDB and addon.GetDB("dashboardFontPath", addon.Dashboard_GetDefaultDashboardFontPath())) or addon.Dashboard_GetDefaultDashboardFontPath()
-    )
-    local eff = addon.Dashboard_EffectiveDashboardFontSize(size)
     local fs = parent:CreateFontString(nil, "OVERLAY")
-    local ok = pcall(function()
-        fs:SetFont(DASHBOARD_WELCOME_EXTENDED_SCRIPT_FONT, eff, "")
-    end)
-    if not ok then
-        ok = pcall(function()
-            fs:SetFont(path, eff, "")
-        end)
+
+    -- Pick font based on the text we're about to render: user dashboard font when there's
+    -- no CJK/Hangul/Kana content, otherwise Blizzard 2002 so contributor names render without
+    -- tofu squares. Must run BEFORE SetText, since SetText errors if no font is set yet.
+    local function applyFontForText(txt)
+        local userPath = addon.Dashboard_ResolveSavedDashboardFontPath(
+            (addon.GetDB and addon.GetDB("dashboardFontPath", addon.Dashboard_GetDefaultDashboardFontPath())) or addon.Dashboard_GetDefaultDashboardFontPath()
+        )
+        local eff = addon.Dashboard_EffectiveDashboardFontSize(size)
+        local needsExt = addon.Dashboard_TextNeedsExtendedScript(txt)
+        local target = needsExt and DASHBOARD_WELCOME_EXTENDED_SCRIPT_FONT or userPath
+        local ok = pcall(function() fs:SetFont(target, eff, "") end)
+        if not ok then
+            ok = pcall(function() fs:SetFont(DASHBOARD_WELCOME_EXTENDED_SCRIPT_FONT, eff, "") end)
+        end
+        if not ok then
+            pcall(function() fs:SetFont("Fonts\\ARIALN.TTF", eff, "") end)
+        end
     end
-    if not ok then
-        pcall(function()
-            fs:SetFont("Fonts\\ARIALN.TTF", eff, "")
-        end)
+
+    -- Per-instance SetText override: re-pick the font for the incoming text first,
+    -- then defer to the original SetText so it has a valid font to render against.
+    local origSetText = fs.SetText
+    fs.SetText = function(self, txt)
+        applyFontForText(txt)
+        origSetText(self, txt)
     end
-    fs:SetText(text)
+
+    fs:SetText(text or "")
     fs:SetTextColor(r, g, b)
     if justify then fs:SetJustifyH(justify) end
     addon.Dashboard_RegisterTypographyFontString(reg, fs, size, "", nil, true)


### PR DESCRIPTION
Closes #197

## Summary

Welcome and News body copy now respects the user's selected Dashboard Font instead of being unconditionally rendered in Blizzard `Fonts\2002.TTF`. The 2002 fallback is preserved — but only for FontStrings whose actual text contains CJK/Hangul/Kana (e.g. contributor names in patch notes).

## Implementation notes

- Added `addon.Dashboard_TextNeedsExtendedScript(text)` — UTF-8 byte scan for leading bytes `0xE3..0xED` (covers CJK Unified Ideographs, Hiragana, Katakana, Hangul Jamo, Hangul Syllables). Trail bytes for those sequences are `0x80..0xBF`, so the scan is exact (no false positives from Latin/emoji content).
- `Dashboard_MakeWelcomeMixedScriptText` now picks the font per-text and overrides `fs:SetText` per-instance so the choice re-evaluates whenever content changes. The override calls `applyFontForText(txt)` *before* `origSetText` so the FontString always has a valid font when text is set (avoids the `FontString:SetText(): Font not set` error).
- `ApplyDashboardTypography`'s `extendedScriptFont` branch checks `fs:GetText()` at apply time and selects user font vs 2002 accordingly. Safety fallback to 2002 on `pcall` failure preserved.
- Single file changed: `options/dashboard/DashboardUtil.lua`. No new options, no DB migration, no locale strings.

## Test plan

- [ ] `/reload` → open Dashboard → Welcome and News tabs render in the user's currently-selected dashboard font (Welcome hero body, "Start here" intro, news editorial body, footer) — not Blizzard 2002.
- [ ] **Axis → Dashboard → Typography → Dashboard Font** → pick a noticeably different font → Welcome and News content restyles live (no `/reload`).
- [ ] Switch back to default → reverts live.
- [ ] **Dashboard Text Size** slider → Welcome/News body resizes proportionally (size scaling intact).
- [ ] **Module Guide** tab — body bullets / intros follow the user font (they share `MakeDashboardWelcomeMixedScriptText`).
- [ ] **Patch Notes** contributor names with CJK glyphs (e.g. "김철수") still render correctly with 2002 fallback.
- [ ] Heading Colour option from #200 still works.
- [ ] No taint risk (unsecured options/UI).