### PR TITLE
fix(focus): apply bar texture and colour changes live

### DIFF
--- a/options/OptionsData.lua
+++ b/options/OptionsData.lua
@@ -575,6 +575,10 @@ function OptionsData_NotifyMainAddon()
     elseif _G.HorizonSuite_ApplyDimensions then _G.HorizonSuite_ApplyDimensions() end
     if addon.ApplyBackdropOpacity then addon.ApplyBackdropOpacity() end
     if addon.ApplyBorderVisibility then addon.ApplyBorderVisibility() end
+    -- Re-apply colours and bar textures on visible entries; FullLayout repositions
+    -- but does not re-run the per-entry renderer that calls SetTexture, so without
+    -- this call texture/colour changes wait for an aggregator pass or /reload.
+    if addon.ApplyFocusColors then addon.ApplyFocusColors() end
     if addon.RequestRefresh then addon.RequestRefresh()
     elseif _G.HorizonSuite_RequestRefresh then _G.HorizonSuite_RequestRefresh() end
     local fullLayout = addon.FullLayout or _G.HorizonSuite_FullLayout


### PR DESCRIPTION
Closes #198

## Summary

Bar texture (and the broader colour cluster — bar fill colour, bar label colour, section header colours, entry text colours) now apply live when changed in options. Previously these changes were stranded until a quest event re-aggregated entries or the user `/reload`ed.

## Implementation notes

- Root cause: `OptionsData_NotifyMainAddon` (the heavy dispatcher fired after every Focus `setDB`) was missing `addon.ApplyFocusColors()`. `FullLayout` re-aggregates and re-positions entries but does *not* re-run the per-entry renderer that calls `SetTexture` — so `progressBarTexture` reads were stranded.
- The sibling `NotifyMainAddon_Live` (used during live colour-picker drag) already calls `ApplyFocusColors`, proving it's safe to call repeatedly with frames mid-render. We just needed it on the heavy dispatcher too.
- `ApplyFocusColors` (FocusLayout.lua:1494) iterates section pool + visible entries and calls `addon.ApplyProgressBarFillTexture` per visible bar, which re-reads `progressBarTexture` from the DB. So the one-line addition covers bar texture, bar fill colour, bar label colour, section header colours, divider colours, and entry text colours.
- Combat-safe: `SetTextColor` and `SetTexture` are unsecured. `FullLayout` is still gated on `InCombatLockdown()` immediately after, so layout-affecting changes still defer correctly.
- Single file changed: `options/OptionsData.lua` (+4 lines including a comment).

## Test plan

- [ ] `/reload` → open Focus → baseline rendering unchanged.
- [ ] **Axis → Focus → Progress Bars → Bar Texture** → switch from `Solid` to a SharedMedia bar (e.g. `Smooth` / `Aluminum`). Visible quest progress bars repaint immediately, no `/reload`.
- [ ] Cycle through several textures rapidly — each applies live.
- [ ] Toggle **Use Category Colour** for progress bars → fill colour switches live.
- [ ] Drag the **progress-bar fill colour** picker — live drag still works (no regression on the existing live path).
- [ ] Change a **section-header colour** → headers recolour live.
- [ ] In combat: change bar texture → `FullLayout` is skipped under combat lockdown, but `ApplyFocusColors` still fires → texture updates, no taint warnings.
- [ ] Heading Colour (#200) and Welcome/News font (#201) still work.