### PR TITLE
feat(axis): standard minimap button mode for Horizon icon (#9)

### DIFF
--- a/core/Config.lua
+++ b/core/Config.lua
@@ -305,6 +305,10 @@ addon.ATLAS_QUEST_IMPORTANT = "importantavailablequesticon"
 addon.ATLAS_QUEST_LEGENDARY = "UI-QuestPoiLegendary-QuestBang"
 addon.ATLAS_QUEST_PVP = "questlog-questtypeicon-pvp"
 
+-- Circular alpha-mask FileDataID (Blizzard's "MASK_CIRCULAR_V"). Used by Vista for the
+-- minimap mask and by MinimapButton to round the Horizon icon when vistaCircular is on.
+addon.MASK_CIRCULAR_FILEDATAID = 186178
+
 addon.CATEGORY_TO_GROUP = {
     COMPLETE  = "COMPLETE",
     DUNGEON   = "DUNGEON",

--- a/core/MinimapButton.lua
+++ b/core/MinimapButton.lua
@@ -54,16 +54,35 @@ end
 local DEFAULT_ANCHOR = "BOTTOMLEFT"
 local DEFAULT_X, DEFAULT_Y = 2, 2
 
--- Standalone minimap child: tooltip anchor; Vista proxies pass ANCHOR_BOTTOMLEFT via ShowGameTooltip.
-local STANDALONE_TOOLTIP_ANCHOR = "ANCHOR_LEFT"
+-- Standalone minimap child: tooltip anchor flips to the opposite quadrant of the button so it
+-- never clips off-screen — same idea LibDBIcon uses (`getAnchors`, BugSack/Libs/LibDBIcon-1.0/
+-- LibDBIcon-1.0.lua:60). Vista proxies still pass ANCHOR_BOTTOMLEFT explicitly.
+--   * y in upper half → tooltip below (ANCHOR_BOTTOM*); lower half → above (ANCHOR_TOP*).
+--   * x in left third → tooltip extends right (*RIGHT); right third → extends left (*LEFT);
+--     middle third → no L/R suffix.
+local function PickStandaloneTooltipAnchor(ownerFrame)
+    if not ownerFrame or not UIParent then return "ANCHOR_LEFT" end
+    local x, y = ownerFrame:GetCenter()
+    if not x or not y then return "ANCHOR_LEFT" end
+    local uw = UIParent:GetWidth()  or 0
+    local uh = UIParent:GetHeight() or 0
+    if uw == 0 or uh == 0 then return "ANCHOR_LEFT" end
+    local v = (y > uh / 2) and "BOTTOM" or "TOP"
+    local h
+    if x < uw / 3 then       h = "RIGHT"
+    elseif x > uw * 2 / 3 then h = "LEFT"
+    else                     h = ""
+    end
+    return "ANCHOR_" .. v .. h
+end
 
 --- Show Horizon minimap tooltip anchored to the given frame (standalone button or Vista proxy).
 --- @param ownerFrame Frame
---- @param anchor string|nil GameTooltip anchor token; default STANDALONE_TOOLTIP_ANCHOR
+--- @param anchor string|nil GameTooltip anchor token; defaults to a quadrant-aware anchor for the standalone btn.
 --- @return nil
 local function ShowGameTooltip(ownerFrame, anchor)
     if not GameTooltip or not ownerFrame then return end
-    anchor = anchor or STANDALONE_TOOLTIP_ANCHOR
+    anchor = anchor or PickStandaloneTooltipAnchor(ownerFrame)
     GameTooltip:SetOwner(ownerFrame, anchor)
     GameTooltip:ClearLines()
     local title = (addon.BrandDisplay and addon.BrandDisplay.minimapTooltipTitle) or "Horizon"
@@ -449,7 +468,7 @@ local function CreateButton()
             self:SetAlpha(1)
         end
         self._hsTooltipStick = true
-        ShowGameTooltip(self, STANDALONE_TOOLTIP_ANCHOR)
+        ShowGameTooltip(self)
     end)
     btn:SetScript("OnLeave", function()
         btn._hsTooltipStick = nil
@@ -487,7 +506,7 @@ local function CreateButton()
         end
         -- Re-anchor tooltip every frame while hovering (minimap resize / drag moves the button).
         if btn and btn._hsTooltipStick and GameTooltip and GameTooltip:GetOwner() == btn then
-            GameTooltip:SetOwner(btn, STANDALONE_TOOLTIP_ANCHOR)
+            GameTooltip:SetOwner(btn, PickStandaloneTooltipAnchor(btn))
             GameTooltip:Show()
         end
     end)

--- a/core/MinimapButton.lua
+++ b/core/MinimapButton.lua
@@ -26,6 +26,8 @@ local btn
 local hoverZone   -- invisible frame over minimap to detect mouse enter/leave
 local iconMask    -- circular MaskTexture; created lazily the first time circular mode is on
 local ringBorder  -- gold ring overlay (Blizzard's standard minimap button frame) shown in circular mode
+local dragHelper  -- separate Frame with OnUpdate that snaps btn to minimap edge while dragging
+local DEFAULT_ANGLE_RAD = math.rad(225)  -- bottom-left, mirroring the legacy DEFAULT_ANCHOR corner
 -- LibDBIcon proportions: icon ~64% of button (centered with insets); ring ~174% anchored TOPLEFT.
 -- The MiniMap-TrackingBorder texture's visible ring artwork is calibrated for these ratios — at
 -- TOPLEFT(0,0) with size 1.74x the button, the ring's inner opening lands around the inset icon.
@@ -200,17 +202,65 @@ local function ApplyShape()
     end
 end
 
+-- True when the minimap silhouette is a circle. Default WoW minimaps are round; when Vista is
+-- enabled we follow its `vistaCircular` setting instead.
+local function MinimapIsRoundShape()
+    if addon.IsModuleEnabled and addon:IsModuleEnabled("vista") then
+        return addon.GetDB and addon.GetDB("vistaCircular", false) and true or false
+    end
+    return true
+end
+
+-- Offset from Minimap CENTER to place the button on the minimap's perimeter at `angle` radians.
+-- Round case: button center sits on the circular edge (half the icon overlaps the minimap, half
+-- overhangs — matches Blizzard's calendar/clock placement). Square case: angle ray clamped to box.
+local function GetEdgePosition(angle)
+    local mw = (Minimap and Minimap:GetWidth()) or 140
+    local mh = (Minimap and Minimap:GetHeight()) or 140
+    local cosA, sinA = math.cos(angle), math.sin(angle)
+    local hw, hh = mw / 2, mh / 2
+    if MinimapIsRoundShape() then
+        return cosA * hw, sinA * hh
+    end
+    local tx = (cosA == 0) and math.huge or (hw / math.abs(cosA))
+    local ty = (sinA == 0) and math.huge or (hh / math.abs(sinA))
+    local t = math.min(tx, ty)
+    return cosA * t, sinA * t
+end
+
+-- Resolve the saved angle, migrating from the legacy `minimapButtonX/Y` keys on first read so
+-- existing users land at the closest edge position rather than jumping to the default corner.
+local function ResolveButtonAngle()
+    if not addon.GetDB then return DEFAULT_ANGLE_RAD end
+    local saved = tonumber(addon.GetDB("minimapButtonAngle", nil))
+    if saved then return saved end
+    local x = tonumber(addon.GetDB("minimapButtonX", nil))
+    local y = tonumber(addon.GetDB("minimapButtonY", nil))
+    if x and y and (x ~= 0 or y ~= 0) then
+        local migrated = math.atan2(y, x)
+        if addon.SetDB then addon.SetDB("minimapButtonAngle", migrated) end
+        return migrated
+    end
+    return DEFAULT_ANGLE_RAD
+end
+
 local function ApplyPosition()
     if not btn or not Minimap then return end
     if vistaCollectedStandaloneHidden then return end
     btn:SetSize(GetMinimapButtonDisplayPixelSize(), GetMinimapButtonDisplayPixelSize())
-    local savedX = addon.GetDB and tonumber(addon.GetDB("minimapButtonX", nil))
-    local savedY = addon.GetDB and tonumber(addon.GetDB("minimapButtonY", nil))
+    local circular = addon.GetDB and addon.GetDB("minimapButtonCircular", false)
     btn:ClearAllPoints()
-    if savedX and savedY then
-        btn:SetPoint("CENTER", Minimap, "CENTER", savedX, savedY)
+    if circular then
+        local x, y = GetEdgePosition(ResolveButtonAngle())
+        btn:SetPoint("CENTER", Minimap, "CENTER", x, y)
     else
-        btn:SetPoint(DEFAULT_ANCHOR, Minimap, DEFAULT_ANCHOR, DEFAULT_X, DEFAULT_Y)
+        local savedX = addon.GetDB and tonumber(addon.GetDB("minimapButtonX", nil))
+        local savedY = addon.GetDB and tonumber(addon.GetDB("minimapButtonY", nil))
+        if savedX and savedY then
+            btn:SetPoint("CENTER", Minimap, "CENTER", savedX, savedY)
+        else
+            btn:SetPoint(DEFAULT_ANCHOR, Minimap, DEFAULT_ANCHOR, DEFAULT_X, DEFAULT_Y)
+        end
     end
     ApplyShape()
     UpdatePatchNotesBadgeInternal()
@@ -310,19 +360,59 @@ local function CreateButton()
     end)
     btn:SetScript("OnDragStart", function(self)
         if IsMinimapButtonLocked() or InCombatLockdown() then return end
-        self:StartMoving()
+        local circular = addon.GetDB and addon.GetDB("minimapButtonCircular", false)
+        if circular then
+            -- Magnetic drag: dragHelper's OnUpdate keeps the button glued to the minimap edge
+            -- under the cursor angle. Initialised lazily to keep load-time work minimal.
+            if not dragHelper then
+                dragHelper = CreateFrame("Frame")
+                dragHelper:Hide()
+                dragHelper:SetScript("OnUpdate", function(self)
+                    local target = self.target
+                    if not target or not Minimap then self:Hide(); return end
+                    local mx, my = Minimap:GetCenter()
+                    if not mx then return end
+                    local cx, cy = GetCursorPosition()
+                    local scale = (Minimap.GetEffectiveScale and Minimap:GetEffectiveScale()) or 1
+                    if scale == 0 then scale = 1 end
+                    cx, cy = cx / scale, cy / scale
+                    local angle = math.atan2(cy - my, cx - mx)
+                    local x, y = GetEdgePosition(angle)
+                    target:ClearAllPoints()
+                    target:SetPoint("CENTER", Minimap, "CENTER", x, y)
+                end)
+            end
+            dragHelper.target = self
+            dragHelper:Show()
+        else
+            self:StartMoving()
+        end
     end)
     btn:SetScript("OnDragStop", function(self)
-        self:StopMovingOrSizing()
-        local mx, my = Minimap:GetCenter()
-        local px, py = self:GetCenter()
-        local ox, oy = px - mx, py - my
-        if addon.SetDB then
-            addon.SetDB("minimapButtonX", ox)
-            addon.SetDB("minimapButtonY", oy)
+        local circular = addon.GetDB and addon.GetDB("minimapButtonCircular", false)
+        if circular then
+            if dragHelper then dragHelper.target = nil; dragHelper:Hide() end
+            local mx, my = Minimap:GetCenter()
+            local px, py = self:GetCenter()
+            if mx and px then
+                local angle = math.atan2(py - my, px - mx)
+                if addon.SetDB then addon.SetDB("minimapButtonAngle", angle) end
+                local nx, ny = GetEdgePosition(angle)
+                self:ClearAllPoints()
+                self:SetPoint("CENTER", Minimap, "CENTER", nx, ny)
+            end
+        else
+            self:StopMovingOrSizing()
+            local mx, my = Minimap:GetCenter()
+            local px, py = self:GetCenter()
+            local ox, oy = px - mx, py - my
+            if addon.SetDB then
+                addon.SetDB("minimapButtonX", ox)
+                addon.SetDB("minimapButtonY", oy)
+            end
+            self:ClearAllPoints()
+            self:SetPoint("CENTER", Minimap, "CENTER", ox, oy)
         end
-        self:ClearAllPoints()
-        self:SetPoint("CENTER", Minimap, "CENTER", ox, oy)
     end)
     btn:SetScript("OnEnter", function(self)
         if MinimapHoverFadeEnabled() then

--- a/core/MinimapButton.lua
+++ b/core/MinimapButton.lua
@@ -23,8 +23,10 @@ local FADE_IN_DUR  = addon.FOCUS_ANIM and addon.FOCUS_ANIM.minimapFadeIn  or 0.2
 local FADE_OUT_DUR = addon.FOCUS_ANIM and addon.FOCUS_ANIM.minimapFadeOut or 0.3
 
 local btn
-local hoverZone  -- invisible frame over minimap to detect mouse enter/leave
-local iconMask   -- circular MaskTexture; created lazily the first time vistaCircular is on
+local hoverZone   -- invisible frame over minimap to detect mouse enter/leave
+local iconMask    -- circular MaskTexture; created lazily the first time circular mode is on
+local ringBorder  -- gold ring overlay (Blizzard's standard minimap button frame) shown in circular mode
+local RING_SCALE = 1.5  -- ring texture is centered on btn at 1.5x button size, matching calendar/clock buttons
 local vistaCollectedStandaloneHidden = false
 -- Vista proxy for HorizonSuiteMinimapButton when the icon is in the collector UI.
 local horizonPatchNotesProxy
@@ -149,11 +151,11 @@ local function UpdatePatchNotesBadgeInternal()
     end
 end
 
--- Match the standalone Horizon icon to the minimap silhouette: when Vista is set to circular,
--- mask btn.icon with the same alpha asset Vista uses on the minimap itself; otherwise leave it square.
+-- When `minimapButtonCircular` is on, mask btn.icon to a circle (same alpha asset Vista uses on the minimap)
+-- and draw the standard Blizzard gold ring overlay so it matches calendar/clock-style minimap buttons.
 local function ApplyShape()
     if not btn or not btn.icon then return end
-    local circular = addon.GetDB and addon.GetDB("vistaCircular", false)
+    local circular = addon.GetDB and addon.GetDB("minimapButtonCircular", false)
     if circular then
         if not iconMask then
             iconMask = btn:CreateMaskTexture(nil, "BACKGROUND")
@@ -162,8 +164,17 @@ local function ApplyShape()
             iconMask:SetAllPoints(btn.icon)
         end
         btn.icon:AddMaskTexture(iconMask)
-    elseif iconMask then
-        btn.icon:RemoveMaskTexture(iconMask)
+        if not ringBorder then
+            ringBorder = btn:CreateTexture(nil, "OVERLAY")
+            ringBorder:SetTexture("Interface\\Minimap\\MiniMap-TrackingBorder")
+            ringBorder:SetPoint("CENTER", btn, "CENTER", 0, 0)
+        end
+        local w, h = btn:GetWidth(), btn:GetHeight()
+        ringBorder:SetSize((w or 22) * RING_SCALE, (h or 22) * RING_SCALE)
+        ringBorder:Show()
+    else
+        if iconMask then btn.icon:RemoveMaskTexture(iconMask) end
+        if ringBorder then ringBorder:Hide() end
     end
 end
 

--- a/core/MinimapButton.lua
+++ b/core/MinimapButton.lua
@@ -30,16 +30,15 @@ local btn
 local hoverZone     -- invisible frame over minimap to detect mouse enter/leave
 local iconMask      -- circular MaskTexture; created lazily the first time circular mode is on
 local ringBorder    -- gold ring overlay (Blizzard's standard minimap button frame) shown in circular mode
-local hoverGlow     -- HIGHLIGHT-layer texture shown on mouseover in circular mode (additive gold glow)
 local dragHelper    -- separate Frame with OnUpdate that snaps btn to minimap edge while dragging
 local DEFAULT_ANGLE_RAD = math.rad(225)  -- bottom-left, mirroring the legacy DEFAULT_ANCHOR corner
--- LibDBIcon proportions: icon ~64% of button (centered with insets); ring ~174% anchored TOPLEFT.
--- The MiniMap-TrackingBorder texture's visible ring artwork is calibrated for these ratios — at
--- TOPLEFT(0,0) with size 1.74x the button, the ring's inner opening lands around the inset icon.
-local ICON_INSET_FRAC_X = 7 / 31    -- LibDBIcon: icon TOPLEFT is (7, -5) on a 31x31 button
-local ICON_INSET_FRAC_Y = 5 / 31
-local ICON_SIZE_FRAC    = 20 / 31   -- icon is 20x20 inside a 31x31 button
-local RING_SIZE_FRAC    = 54 / 31   -- border is 54x54 anchored TOPLEFT(0, 0)
+-- LibDBIcon proportions for WOW_PROJECT_MAINLINE (retail / Midnight): icon 18x18 CENTER-anchored,
+-- border 50x50 TOPLEFT(0, 0), inside a 31x31 button. The MiniMap-TrackingBorder texture's visible
+-- artwork is calibrated for exactly these dimensions — see Libs/LibDBIcon-1.0/LibDBIcon-1.0.lua
+-- in BugSack (`ResetButtonIcon` / `ResetButtonBorder`, lines 526–617). Different numbers leave the
+-- icon off-centre or the ring loose around it.
+local ICON_SIZE_FRAC = 18 / 31
+local RING_SIZE_FRAC = 50 / 31
 local vistaCollectedStandaloneHidden = false
 -- Vista proxy for HorizonSuiteMinimapButton when the icon is in the collector UI.
 local horizonPatchNotesProxy
@@ -187,12 +186,12 @@ local function ApplyShape()
     local w = btn:GetWidth() or 22
     local h = btn:GetHeight() or 22
     if circular then
-        -- Resize and re-anchor btn.icon to the LibDBIcon-style inset so the visible logo lands inside
-        -- the gold ring's inner opening. SetTexCoord(0,1,0,1) drops the original 8% square crop —
+        -- Resize and re-anchor btn.icon to LibDBIcon's mainline proportions so the visible logo lands
+        -- inside the gold ring's inner opening. SetTexCoord(0,1,0,1) drops the original 8% square crop —
         -- the alpha mask now defines the visible silhouette, so cropping would just clip the logo.
         btn.icon:ClearAllPoints()
         btn.icon:SetSize(w * ICON_SIZE_FRAC, h * ICON_SIZE_FRAC)
-        btn.icon:SetPoint("TOPLEFT", btn, "TOPLEFT", w * ICON_INSET_FRAC_X, -h * ICON_INSET_FRAC_Y)
+        btn.icon:SetPoint("CENTER", btn, "CENTER", 0, 0)
         btn.icon:SetTexCoord(0, 1, 0, 1)
 
         if not iconMask then
@@ -213,16 +212,9 @@ local function ApplyShape()
         ringBorder:SetPoint("TOPLEFT", btn, "TOPLEFT", 0, 0)
         ringBorder:Show()
 
-        -- Mouseover glow: standard Blizzard minimap-button highlight, additive blend.
-        -- HIGHLIGHT-layer textures are auto-shown by WoW only while the cursor is over the button.
-        if not hoverGlow then
-            hoverGlow = btn:CreateTexture(nil, "HIGHLIGHT")
-            hoverGlow:SetTexture("Interface\\Minimap\\UI-Minimap-ZoomButton-Highlight")
-            hoverGlow:SetBlendMode("ADD")
-        end
-        hoverGlow:ClearAllPoints()
-        hoverGlow:SetAllPoints(btn)
-        hoverGlow:Show()
+        -- Mouseover glow: same FileDataID LibDBIcon installs via SetHighlightTexture, which puts
+        -- the texture on the auto-managed HIGHLIGHT layer (only visible while cursor is over btn).
+        btn:SetHighlightTexture(136477)  -- "Interface\\Minimap\\UI-Minimap-ZoomButton-Highlight"
     else
         -- Restore the square presentation: full-button icon with the original 8% TexCoord crop.
         btn.icon:ClearAllPoints()
@@ -230,7 +222,7 @@ local function ApplyShape()
         btn.icon:SetTexCoord(0.08, 0.92, 0.08, 0.92)
         if iconMask then btn.icon:RemoveMaskTexture(iconMask) end
         if ringBorder then ringBorder:Hide() end
-        if hoverGlow then hoverGlow:Hide() end
+        btn:SetHighlightTexture(nil)
     end
 end
 

--- a/core/MinimapButton.lua
+++ b/core/MinimapButton.lua
@@ -15,6 +15,10 @@ if not Minimap then return end
 local VISTA_ADDON_BTN_MIN = 16
 local VISTA_ADDON_BTN_MAX = 48
 local VISTA_ADDON_BTN_DEFAULT = 26
+-- Blizzard / LibDBIcon canonical addon-minimap-button size: 31px button, 54px ring. Used only when
+-- `minimapButtonCircular` is on and the button is standalone, so the stock-button look matches
+-- calendar/clock dimensions. Vista-collected proxy continues to use the slider (`vistaAddonBtnSize`).
+local STANDARD_CIRCULAR_BTN_PX = 31
 
 local ICON_PATH = "Interface\\AddOns\\HorizonSuite\\HorizonLogo"
 local FALLBACK_ICON = "Interface\\Icons\\INV_Misc_QuestionMark"
@@ -106,6 +110,21 @@ local function GetMinimapButtonDisplayPixelSize()
         return enlarged
     end
     return base
+end
+
+-- Size used for the standalone btn frame. When circular mode is on, override to Blizzard's
+-- canonical 31px (with the same patch-notes-unread enlarge multiplier on top). Vista's
+-- collected proxy keeps using `GetMinimapButtonDisplayPixelSize` so the bar stays uniform.
+local function GetStandalonePixelSize()
+    if addon.GetDB and addon.GetDB("minimapButtonCircular", false) then
+        local base = STANDARD_CIRCULAR_BTN_PX
+        if addon.PatchNotes_HasUnread and addon.PatchNotes_HasUnread() then
+            local enlarged = math.floor(base * UNREAD_MINIMAP_SIZE_MULT + 0.5)
+            return math.max(enlarged, base + 2)
+        end
+        return base
+    end
+    return GetMinimapButtonDisplayPixelSize()
 end
 
 -- ~25% of minimap / Vista proxy button — top-right corner exclamation-style marker.
@@ -247,7 +266,8 @@ end
 local function ApplyPosition()
     if not btn or not Minimap then return end
     if vistaCollectedStandaloneHidden then return end
-    btn:SetSize(GetMinimapButtonDisplayPixelSize(), GetMinimapButtonDisplayPixelSize())
+    local size = GetStandalonePixelSize()
+    btn:SetSize(size, size)
     local circular = addon.GetDB and addon.GetDB("minimapButtonCircular", false)
     btn:ClearAllPoints()
     if circular then
@@ -335,7 +355,8 @@ local function CreateButton()
     if btn then return btn end
 
     btn = CreateFrame("Button", "HorizonSuiteMinimapButton", Minimap)
-    btn:SetSize(GetMinimapButtonDisplayPixelSize(), GetMinimapButtonDisplayPixelSize())
+    local initSize = GetStandalonePixelSize()
+    btn:SetSize(initSize, initSize)
     btn:SetFrameStrata("MEDIUM")
     btn:SetFrameLevel(Minimap:GetFrameLevel() + 5)
     btn:SetClampedToScreen(true)

--- a/core/MinimapButton.lua
+++ b/core/MinimapButton.lua
@@ -26,7 +26,13 @@ local btn
 local hoverZone   -- invisible frame over minimap to detect mouse enter/leave
 local iconMask    -- circular MaskTexture; created lazily the first time circular mode is on
 local ringBorder  -- gold ring overlay (Blizzard's standard minimap button frame) shown in circular mode
-local RING_SCALE = 1.5  -- ring texture is centered on btn at 1.5x button size, matching calendar/clock buttons
+-- LibDBIcon proportions: icon ~64% of button (centered with insets); ring ~174% anchored TOPLEFT.
+-- The MiniMap-TrackingBorder texture's visible ring artwork is calibrated for these ratios — at
+-- TOPLEFT(0,0) with size 1.74x the button, the ring's inner opening lands around the inset icon.
+local ICON_INSET_FRAC_X = 7 / 31    -- LibDBIcon: icon TOPLEFT is (7, -5) on a 31x31 button
+local ICON_INSET_FRAC_Y = 5 / 31
+local ICON_SIZE_FRAC    = 20 / 31   -- icon is 20x20 inside a 31x31 button
+local RING_SIZE_FRAC    = 54 / 31   -- border is 54x54 anchored TOPLEFT(0, 0)
 local vistaCollectedStandaloneHidden = false
 -- Vista proxy for HorizonSuiteMinimapButton when the icon is in the collector UI.
 local horizonPatchNotesProxy
@@ -151,28 +157,44 @@ local function UpdatePatchNotesBadgeInternal()
     end
 end
 
--- When `minimapButtonCircular` is on, mask btn.icon to a circle (same alpha asset Vista uses on the minimap)
--- and draw the standard Blizzard gold ring overlay so it matches calendar/clock-style minimap buttons.
+-- When `minimapButtonCircular` is on, shrink btn.icon to LibDBIcon proportions, mask it to a circle,
+-- and overlay Blizzard's MiniMap-TrackingBorder so it matches calendar/clock-style minimap buttons.
 local function ApplyShape()
     if not btn or not btn.icon then return end
     local circular = addon.GetDB and addon.GetDB("minimapButtonCircular", false)
+    local w = btn:GetWidth() or 22
+    local h = btn:GetHeight() or 22
     if circular then
+        -- Resize and re-anchor btn.icon to the LibDBIcon-style inset so the visible logo lands inside
+        -- the gold ring's inner opening. SetTexCoord(0,1,0,1) drops the original 8% square crop —
+        -- the alpha mask now defines the visible silhouette, so cropping would just clip the logo.
+        btn.icon:ClearAllPoints()
+        btn.icon:SetSize(w * ICON_SIZE_FRAC, h * ICON_SIZE_FRAC)
+        btn.icon:SetPoint("TOPLEFT", btn, "TOPLEFT", w * ICON_INSET_FRAC_X, -h * ICON_INSET_FRAC_Y)
+        btn.icon:SetTexCoord(0, 1, 0, 1)
+
         if not iconMask then
             iconMask = btn:CreateMaskTexture(nil, "BACKGROUND")
             iconMask:SetTexture(addon.MASK_CIRCULAR_FILEDATAID,
                 "CLAMPTOBLACKADDITIVE", "CLAMPTOBLACKADDITIVE")
-            iconMask:SetAllPoints(btn.icon)
         end
+        iconMask:ClearAllPoints()
+        iconMask:SetAllPoints(btn.icon)
         btn.icon:AddMaskTexture(iconMask)
+
         if not ringBorder then
             ringBorder = btn:CreateTexture(nil, "OVERLAY")
             ringBorder:SetTexture("Interface\\Minimap\\MiniMap-TrackingBorder")
-            ringBorder:SetPoint("CENTER", btn, "CENTER", 0, 0)
         end
-        local w, h = btn:GetWidth(), btn:GetHeight()
-        ringBorder:SetSize((w or 22) * RING_SCALE, (h or 22) * RING_SCALE)
+        ringBorder:ClearAllPoints()
+        ringBorder:SetSize(w * RING_SIZE_FRAC, h * RING_SIZE_FRAC)
+        ringBorder:SetPoint("TOPLEFT", btn, "TOPLEFT", 0, 0)
         ringBorder:Show()
     else
+        -- Restore the square presentation: full-button icon with the original 8% TexCoord crop.
+        btn.icon:ClearAllPoints()
+        btn.icon:SetAllPoints(btn)
+        btn.icon:SetTexCoord(0.08, 0.92, 0.08, 0.92)
         if iconMask then btn.icon:RemoveMaskTexture(iconMask) end
         if ringBorder then ringBorder:Hide() end
     end

--- a/core/MinimapButton.lua
+++ b/core/MinimapButton.lua
@@ -187,12 +187,14 @@ local function ApplyShape()
     local h = btn:GetHeight() or 22
     if circular then
         -- Resize and re-anchor btn.icon to LibDBIcon's mainline proportions so the visible logo lands
-        -- inside the gold ring's inner opening. SetTexCoord(0,1,0,1) drops the original 8% square crop —
-        -- the alpha mask now defines the visible silhouette, so cropping would just clip the logo.
+        -- inside the gold ring's inner opening. Keep the 8% TexCoord crop the square mode uses:
+        -- LibDBIcon assumes edge-to-edge icon content (Blizzard ability/quest icons), but HorizonLogo
+        -- has transparent padding inside the texture canvas — without the crop, the visible glass is
+        -- smaller than the 18×18 box and a gap appears between the logo and the ring's inner edge.
         btn.icon:ClearAllPoints()
         btn.icon:SetSize(w * ICON_SIZE_FRAC, h * ICON_SIZE_FRAC)
         btn.icon:SetPoint("CENTER", btn, "CENTER", 0, 0)
-        btn.icon:SetTexCoord(0, 1, 0, 1)
+        btn.icon:SetTexCoord(0.08, 0.92, 0.08, 0.92)
 
         if not iconMask then
             iconMask = btn:CreateMaskTexture(nil, "BACKGROUND")

--- a/core/MinimapButton.lua
+++ b/core/MinimapButton.lua
@@ -27,10 +27,11 @@ local FADE_IN_DUR  = addon.FOCUS_ANIM and addon.FOCUS_ANIM.minimapFadeIn  or 0.2
 local FADE_OUT_DUR = addon.FOCUS_ANIM and addon.FOCUS_ANIM.minimapFadeOut or 0.3
 
 local btn
-local hoverZone   -- invisible frame over minimap to detect mouse enter/leave
-local iconMask    -- circular MaskTexture; created lazily the first time circular mode is on
-local ringBorder  -- gold ring overlay (Blizzard's standard minimap button frame) shown in circular mode
-local dragHelper  -- separate Frame with OnUpdate that snaps btn to minimap edge while dragging
+local hoverZone     -- invisible frame over minimap to detect mouse enter/leave
+local iconMask      -- circular MaskTexture; created lazily the first time circular mode is on
+local ringBorder    -- gold ring overlay (Blizzard's standard minimap button frame) shown in circular mode
+local hoverGlow     -- HIGHLIGHT-layer texture shown on mouseover in circular mode (additive gold glow)
+local dragHelper    -- separate Frame with OnUpdate that snaps btn to minimap edge while dragging
 local DEFAULT_ANGLE_RAD = math.rad(225)  -- bottom-left, mirroring the legacy DEFAULT_ANCHOR corner
 -- LibDBIcon proportions: icon ~64% of button (centered with insets); ring ~174% anchored TOPLEFT.
 -- The MiniMap-TrackingBorder texture's visible ring artwork is calibrated for these ratios — at
@@ -211,6 +212,17 @@ local function ApplyShape()
         ringBorder:SetSize(w * RING_SIZE_FRAC, h * RING_SIZE_FRAC)
         ringBorder:SetPoint("TOPLEFT", btn, "TOPLEFT", 0, 0)
         ringBorder:Show()
+
+        -- Mouseover glow: standard Blizzard minimap-button highlight, additive blend.
+        -- HIGHLIGHT-layer textures are auto-shown by WoW only while the cursor is over the button.
+        if not hoverGlow then
+            hoverGlow = btn:CreateTexture(nil, "HIGHLIGHT")
+            hoverGlow:SetTexture("Interface\\Minimap\\UI-Minimap-ZoomButton-Highlight")
+            hoverGlow:SetBlendMode("ADD")
+        end
+        hoverGlow:ClearAllPoints()
+        hoverGlow:SetAllPoints(btn)
+        hoverGlow:Show()
     else
         -- Restore the square presentation: full-button icon with the original 8% TexCoord crop.
         btn.icon:ClearAllPoints()
@@ -218,6 +230,7 @@ local function ApplyShape()
         btn.icon:SetTexCoord(0.08, 0.92, 0.08, 0.92)
         if iconMask then btn.icon:RemoveMaskTexture(iconMask) end
         if ringBorder then ringBorder:Hide() end
+        if hoverGlow then hoverGlow:Hide() end
     end
 end
 

--- a/core/MinimapButton.lua
+++ b/core/MinimapButton.lua
@@ -194,7 +194,7 @@ local function ApplyShape()
         btn.icon:ClearAllPoints()
         btn.icon:SetSize(w * ICON_SIZE_FRAC, h * ICON_SIZE_FRAC)
         btn.icon:SetPoint("CENTER", btn, "CENTER", 0, 0)
-        btn.icon:SetTexCoord(0.08, 0.92, 0.08, 0.92)
+        btn.icon:SetTexCoord(0.15, 0.85, 0.15, 0.85)
 
         if not iconMask then
             iconMask = btn:CreateMaskTexture(nil, "BACKGROUND")

--- a/core/MinimapButton.lua
+++ b/core/MinimapButton.lua
@@ -24,6 +24,7 @@ local FADE_OUT_DUR = addon.FOCUS_ANIM and addon.FOCUS_ANIM.minimapFadeOut or 0.3
 
 local btn
 local hoverZone  -- invisible frame over minimap to detect mouse enter/leave
+local iconMask   -- circular MaskTexture; created lazily the first time vistaCircular is on
 local vistaCollectedStandaloneHidden = false
 -- Vista proxy for HorizonSuiteMinimapButton when the icon is in the collector UI.
 local horizonPatchNotesProxy
@@ -148,6 +149,24 @@ local function UpdatePatchNotesBadgeInternal()
     end
 end
 
+-- Match the standalone Horizon icon to the minimap silhouette: when Vista is set to circular,
+-- mask btn.icon with the same alpha asset Vista uses on the minimap itself; otherwise leave it square.
+local function ApplyShape()
+    if not btn or not btn.icon then return end
+    local circular = addon.GetDB and addon.GetDB("vistaCircular", false)
+    if circular then
+        if not iconMask then
+            iconMask = btn:CreateMaskTexture(nil, "BACKGROUND")
+            iconMask:SetTexture(addon.MASK_CIRCULAR_FILEDATAID,
+                "CLAMPTOBLACKADDITIVE", "CLAMPTOBLACKADDITIVE")
+            iconMask:SetAllPoints(btn.icon)
+        end
+        btn.icon:AddMaskTexture(iconMask)
+    elseif iconMask then
+        btn.icon:RemoveMaskTexture(iconMask)
+    end
+end
+
 local function ApplyPosition()
     if not btn or not Minimap then return end
     if vistaCollectedStandaloneHidden then return end
@@ -160,6 +179,7 @@ local function ApplyPosition()
     else
         btn:SetPoint(DEFAULT_ANCHOR, Minimap, DEFAULT_ANCHOR, DEFAULT_X, DEFAULT_Y)
     end
+    ApplyShape()
     UpdatePatchNotesBadgeInternal()
 end
 
@@ -250,6 +270,7 @@ local function CreateButton()
         icon:SetTexture(FALLBACK_ICON)
     end
     btn.icon = icon
+    ApplyShape()
 
     btn:SetScript("OnClick", function(self, mouseButton)
         ShowOptions()
@@ -361,6 +382,10 @@ end)
 addon.MinimapButton_SetVistaCollected = SetVistaCollected
 addon.MinimapButton_UpdateVisibility = UpdateVisibility
 addon.MinimapButton_ApplyPosition = ApplyPosition
+--- Re-mask the standalone Horizon icon to match Vista's minimap shape (circular vs. square).
+--- Called from Vista's ApplyOptions_Minimap so live shape toggles take effect without /reload.
+--- @return nil
+addon.MinimapButton_ApplyShape = ApplyShape
 addon.MinimapButton_ShowGameTooltip = ShowGameTooltip
 --- Effective minimap button edge size (slightly enlarged when patch notes are unread); Vista proxy matches this.
 --- @return number

--- a/localisation/horizon/deDE.lua
+++ b/localisation/horizon/deDE.lua
@@ -1,6 +1,6 @@
 if GetLocale() ~= "deDE" then return end
 
-local addon = _G.HorizonSuite
+local addon = _G._HorizonSuite_Loading or _G.HorizonSuiteBeta or _G.HorizonSuite
 if not addon then return end
 
 local L = setmetatable({}, { __index = addon.L })
@@ -203,7 +203,17 @@ L["DASH_WELCOME_CONTRIBUTORS_BODY"]                           = [=[Danke an alle
 L["DASH_WELCOME_SUPPORTERS_HEADING"]                          = "Unterstützer"
 L["DASH_WELCOME_SUPPORTERS_BODY"]                             = [=[Vielen Dank an alle, die Horizon Suite über Ko-fi, Patreon und andere Wege unterstützen.]=]
 L["DASH_WELCOME_LOCALISATIONS_HEADING"]                       = "Lokalisierungen"
--- L["DASH_WELCOME_LOCALISATIONS_BODY"] = ... (falls back to enUS until retranslated against new path layout)
+-- L["DASH_WELCOME_LOCALISATIONS_BODY"]                       = [=[The addon UI is localised for:
+-- 
+-- • German (deDE) — `localisation/horizon/deDE.lua`
+-- • English (enUS) — `localisation/horizon/enUS.lua`
+-- • Spanish (esES) — `localisation/horizon/esES.lua`
+-- • French (frFR) — `localisation/horizon/frFR.lua`
+-- • Korean (koKR) — `localisation/horizon/koKR.lua`
+-- • Brazilian Portuguese (ptBR) — `localisation/horizon/ptBR.lua`
+-- • Chinese (zhCN) — `localisation/horizon/zhCN.lua`
+-- 
+-- See contributions/translate.md in the repo for how to contribute. Additional locales are welcome via Discord.]=]
 
 
 -- =====================================================================
@@ -317,6 +327,9 @@ L["FOCUS_CONTENT_TYPES"]                                      = "Inhaltstypen"
 L["FOCUS_DELVES"]                                             = "Tiefen"
 L["FOCUS_DELVES_DUNGEONS"]                                    = "Tiefen & Verliese"
 L["FOCUS_DELVE_COMPLETE"]                                     = "Tiefe abgeschlossen"
+-- L["FOCUS_RITUAL_SITE_TITLE_COUNTERS"]                      = "Ritual Site Title Counters"
+-- L["FOCUS_RITUAL_SITE_TITLE_COUNTERS_DESC"]                 = "Show Ritual Site spoils and deaths beside the scenario title."
+-- L["FOCUS_RITUAL_SITE_TITLE_COUNTERS_TOOLTIP"]              = "Uses the same title-row counter style as Delves when the scenario provides header currency icons."
 L["FOCUS_INTERACTIONS"]                                       = "Interaktionen"
 -- L["FOCUS_LAYOUT_TAB_DESC"]                                 = "Configure and customise settings related to layout."
 L["FOCUS_APPEARANCE_TAB_DESC"]                                = "Darstellung, Abblendung und Listen-Layout (Kopfbereich, Abschnitte, Einträge, Timer, Hervorhebung) des Zielverfolgers."
@@ -377,6 +390,8 @@ L["AXIS_GLOBAL_TOGGLES"]                                      = "Globale Einstel
 -- L["AXIS_GLOBAL_FONT_SECTION"]                              = "Global Font (Coming Soon!)"
 -- L["AXIS_GLOBAL_SCALE_SECTION"]                             = "Global Scale"
 -- L["AXIS_MINIMAP_ICON_SECTION"]                             = "Minimap Icon"
+-- L["AXIS_MINIMAP_ICON_CIRCULAR"]                            = "Circular icon"
+-- L["AXIS_MINIMAP_ICON_CIRCULAR_DESC"]                       = "Round the Horizon minimap icon and add a gold ring border to match calendar, clock, and other circular minimap buttons."
 -- L["AXIS_CLASS_THEME_SECTION"]                              = "Class Theme"
 -- L["AXIS_GLOBAL_CLASS_THEME"]                               = "Global Class Theme"
 -- L["AXIS_CLASS_THEME_DASHBOARD"]                            = "Dashboard"
@@ -406,7 +421,7 @@ L["INSIGHT_SCALE"]                                            = "Insight-Skalier
 L["AXIS_SCALE_INSIGHT_TOOLTIP_MODULE"]                        = "Skalierung für das Insight-Tooltip-Modul (50–200 %)"
 L["CACHE_SCALE"]                                              = "Cache-Skalierung"
 L["AXIS_SCALE_CACHE_LOOT_TOAST_MODULE"]                       = "Skalierung des Cache-Beutebenachrichtungsmoduls (50–200 %)."
--- L["CACHE_FONT"]                                            = "Loot toast font"
+L["CACHE_FONT"]                                               = "Loot toast font"
 -- L["CACHE_FONT_FAMILY"]                                     = "Font family used for loot toast text. Use 'Use global font' to follow the addon-wide font."
 L["AXIS_ENABLE_HORIZON_INSIGHT_MODULE"]                       = "Horizon-Insight-Modul aktivieren"
 L["AXIS_CINEMATIC_TOOLTIPS_CLASS_COLOURS_SPEC_DISPLAY"]       = "Filmische Tooltips mit Klassenfarben, Spezialisierungsanzeige und Fraktionssymbolen."
@@ -987,6 +1002,11 @@ L["DASHBOARD_TYPO_OUTLINE"]                                   = "Schriftkontur d
 L["DASHBOARD_TYPO_OUTLINE_DESC"]                              = "When on, dashboard UI text uses the standard outlined font style. Turn off for a softer, flat look."
 L["DASHBOARD_TYPO_SHADOW"]                                    = "Textschattierung für Dashboard-Text"
 L["DASHBOARD_TYPO_SHADOW_DESC"]                               = "Fügt einen subtilen Schlagschatten hinter dem Dashboard-Text, um die Lesbarkeit zu verbessern."
+-- L["DASHBOARD_TYPO_HEADING_COLOR"]                          = "Heading Colour"
+-- L["DASHBOARD_TYPO_HEADING_COLOR_DESC"]                     = "Colour of the large headings on the Welcome and News tabs. Use a softer tone if pure white feels too bright on HDR displays."
+-- L["DASHBOARD_TYPO_HEADING_COLOR_WHITE"]                    = "White (default)"
+-- L["DASHBOARD_TYPO_HEADING_COLOR_CYAN"]                     = "Cyan (relaxed)"
+-- L["DASHBOARD_TYPO_HEADING_COLOR_GOLD"]                     = "Gold (relaxed)"
 L["FOCUS_BACKDROP_OPACITY"]                                   = "Deckkraft des Hintergrunds"
 L["FOCUS_PANEL_BACKGROUND_OPACITY"]                           = "Hintergrunddeckkraft des Fensters (0–1)."
 L["FOCUS_BORDER"]                                             = "Rahmen anzeigen"
@@ -1238,6 +1258,9 @@ L["PRESENCE_FONT_SIZE_SMALL_NOTIFICATION_SUBTITLES"]          = "Schriftgröße 
 -- =====================================================================
 L["FOCUS_OUTLINE_NONE"]                                       = "Keine"
 L["FOCUS_THICK_OUTLINE"]                                      = "Starke Kontur"
+-- L["FOCUS_SLUG"]                                            = "SLUG"
+-- L["FOCUS_SLUG_OUTLINE"]                                    = "SLUG Outline"
+-- L["FOCUS_SLUG_THICK_OUTLINE"]                              = "SLUG Thick Outline"
 
 -- =====================================================================
 -- OptionsData.lua Dropdown options — Highlight style
@@ -1578,10 +1601,10 @@ L["VISTA_DISABLE_DONE"]                                       = "Deaktivieren we
 L["VISTA_MOUSEOVER_BAR"]                                      = "Mausüber-Leiste"
 L["VISTA_RIGHT_CLICK_PANEL"]                                  = "Rechtsklick-Anzeige"
 L["VISTA_FLOATING_DRAWER"]                                    = "Schwebende Schublade"
--- L["VISTA_DRAWER_BUTTON_ICON"]                              = "Drawer button icon"
+L["VISTA_DRAWER_BUTTON_ICON"]                                 = "Drawer button icon"
 L["VISTA_DRAWER_BUTTON_ICON_DESC"]                            = "Enter a Blizzard icon file ID or texture path. Leave blank to use the default drawer icon."
 -- L["VISTA_CHOOSE_ICON"]                                     = "Choose icon"
-L["VISTA_CHOOSE_DRAWER_ICON"]                                 = "Choose Drawer Icon"
+-- L["VISTA_CHOOSE_DRAWER_ICON"]                              = "Choose Drawer Icon"
 L["VISTA_LOCK_DRAWER_BUTTON_POSITION"]                        = "Position der Schubladenschaltfläche fixieren"
 L["VISTA_PREVENT_DRAGGING_FLOATING_DRAWER_BUTTON"]            = "Schubladenschaltfläche nicht verschiebbar."
 L["VISTA_LOCK_MOUSEOVER_BAR_POSITION"]                        = "Position der Mausüber-Leiste fixieren"
@@ -1927,6 +1950,7 @@ L["ZONE_LABELS"]                                              = "Zonenbeschriftu
 L["ZONE_NAME_NEW_ZONE"]                                       = "Der Zonenname erscheint weiterhin beim Betreten einer neuen Zone."
 L["ZONE_TYPE_COLOURING"]                                      = "Färbung nach Zonentyp"
 L["FOCUS_COMPLETED_CHECKMARK"]                                = "|TInterface\\\\Buttons\\\\UI-CheckBox-Check:12:12:0:0|t anstelle von grüngefärbten abgeschlossenen Zielen."
+
 
 
 

--- a/localisation/horizon/deDE.lua
+++ b/localisation/horizon/deDE.lua
@@ -203,7 +203,7 @@ L["DASH_WELCOME_CONTRIBUTORS_BODY"]                           = [=[Danke an alle
 L["DASH_WELCOME_SUPPORTERS_HEADING"]                          = "Unterstützer"
 L["DASH_WELCOME_SUPPORTERS_BODY"]                             = [=[Vielen Dank an alle, die Horizon Suite über Ko-fi, Patreon und andere Wege unterstützen.]=]
 L["DASH_WELCOME_LOCALISATIONS_HEADING"]                       = "Lokalisierungen"
--- L["DASH_WELCOME_LOCALISATIONS_BODY"]                       = [=[The addon UI is localised for:
+L["DASH_WELCOME_LOCALISATIONS_BODY"]                          = [=[The addon UI is localised for:
 -- 
 -- • German (deDE) — `localisation/horizon/deDE.lua`
 -- • English (enUS) — `localisation/horizon/enUS.lua`
@@ -391,7 +391,7 @@ L["AXIS_GLOBAL_TOGGLES"]                                      = "Globale Einstel
 -- L["AXIS_GLOBAL_SCALE_SECTION"]                             = "Global Scale"
 -- L["AXIS_MINIMAP_ICON_SECTION"]                             = "Minimap Icon"
 -- L["AXIS_MINIMAP_ICON_CIRCULAR"]                            = "Circular icon"
--- L["AXIS_MINIMAP_ICON_CIRCULAR_DESC"]                       = "Round the Horizon minimap icon and add a gold ring border to match calendar, clock, and other circular minimap buttons."
+L["AXIS_MINIMAP_ICON_CIRCULAR_DESC"]                          = "Round the Horizon minimap icon and add a gold ring border to match calendar, clock, and other circular minimap buttons."
 -- L["AXIS_CLASS_THEME_SECTION"]                              = "Class Theme"
 -- L["AXIS_GLOBAL_CLASS_THEME"]                               = "Global Class Theme"
 -- L["AXIS_CLASS_THEME_DASHBOARD"]                            = "Dashboard"
@@ -1950,6 +1950,7 @@ L["ZONE_LABELS"]                                              = "Zonenbeschriftu
 L["ZONE_NAME_NEW_ZONE"]                                       = "Der Zonenname erscheint weiterhin beim Betreten einer neuen Zone."
 L["ZONE_TYPE_COLOURING"]                                      = "Färbung nach Zonentyp"
 L["FOCUS_COMPLETED_CHECKMARK"]                                = "|TInterface\\\\Buttons\\\\UI-CheckBox-Check:12:12:0:0|t anstelle von grüngefärbten abgeschlossenen Zielen."
+
 
 
 

--- a/localisation/horizon/enUS.lua
+++ b/localisation/horizon/enUS.lua
@@ -392,6 +392,8 @@ L["AXIS_DASHBOARD_SECTION"]                                   = "Dashboard"
 L["AXIS_GLOBAL_FONT_SECTION"]                                 = "Global Font (Coming Soon!)"
 L["AXIS_GLOBAL_SCALE_SECTION"]                                = "Global Scale"
 L["AXIS_MINIMAP_ICON_SECTION"]                                = "Minimap Icon"
+L["AXIS_MINIMAP_ICON_CIRCULAR"]                               = "Circular icon"
+L["AXIS_MINIMAP_ICON_CIRCULAR_DESC"]                          = "Round the Horizon minimap icon and add a gold ring border to match calendar, clock, and other circular minimap buttons."
 L["AXIS_CLASS_THEME_SECTION"]                                 = "Class Theme"
 L["AXIS_GLOBAL_CLASS_THEME"]                                  = "Global Class Theme"
 L["AXIS_CLASS_THEME_DASHBOARD"]                               = "Dashboard"
@@ -1950,6 +1952,7 @@ L["ZONE_LABELS"]                                              = "Zone Labels"
 L["ZONE_NAME_NEW_ZONE"]                                       = "Zone name still appears when entering a new zone."
 L["ZONE_TYPE_COLOURING"]                                      = "Zone Type Colouring"
 L["FOCUS_COMPLETED_CHECKMARK"]                                = "|TInterface\\\\Buttons\\\\UI-CheckBox-Check:12:12:0:0|t instead of green for done objectives."
+
 
 
 

--- a/localisation/horizon/enUS.lua
+++ b/localisation/horizon/enUS.lua
@@ -393,7 +393,7 @@ L["AXIS_GLOBAL_FONT_SECTION"]                                 = "Global Font (Co
 L["AXIS_GLOBAL_SCALE_SECTION"]                                = "Global Scale"
 L["AXIS_MINIMAP_ICON_SECTION"]                                = "Minimap Icon"
 L["AXIS_MINIMAP_ICON_CIRCULAR"]                               = "Circular icon"
-L["AXIS_MINIMAP_ICON_CIRCULAR_DESC"]                          = "Round the Horizon minimap icon and add a gold ring border to match calendar, clock, and other circular minimap buttons."
+L["AXIS_MINIMAP_ICON_CIRCULAR_DESC"]                          = "Round the Horizon icon, add a gold ring border, and snap it to the minimap's edge while dragging — matching calendar, clock, and other standard minimap buttons."
 L["AXIS_CLASS_THEME_SECTION"]                                 = "Class Theme"
 L["AXIS_GLOBAL_CLASS_THEME"]                                  = "Global Class Theme"
 L["AXIS_CLASS_THEME_DASHBOARD"]                               = "Dashboard"
@@ -1952,6 +1952,7 @@ L["ZONE_LABELS"]                                              = "Zone Labels"
 L["ZONE_NAME_NEW_ZONE"]                                       = "Zone name still appears when entering a new zone."
 L["ZONE_TYPE_COLOURING"]                                      = "Zone Type Colouring"
 L["FOCUS_COMPLETED_CHECKMARK"]                                = "|TInterface\\\\Buttons\\\\UI-CheckBox-Check:12:12:0:0|t instead of green for done objectives."
+
 
 
 

--- a/localisation/horizon/esES.lua
+++ b/localisation/horizon/esES.lua
@@ -201,7 +201,7 @@ L["DASH_WELCOME_CONTRIBUTORS_BODY"]                           = [=[Thanks to eve
 -- L["DASH_WELCOME_SUPPORTERS_HEADING"]                       = "Supporters"
 -- L["DASH_WELCOME_SUPPORTERS_BODY"]                          = [=[Thank you to everyone who supports Horizon Suite through Ko-fi, Patreon, and other channels.]=]
 -- L["DASH_WELCOME_LOCALISATIONS_HEADING"]                    = "Localisations"
--- L["DASH_WELCOME_LOCALISATIONS_BODY"]                       = [=[The addon UI is localised for:
+L["DASH_WELCOME_LOCALISATIONS_BODY"]                          = [=[The addon UI is localised for:
 -- 
 -- • German (deDE) — `localisation/horizon/deDE.lua`
 -- • English (enUS) — `localisation/horizon/enUS.lua`
@@ -389,7 +389,7 @@ L["AXIS_GLOBAL_TOGGLES"]                                      = "Global Toggles"
 -- L["AXIS_GLOBAL_SCALE_SECTION"]                             = "Global Scale"
 -- L["AXIS_MINIMAP_ICON_SECTION"]                             = "Minimap Icon"
 -- L["AXIS_MINIMAP_ICON_CIRCULAR"]                            = "Circular icon"
--- L["AXIS_MINIMAP_ICON_CIRCULAR_DESC"]                       = "Round the Horizon minimap icon and add a gold ring border to match calendar, clock, and other circular minimap buttons."
+L["AXIS_MINIMAP_ICON_CIRCULAR_DESC"]                          = "Round the Horizon minimap icon and add a gold ring border to match calendar, clock, and other circular minimap buttons."
 -- L["AXIS_CLASS_THEME_SECTION"]                              = "Class Theme"
 -- L["AXIS_GLOBAL_CLASS_THEME"]                               = "Global Class Theme"
 -- L["AXIS_CLASS_THEME_DASHBOARD"]                            = "Dashboard"
@@ -1948,6 +1948,7 @@ L["ZONE_LABELS"]                                              = "Zone labels"
 -- L["ZONE_NAME_NEW_ZONE"]                                    = "Zone name still appears when entering a new zone."
 L["ZONE_TYPE_COLOURING"]                                      = "Zone type colouring"
 -- L["FOCUS_COMPLETED_CHECKMARK"]                             = "|TInterface\\\\Buttons\\\\UI-CheckBox-Check:12:12:0:0|t instead of green for done objectives."
+
 
 
 

--- a/localisation/horizon/esES.lua
+++ b/localisation/horizon/esES.lua
@@ -1,6 +1,6 @@
 if GetLocale() ~= "esES" then return end
 
-local addon = _G.HorizonSuite
+local addon = _G._HorizonSuite_Loading or _G.HorizonSuiteBeta or _G.HorizonSuite
 if not addon then return end
 
 local L = setmetatable({}, { __index = addon.L })
@@ -201,7 +201,17 @@ L["DASH_WELCOME_CONTRIBUTORS_BODY"]                           = [=[Thanks to eve
 -- L["DASH_WELCOME_SUPPORTERS_HEADING"]                       = "Supporters"
 -- L["DASH_WELCOME_SUPPORTERS_BODY"]                          = [=[Thank you to everyone who supports Horizon Suite through Ko-fi, Patreon, and other channels.]=]
 -- L["DASH_WELCOME_LOCALISATIONS_HEADING"]                    = "Localisations"
--- L["DASH_WELCOME_LOCALISATIONS_BODY"] = ... (falls back to enUS until retranslated against new path layout)
+-- L["DASH_WELCOME_LOCALISATIONS_BODY"]                       = [=[The addon UI is localised for:
+-- 
+-- • German (deDE) — `localisation/horizon/deDE.lua`
+-- • English (enUS) — `localisation/horizon/enUS.lua`
+-- • Spanish (esES) — `localisation/horizon/esES.lua`
+-- • French (frFR) — `localisation/horizon/frFR.lua`
+-- • Korean (koKR) — `localisation/horizon/koKR.lua`
+-- • Brazilian Portuguese (ptBR) — `localisation/horizon/ptBR.lua`
+-- • Chinese (zhCN) — `localisation/horizon/zhCN.lua`
+-- 
+-- See contributions/translate.md in the repo for how to contribute. Additional locales are welcome via Discord.]=]
 
 
 -- =====================================================================
@@ -315,6 +325,9 @@ L["FOCUS_CONTENT_TYPES"]                                      = "Tipos de conten
 L["FOCUS_DELVES"]                                             = "Simas"
 L["FOCUS_DELVES_DUNGEONS"]                                    = "Simas y Mazmorras"
 L["FOCUS_DELVE_COMPLETE"]                                     = "Sima completada"
+-- L["FOCUS_RITUAL_SITE_TITLE_COUNTERS"]                      = "Ritual Site Title Counters"
+-- L["FOCUS_RITUAL_SITE_TITLE_COUNTERS_DESC"]                 = "Show Ritual Site spoils and deaths beside the scenario title."
+-- L["FOCUS_RITUAL_SITE_TITLE_COUNTERS_TOOLTIP"]              = "Uses the same title-row counter style as Delves when the scenario provides header currency icons."
 L["FOCUS_INTERACTIONS"]                                       = "Interacciones"
 -- L["FOCUS_LAYOUT_TAB_DESC"]                                 = "Configure and customise settings related to layout."
 -- L["FOCUS_APPEARANCE_TAB_DESC"]                             = "Tracker panel look, fading, and list layout (header, sections, entries, timers, emphasis)."
@@ -375,6 +388,8 @@ L["AXIS_GLOBAL_TOGGLES"]                                      = "Global Toggles"
 -- L["AXIS_GLOBAL_FONT_SECTION"]                              = "Global Font (Coming Soon!)"
 -- L["AXIS_GLOBAL_SCALE_SECTION"]                             = "Global Scale"
 -- L["AXIS_MINIMAP_ICON_SECTION"]                             = "Minimap Icon"
+-- L["AXIS_MINIMAP_ICON_CIRCULAR"]                            = "Circular icon"
+-- L["AXIS_MINIMAP_ICON_CIRCULAR_DESC"]                       = "Round the Horizon minimap icon and add a gold ring border to match calendar, clock, and other circular minimap buttons."
 -- L["AXIS_CLASS_THEME_SECTION"]                              = "Class Theme"
 -- L["AXIS_GLOBAL_CLASS_THEME"]                               = "Global Class Theme"
 -- L["AXIS_CLASS_THEME_DASHBOARD"]                            = "Dashboard"
@@ -404,7 +419,7 @@ L["INSIGHT_SCALE"]                                            = "Escala Insight"
 L["AXIS_SCALE_INSIGHT_TOOLTIP_MODULE"]                        = "Escala del módulo de descripción Insight (50–200%)."
 L["CACHE_SCALE"]                                              = "Escala Cache"
 L["AXIS_SCALE_CACHE_LOOT_TOAST_MODULE"]                       = "Escala del módulo de notificaciones de botín Cache (50–200%)."
--- L["CACHE_FONT"]                                            = "Loot toast font"
+L["CACHE_FONT"]                                               = "Loot toast font"
 -- L["CACHE_FONT_FAMILY"]                                     = "Font family used for loot toast text. Use 'Use global font' to follow the addon-wide font."
 L["AXIS_ENABLE_HORIZON_INSIGHT_MODULE"]                       = "Activar módulo Horizon Insight"
 L["AXIS_CINEMATIC_TOOLTIPS_CLASS_COLOURS_SPEC_DISPLAY"]       = "Descripciones cinematográficas con colores de clase, especialización e iconos de facción."
@@ -985,6 +1000,11 @@ L["DASHBOARD_TYPO_OUTLINE"]                                   = "Dashboard text 
 L["DASHBOARD_TYPO_OUTLINE_DESC"]                              = "When on, dashboard UI text uses the standard outlined font style. Turn off for a softer, flat look."
 L["DASHBOARD_TYPO_SHADOW"]                                    = "Dashboard text shadow"
 L["DASHBOARD_TYPO_SHADOW_DESC"]                               = "Adds a subtle drop shadow behind dashboard text to improve readability on busy backgrounds."
+-- L["DASHBOARD_TYPO_HEADING_COLOR"]                          = "Heading Colour"
+-- L["DASHBOARD_TYPO_HEADING_COLOR_DESC"]                     = "Colour of the large headings on the Welcome and News tabs. Use a softer tone if pure white feels too bright on HDR displays."
+-- L["DASHBOARD_TYPO_HEADING_COLOR_WHITE"]                    = "White (default)"
+-- L["DASHBOARD_TYPO_HEADING_COLOR_CYAN"]                     = "Cyan (relaxed)"
+-- L["DASHBOARD_TYPO_HEADING_COLOR_GOLD"]                     = "Gold (relaxed)"
 L["FOCUS_BACKDROP_OPACITY"]                                   = "Opacidad del fondo"
 L["FOCUS_PANEL_BACKGROUND_OPACITY"]                           = "Opacidad del fondo del panel (0–1)."
 L["FOCUS_BORDER"]                                             = "Mostrar borde"
@@ -1236,6 +1256,9 @@ L["PRESENCE_SMALL_SECONDARY_SIZE"]                            = "Small secondary
 -- =====================================================================
 L["FOCUS_OUTLINE_NONE"]                                       = "Ninguno"
 L["FOCUS_THICK_OUTLINE"]                                      = "Contorno grueso"
+-- L["FOCUS_SLUG"]                                            = "SLUG"
+-- L["FOCUS_SLUG_OUTLINE"]                                    = "SLUG Outline"
+-- L["FOCUS_SLUG_THICK_OUTLINE"]                              = "SLUG Thick Outline"
 
 -- =====================================================================
 -- OptionsData.lua Dropdown options — Highlight style
@@ -1576,10 +1599,10 @@ L["VISTA_ALWAYS_BAR"]                                         = "Always show bar
 L["VISTA_MOUSEOVER_BAR"]                                      = "Barra al pasar el ratón"
 L["VISTA_RIGHT_CLICK_PANEL"]                                  = "Panel clic derecho"
 L["VISTA_FLOATING_DRAWER"]                                    = "Cajón flotante"
--- L["VISTA_DRAWER_BUTTON_ICON"]                              = "Drawer button icon"
+L["VISTA_DRAWER_BUTTON_ICON"]                                 = "Drawer button icon"
 L["VISTA_DRAWER_BUTTON_ICON_DESC"]                            = "Enter a Blizzard icon file ID or texture path. Leave blank to use the default drawer icon."
 -- L["VISTA_CHOOSE_ICON"]                                     = "Choose icon"
-L["VISTA_CHOOSE_DRAWER_ICON"]                                 = "Choose Drawer Icon"
+-- L["VISTA_CHOOSE_DRAWER_ICON"]                              = "Choose Drawer Icon"
 L["VISTA_LOCK_DRAWER_BUTTON_POSITION"]                        = "Bloquear posición del botón del cajón"
 L["VISTA_PREVENT_DRAGGING_FLOATING_DRAWER_BUTTON"]            = "Impide arrastrar el botón del cajón flotante."
 L["VISTA_LOCK_MOUSEOVER_BAR_POSITION"]                        = "Bloquear posición de la barra al pasar el ratón"
@@ -1651,7 +1674,7 @@ L["AFFIX_ICONS"]                                              = "Affix icons"
 L["AFFIX_TOOLTIPS"]                                           = "Affix tooltips"
 -- L["AFFECTS_SCENARIO_PROGRESS_TIMER_BARS"]                  = "Also affects scenario progress and timer bars."
 L["ALWAYS"]                                                   = "Always show"
--- L["ALWAYS_M_TIMER"]                                        = "Always show M+ timer."
+L["ALWAYS_M_TIMER"]                                           = "Always show M+ timer."
 -- L["AUTO_ADD_WQS_YOUR_CURRENT_ZONE"]                        = "Auto-add WQs in your current zone."
 -- L["AUTO_CLOSE_DELAY_DISABLE"]                              = "Auto-close delay (0 to disable)."
 -- L["AUTO_UNTRACK_FINISHED_ACTIVITIES"]                      = "Auto-untrack finished activities."
@@ -1865,7 +1888,7 @@ L["FOCUS_AH_CRAFT_HINT_TIER"]                                 = "Crafting tier 1
 -- L["RECENT_PROGRESS_TOP"]                                   = "Show recent progress at the top."
 -- L["RECIPE_ICON_NEXT_TITLE_REQUIRES_QUEST"]                 = "Show recipe icon next to title. Requires quest type icons in Display."
 L["SECTION_DIVIDERS"]                                         = "Show section dividers"
--- L["M_BLOCK_WHENEVER_AN_ACTIVE_KEYSTONE"]                   = "Show the M+ block whenever an active keystone is running."
+L["M_BLOCK_WHENEVER_AN_ACTIVE_KEYSTONE"]                      = "Show the M+ block whenever an active keystone is running."
 -- L["TRACKED_PROFESSION_RECIPES_LIST"]                       = "Show tracked profession recipes in the list."
 -- L["TRACKER_HEROIC_DUNGEONS"]                               = "Show tracker in Heroic dungeons. When unset, uses the master dungeon toggle."
 -- L["TRACKER_HEROIC_RAIDS"]                                  = "Show tracker in Heroic raids. When unset, uses the master raid toggle."
@@ -1925,6 +1948,7 @@ L["ZONE_LABELS"]                                              = "Zone labels"
 -- L["ZONE_NAME_NEW_ZONE"]                                    = "Zone name still appears when entering a new zone."
 L["ZONE_TYPE_COLOURING"]                                      = "Zone type colouring"
 -- L["FOCUS_COMPLETED_CHECKMARK"]                             = "|TInterface\\\\Buttons\\\\UI-CheckBox-Check:12:12:0:0|t instead of green for done objectives."
+
 
 
 

--- a/localisation/horizon/frFR.lua
+++ b/localisation/horizon/frFR.lua
@@ -201,7 +201,7 @@ L["DASH_WELCOME_CONTRIBUTORS_BODY"]                           = [=[Thanks to eve
 -- L["DASH_WELCOME_SUPPORTERS_HEADING"]                       = "Supporters"
 -- L["DASH_WELCOME_SUPPORTERS_BODY"]                          = [=[Thank you to everyone who supports Horizon Suite through Ko-fi, Patreon, and other channels.]=]
 -- L["DASH_WELCOME_LOCALISATIONS_HEADING"]                    = "Localisations"
--- L["DASH_WELCOME_LOCALISATIONS_BODY"]                       = [=[The addon UI is localised for:
+L["DASH_WELCOME_LOCALISATIONS_BODY"]                          = [=[The addon UI is localised for:
 -- 
 -- • German (deDE) — `localisation/horizon/deDE.lua`
 -- • English (enUS) — `localisation/horizon/enUS.lua`
@@ -389,7 +389,7 @@ L["AXIS_GLOBAL_TOGGLES"]                                      = "Réglages globa
 -- L["AXIS_GLOBAL_SCALE_SECTION"]                             = "Global Scale"
 -- L["AXIS_MINIMAP_ICON_SECTION"]                             = "Minimap Icon"
 -- L["AXIS_MINIMAP_ICON_CIRCULAR"]                            = "Circular icon"
--- L["AXIS_MINIMAP_ICON_CIRCULAR_DESC"]                       = "Round the Horizon minimap icon and add a gold ring border to match calendar, clock, and other circular minimap buttons."
+L["AXIS_MINIMAP_ICON_CIRCULAR_DESC"]                          = "Round the Horizon minimap icon and add a gold ring border to match calendar, clock, and other circular minimap buttons."
 -- L["AXIS_CLASS_THEME_SECTION"]                              = "Class Theme"
 -- L["AXIS_GLOBAL_CLASS_THEME"]                               = "Global Class Theme"
 -- L["AXIS_CLASS_THEME_DASHBOARD"]                            = "Dashboard"
@@ -1948,6 +1948,7 @@ L["ZONE_LABELS"]                                              = "Zone labels"
 -- L["ZONE_NAME_NEW_ZONE"]                                    = "Zone name still appears when entering a new zone."
 L["ZONE_TYPE_COLOURING"]                                      = "Zone type colouring"
 -- L["FOCUS_COMPLETED_CHECKMARK"]                             = "|TInterface\\\\Buttons\\\\UI-CheckBox-Check:12:12:0:0|t instead of green for done objectives."
+
 
 
 

--- a/localisation/horizon/frFR.lua
+++ b/localisation/horizon/frFR.lua
@@ -1,6 +1,6 @@
 if GetLocale() ~= "frFR" then return end
 
-local addon = _G.HorizonSuite
+local addon = _G._HorizonSuite_Loading or _G.HorizonSuiteBeta or _G.HorizonSuite
 if not addon then return end
 
 local L = setmetatable({}, { __index = addon.L })
@@ -201,7 +201,17 @@ L["DASH_WELCOME_CONTRIBUTORS_BODY"]                           = [=[Thanks to eve
 -- L["DASH_WELCOME_SUPPORTERS_HEADING"]                       = "Supporters"
 -- L["DASH_WELCOME_SUPPORTERS_BODY"]                          = [=[Thank you to everyone who supports Horizon Suite through Ko-fi, Patreon, and other channels.]=]
 -- L["DASH_WELCOME_LOCALISATIONS_HEADING"]                    = "Localisations"
--- L["DASH_WELCOME_LOCALISATIONS_BODY"] = ... (falls back to enUS until retranslated against new path layout)
+-- L["DASH_WELCOME_LOCALISATIONS_BODY"]                       = [=[The addon UI is localised for:
+-- 
+-- • German (deDE) — `localisation/horizon/deDE.lua`
+-- • English (enUS) — `localisation/horizon/enUS.lua`
+-- • Spanish (esES) — `localisation/horizon/esES.lua`
+-- • French (frFR) — `localisation/horizon/frFR.lua`
+-- • Korean (koKR) — `localisation/horizon/koKR.lua`
+-- • Brazilian Portuguese (ptBR) — `localisation/horizon/ptBR.lua`
+-- • Chinese (zhCN) — `localisation/horizon/zhCN.lua`
+-- 
+-- See contributions/translate.md in the repo for how to contribute. Additional locales are welcome via Discord.]=]
 
 
 -- =====================================================================
@@ -315,6 +325,9 @@ L["FOCUS_CONTENT_TYPES"]                                      = "Types de conten
 L["FOCUS_DELVES"]                                             = "Gouffres"
 L["FOCUS_DELVES_DUNGEONS"]                                    = "Gouffres & Donjons"
 L["FOCUS_DELVE_COMPLETE"]                                     = "Gouffre terminé"
+-- L["FOCUS_RITUAL_SITE_TITLE_COUNTERS"]                      = "Ritual Site Title Counters"
+-- L["FOCUS_RITUAL_SITE_TITLE_COUNTERS_DESC"]                 = "Show Ritual Site spoils and deaths beside the scenario title."
+-- L["FOCUS_RITUAL_SITE_TITLE_COUNTERS_TOOLTIP"]              = "Uses the same title-row counter style as Delves when the scenario provides header currency icons."
 -- L["FOCUS_INTERACTIONS"]                                    = "Interactions"
 -- L["FOCUS_LAYOUT_TAB_DESC"]                                 = "Configure and customise settings related to layout."
 -- L["FOCUS_APPEARANCE_TAB_DESC"]                             = "Tracker panel look, fading, and list layout (header, sections, entries, timers, emphasis)."
@@ -375,6 +388,8 @@ L["AXIS_GLOBAL_TOGGLES"]                                      = "Réglages globa
 -- L["AXIS_GLOBAL_FONT_SECTION"]                              = "Global Font (Coming Soon!)"
 -- L["AXIS_GLOBAL_SCALE_SECTION"]                             = "Global Scale"
 -- L["AXIS_MINIMAP_ICON_SECTION"]                             = "Minimap Icon"
+-- L["AXIS_MINIMAP_ICON_CIRCULAR"]                            = "Circular icon"
+-- L["AXIS_MINIMAP_ICON_CIRCULAR_DESC"]                       = "Round the Horizon minimap icon and add a gold ring border to match calendar, clock, and other circular minimap buttons."
 -- L["AXIS_CLASS_THEME_SECTION"]                              = "Class Theme"
 -- L["AXIS_GLOBAL_CLASS_THEME"]                               = "Global Class Theme"
 -- L["AXIS_CLASS_THEME_DASHBOARD"]                            = "Dashboard"
@@ -404,7 +419,7 @@ L["INSIGHT_SCALE"]                                            = "Échelle Insigh
 L["AXIS_SCALE_INSIGHT_TOOLTIP_MODULE"]                        = "Échelle du module d'infobulle Insight (50–200 %)."
 L["CACHE_SCALE"]                                              = "Échelle Cache"
 L["AXIS_SCALE_CACHE_LOOT_TOAST_MODULE"]                       = "Échelle du module d'alerte de butin Cache (50–200 %)."
--- L["CACHE_FONT"]                                            = "Loot toast font"
+L["CACHE_FONT"]                                               = "Loot toast font"
 -- L["CACHE_FONT_FAMILY"]                                     = "Font family used for loot toast text. Use 'Use global font' to follow the addon-wide font."
 L["AXIS_ENABLE_HORIZON_INSIGHT_MODULE"]                       = "Activer le module Horizon Insight"
 L["AXIS_CINEMATIC_TOOLTIPS_CLASS_COLOURS_SPEC_DISPLAY"]       = "Infobulles cinématiques avec couleurs de classe, spécialisation et icônes de faction."
@@ -985,6 +1000,11 @@ L["DASHBOARD_TYPO_OUTLINE"]                                   = "Dashboard text 
 L["DASHBOARD_TYPO_OUTLINE_DESC"]                              = "When on, dashboard UI text uses the standard outlined font style. Turn off for a softer, flat look."
 L["DASHBOARD_TYPO_SHADOW"]                                    = "Dashboard text shadow"
 L["DASHBOARD_TYPO_SHADOW_DESC"]                               = "Adds a subtle drop shadow behind dashboard text to improve readability on busy backgrounds."
+-- L["DASHBOARD_TYPO_HEADING_COLOR"]                          = "Heading Colour"
+-- L["DASHBOARD_TYPO_HEADING_COLOR_DESC"]                     = "Colour of the large headings on the Welcome and News tabs. Use a softer tone if pure white feels too bright on HDR displays."
+-- L["DASHBOARD_TYPO_HEADING_COLOR_WHITE"]                    = "White (default)"
+-- L["DASHBOARD_TYPO_HEADING_COLOR_CYAN"]                     = "Cyan (relaxed)"
+-- L["DASHBOARD_TYPO_HEADING_COLOR_GOLD"]                     = "Gold (relaxed)"
 L["FOCUS_BACKDROP_OPACITY"]                                   = "Opacité du fond"
 L["FOCUS_PANEL_BACKGROUND_OPACITY"]                           = "Opacité du fond du panneau (0–1)."
 L["FOCUS_BORDER"]                                             = "Afficher la bordure"
@@ -1236,6 +1256,9 @@ L["PRESENCE_FONT_SIZE_SMALL_NOTIFICATION_SUBTITLES"]          = "Taille de sous-
 -- =====================================================================
 L["FOCUS_OUTLINE_NONE"]                                       = "Aucun"
 L["FOCUS_THICK_OUTLINE"]                                      = "Contour épais"
+-- L["FOCUS_SLUG"]                                            = "SLUG"
+-- L["FOCUS_SLUG_OUTLINE"]                                    = "SLUG Outline"
+-- L["FOCUS_SLUG_THICK_OUTLINE"]                              = "SLUG Thick Outline"
 
 -- =====================================================================
 -- OptionsData.lua Dropdown options — Highlight style
@@ -1576,10 +1599,10 @@ L["VISTA_DISABLE_DONE"]                                       = "Désactiver une
 L["VISTA_MOUSEOVER_BAR"]                                      = "Barre au survol"
 L["VISTA_RIGHT_CLICK_PANEL"]                                  = "Panneau clic droit"
 L["VISTA_FLOATING_DRAWER"]                                    = "Tiroir flottant"
--- L["VISTA_DRAWER_BUTTON_ICON"]                              = "Drawer button icon"
+L["VISTA_DRAWER_BUTTON_ICON"]                                 = "Drawer button icon"
 L["VISTA_DRAWER_BUTTON_ICON_DESC"]                            = "Enter a Blizzard icon file ID or texture path. Leave blank to use the default drawer icon."
 -- L["VISTA_CHOOSE_ICON"]                                     = "Choose icon"
-L["VISTA_CHOOSE_DRAWER_ICON"]                                 = "Choose Drawer Icon"
+-- L["VISTA_CHOOSE_DRAWER_ICON"]                              = "Choose Drawer Icon"
 L["VISTA_LOCK_DRAWER_BUTTON_POSITION"]                        = "Verrouiller la position du bouton tiroir"
 L["VISTA_PREVENT_DRAGGING_FLOATING_DRAWER_BUTTON"]            = "Empêche de déplacer le bouton du tiroir flottant."
 L["VISTA_LOCK_MOUSEOVER_BAR_POSITION"]                        = "Verrouiller la position de la barre au survol"
@@ -1651,7 +1674,7 @@ L["AFFIX_ICONS"]                                              = "Affix icons"
 L["AFFIX_TOOLTIPS"]                                           = "Affix tooltips"
 -- L["AFFECTS_SCENARIO_PROGRESS_TIMER_BARS"]                  = "Also affects scenario progress and timer bars."
 L["ALWAYS"]                                                   = "Always show"
--- L["ALWAYS_M_TIMER"]                                        = "Always show M+ timer."
+L["ALWAYS_M_TIMER"]                                           = "Always show M+ timer."
 -- L["AUTO_ADD_WQS_YOUR_CURRENT_ZONE"]                        = "Auto-add WQs in your current zone."
 -- L["AUTO_CLOSE_DELAY_DISABLE"]                              = "Auto-close delay (0 to disable)."
 -- L["AUTO_UNTRACK_FINISHED_ACTIVITIES"]                      = "Auto-untrack finished activities."
@@ -1865,7 +1888,7 @@ L["FOCUS_AH_CRAFT_HINT_TIER"]                                 = "Crafting tier 1
 -- L["RECENT_PROGRESS_TOP"]                                   = "Show recent progress at the top."
 -- L["RECIPE_ICON_NEXT_TITLE_REQUIRES_QUEST"]                 = "Show recipe icon next to title. Requires quest type icons in Display."
 L["SECTION_DIVIDERS"]                                         = "Show section dividers"
--- L["M_BLOCK_WHENEVER_AN_ACTIVE_KEYSTONE"]                   = "Show the M+ block whenever an active keystone is running."
+L["M_BLOCK_WHENEVER_AN_ACTIVE_KEYSTONE"]                      = "Show the M+ block whenever an active keystone is running."
 -- L["TRACKED_PROFESSION_RECIPES_LIST"]                       = "Show tracked profession recipes in the list."
 -- L["TRACKER_HEROIC_DUNGEONS"]                               = "Show tracker in Heroic dungeons. When unset, uses the master dungeon toggle."
 -- L["TRACKER_HEROIC_RAIDS"]                                  = "Show tracker in Heroic raids. When unset, uses the master raid toggle."
@@ -1925,6 +1948,7 @@ L["ZONE_LABELS"]                                              = "Zone labels"
 -- L["ZONE_NAME_NEW_ZONE"]                                    = "Zone name still appears when entering a new zone."
 L["ZONE_TYPE_COLOURING"]                                      = "Zone type colouring"
 -- L["FOCUS_COMPLETED_CHECKMARK"]                             = "|TInterface\\\\Buttons\\\\UI-CheckBox-Check:12:12:0:0|t instead of green for done objectives."
+
 
 
 

--- a/localisation/horizon/koKR.lua
+++ b/localisation/horizon/koKR.lua
@@ -201,7 +201,7 @@ L["DASH_WELCOME_CONTRIBUTORS_BODY"]                           = [=[Thanks to eve
 -- L["DASH_WELCOME_SUPPORTERS_HEADING"]                       = "Supporters"
 -- L["DASH_WELCOME_SUPPORTERS_BODY"]                          = [=[Thank you to everyone who supports Horizon Suite through Ko-fi, Patreon, and other channels.]=]
 -- L["DASH_WELCOME_LOCALISATIONS_HEADING"]                    = "Localisations"
--- L["DASH_WELCOME_LOCALISATIONS_BODY"]                       = [=[The addon UI is localised for:
+L["DASH_WELCOME_LOCALISATIONS_BODY"]                          = [=[The addon UI is localised for:
 -- 
 -- • German (deDE) — `localisation/horizon/deDE.lua`
 -- • English (enUS) — `localisation/horizon/enUS.lua`
@@ -389,7 +389,7 @@ L["AXIS_GLOBAL_TOGGLES"]                                      = "Global Toggles"
 -- L["AXIS_GLOBAL_SCALE_SECTION"]                             = "Global Scale"
 -- L["AXIS_MINIMAP_ICON_SECTION"]                             = "Minimap Icon"
 -- L["AXIS_MINIMAP_ICON_CIRCULAR"]                            = "Circular icon"
--- L["AXIS_MINIMAP_ICON_CIRCULAR_DESC"]                       = "Round the Horizon minimap icon and add a gold ring border to match calendar, clock, and other circular minimap buttons."
+L["AXIS_MINIMAP_ICON_CIRCULAR_DESC"]                          = "Round the Horizon minimap icon and add a gold ring border to match calendar, clock, and other circular minimap buttons."
 -- L["AXIS_CLASS_THEME_SECTION"]                              = "Class Theme"
 -- L["AXIS_GLOBAL_CLASS_THEME"]                               = "Global Class Theme"
 -- L["AXIS_CLASS_THEME_DASHBOARD"]                            = "Dashboard"
@@ -1948,6 +1948,7 @@ L["ZONE_LABELS"]                                              = "Zone labels"
 -- L["ZONE_NAME_NEW_ZONE"]                                    = "Zone name still appears when entering a new zone."
 L["ZONE_TYPE_COLOURING"]                                      = "Zone type colouring"
 -- L["FOCUS_COMPLETED_CHECKMARK"]                             = "|TInterface\\\\Buttons\\\\UI-CheckBox-Check:12:12:0:0|t instead of green for done objectives."
+
 
 
 

--- a/localisation/horizon/koKR.lua
+++ b/localisation/horizon/koKR.lua
@@ -1,6 +1,6 @@
 if GetLocale() ~= "koKR" then return end
 
-local addon = _G.HorizonSuite
+local addon = _G._HorizonSuite_Loading or _G.HorizonSuiteBeta or _G.HorizonSuite
 if not addon then return end
 
 local L = setmetatable({}, { __index = addon.L })
@@ -201,7 +201,17 @@ L["DASH_WELCOME_CONTRIBUTORS_BODY"]                           = [=[Thanks to eve
 -- L["DASH_WELCOME_SUPPORTERS_HEADING"]                       = "Supporters"
 -- L["DASH_WELCOME_SUPPORTERS_BODY"]                          = [=[Thank you to everyone who supports Horizon Suite through Ko-fi, Patreon, and other channels.]=]
 -- L["DASH_WELCOME_LOCALISATIONS_HEADING"]                    = "Localisations"
--- L["DASH_WELCOME_LOCALISATIONS_BODY"] = ... (falls back to enUS until retranslated against new path layout)
+-- L["DASH_WELCOME_LOCALISATIONS_BODY"]                       = [=[The addon UI is localised for:
+-- 
+-- • German (deDE) — `localisation/horizon/deDE.lua`
+-- • English (enUS) — `localisation/horizon/enUS.lua`
+-- • Spanish (esES) — `localisation/horizon/esES.lua`
+-- • French (frFR) — `localisation/horizon/frFR.lua`
+-- • Korean (koKR) — `localisation/horizon/koKR.lua`
+-- • Brazilian Portuguese (ptBR) — `localisation/horizon/ptBR.lua`
+-- • Chinese (zhCN) — `localisation/horizon/zhCN.lua`
+-- 
+-- See contributions/translate.md in the repo for how to contribute. Additional locales are welcome via Discord.]=]
 
 
 -- =====================================================================
@@ -315,6 +325,9 @@ L["FOCUS_CONTENT_TYPES"]                                      = "콘텐츠 유�
 L["FOCUS_DELVES"]                                             = "구렁"
 L["FOCUS_DELVES_DUNGEONS"]                                    = "구렁 & 던전"
 L["FOCUS_DELVE_COMPLETE"]                                     = "구렁 완료"
+-- L["FOCUS_RITUAL_SITE_TITLE_COUNTERS"]                      = "Ritual Site Title Counters"
+-- L["FOCUS_RITUAL_SITE_TITLE_COUNTERS_DESC"]                 = "Show Ritual Site spoils and deaths beside the scenario title."
+-- L["FOCUS_RITUAL_SITE_TITLE_COUNTERS_TOOLTIP"]              = "Uses the same title-row counter style as Delves when the scenario provides header currency icons."
 L["FOCUS_INTERACTIONS"]                                       = "상호작용"
 -- L["FOCUS_LAYOUT_TAB_DESC"]                                 = "Configure and customise settings related to layout."
 -- L["FOCUS_APPEARANCE_TAB_DESC"]                             = "Tracker panel look, fading, and list layout (header, sections, entries, timers, emphasis)."
@@ -375,6 +388,8 @@ L["AXIS_GLOBAL_TOGGLES"]                                      = "Global Toggles"
 -- L["AXIS_GLOBAL_FONT_SECTION"]                              = "Global Font (Coming Soon!)"
 -- L["AXIS_GLOBAL_SCALE_SECTION"]                             = "Global Scale"
 -- L["AXIS_MINIMAP_ICON_SECTION"]                             = "Minimap Icon"
+-- L["AXIS_MINIMAP_ICON_CIRCULAR"]                            = "Circular icon"
+-- L["AXIS_MINIMAP_ICON_CIRCULAR_DESC"]                       = "Round the Horizon minimap icon and add a gold ring border to match calendar, clock, and other circular minimap buttons."
 -- L["AXIS_CLASS_THEME_SECTION"]                              = "Class Theme"
 -- L["AXIS_GLOBAL_CLASS_THEME"]                               = "Global Class Theme"
 -- L["AXIS_CLASS_THEME_DASHBOARD"]                            = "Dashboard"
@@ -404,7 +419,7 @@ L["INSIGHT_SCALE"]                                            = "툴팁"
 L["AXIS_SCALE_INSIGHT_TOOLTIP_MODULE"]                        = "툴팁 크기 조정 (50–200%)."
 L["CACHE_SCALE"]                                              = "획득 알림"
 L["AXIS_SCALE_CACHE_LOOT_TOAST_MODULE"]                       = "획득 알림 기능의 크기 조정 (50–200%)."
--- L["CACHE_FONT"]                                            = "Loot toast font"
+L["CACHE_FONT"]                                               = "Loot toast font"
 -- L["CACHE_FONT_FAMILY"]                                     = "Font family used for loot toast text. Use 'Use global font' to follow the addon-wide font."
 L["AXIS_ENABLE_HORIZON_INSIGHT_MODULE"]                       = "툴팁 기능 활성화"
 L["AXIS_CINEMATIC_TOOLTIPS_CLASS_COLOURS_SPEC_DISPLAY"]       = "직업 색상, 전문화 표시, 진영 아이콘이 있는 시네마틱 툴팁."
@@ -985,6 +1000,11 @@ L["DASHBOARD_TYPO_OUTLINE"]                                   = "Dashboard text 
 L["DASHBOARD_TYPO_OUTLINE_DESC"]                              = "When on, dashboard UI text uses the standard outlined font style. Turn off for a softer, flat look."
 L["DASHBOARD_TYPO_SHADOW"]                                    = "Dashboard text shadow"
 L["DASHBOARD_TYPO_SHADOW_DESC"]                               = "Adds a subtle drop shadow behind dashboard text to improve readability on busy backgrounds."
+-- L["DASHBOARD_TYPO_HEADING_COLOR"]                          = "Heading Colour"
+-- L["DASHBOARD_TYPO_HEADING_COLOR_DESC"]                     = "Colour of the large headings on the Welcome and News tabs. Use a softer tone if pure white feels too bright on HDR displays."
+-- L["DASHBOARD_TYPO_HEADING_COLOR_WHITE"]                    = "White (default)"
+-- L["DASHBOARD_TYPO_HEADING_COLOR_CYAN"]                     = "Cyan (relaxed)"
+-- L["DASHBOARD_TYPO_HEADING_COLOR_GOLD"]                     = "Gold (relaxed)"
 L["FOCUS_BACKDROP_OPACITY"]                                   = "배경 투명도"
 L["FOCUS_PANEL_BACKGROUND_OPACITY"]                           = "패널 배경 투명도 (0–1)."
 L["FOCUS_BORDER"]                                             = "테두리 표시"
@@ -1236,6 +1256,9 @@ L["PRESENCE_SMALL_SECONDARY_SIZE"]                            = "Small secondary
 -- =====================================================================
 L["FOCUS_OUTLINE_NONE"]                                       = "없음"
 L["FOCUS_THICK_OUTLINE"]                                      = "두꺼운 외곽선"
+-- L["FOCUS_SLUG"]                                            = "SLUG"
+-- L["FOCUS_SLUG_OUTLINE"]                                    = "SLUG Outline"
+-- L["FOCUS_SLUG_THICK_OUTLINE"]                              = "SLUG Thick Outline"
 
 -- =====================================================================
 -- OptionsData.lua Dropdown options — Highlight style
@@ -1576,10 +1599,10 @@ L["VISTA_ALWAYS_BAR"]                                         = "Always show bar
 L["VISTA_MOUSEOVER_BAR"]                                      = "마우스오버 바"
 L["VISTA_RIGHT_CLICK_PANEL"]                                  = "우클릭 패널"
 L["VISTA_FLOATING_DRAWER"]                                    = "플로팅 서랍"
--- L["VISTA_DRAWER_BUTTON_ICON"]                              = "Drawer button icon"
+L["VISTA_DRAWER_BUTTON_ICON"]                                 = "Drawer button icon"
 L["VISTA_DRAWER_BUTTON_ICON_DESC"]                            = "Enter a Blizzard icon file ID or texture path. Leave blank to use the default drawer icon."
 -- L["VISTA_CHOOSE_ICON"]                                     = "Choose icon"
-L["VISTA_CHOOSE_DRAWER_ICON"]                                 = "Choose Drawer Icon"
+-- L["VISTA_CHOOSE_DRAWER_ICON"]                              = "Choose Drawer Icon"
 L["VISTA_LOCK_DRAWER_BUTTON_POSITION"]                        = "서랍 버튼 위치 잠금"
 L["VISTA_PREVENT_DRAGGING_FLOATING_DRAWER_BUTTON"]            = "플로팅 서랍 버튼을 드래그할 수 없게 합니다."
 L["VISTA_LOCK_MOUSEOVER_BAR_POSITION"]                        = "마우스오버 바 위치 잠금"
@@ -1651,7 +1674,7 @@ L["AFFIX_ICONS"]                                              = "Affix icons"
 L["AFFIX_TOOLTIPS"]                                           = "Affix tooltips"
 -- L["AFFECTS_SCENARIO_PROGRESS_TIMER_BARS"]                  = "Also affects scenario progress and timer bars."
 L["ALWAYS"]                                                   = "Always show"
--- L["ALWAYS_M_TIMER"]                                        = "Always show M+ timer."
+L["ALWAYS_M_TIMER"]                                           = "Always show M+ timer."
 -- L["AUTO_ADD_WQS_YOUR_CURRENT_ZONE"]                        = "Auto-add WQs in your current zone."
 -- L["AUTO_CLOSE_DELAY_DISABLE"]                              = "Auto-close delay (0 to disable)."
 -- L["AUTO_UNTRACK_FINISHED_ACTIVITIES"]                      = "Auto-untrack finished activities."
@@ -1865,7 +1888,7 @@ L["FOCUS_AH_CRAFT_HINT_TIER"]                                 = "Crafting tier 1
 -- L["RECENT_PROGRESS_TOP"]                                   = "Show recent progress at the top."
 -- L["RECIPE_ICON_NEXT_TITLE_REQUIRES_QUEST"]                 = "Show recipe icon next to title. Requires quest type icons in Display."
 L["SECTION_DIVIDERS"]                                         = "Show section dividers"
--- L["M_BLOCK_WHENEVER_AN_ACTIVE_KEYSTONE"]                   = "Show the M+ block whenever an active keystone is running."
+L["M_BLOCK_WHENEVER_AN_ACTIVE_KEYSTONE"]                      = "Show the M+ block whenever an active keystone is running."
 -- L["TRACKED_PROFESSION_RECIPES_LIST"]                       = "Show tracked profession recipes in the list."
 -- L["TRACKER_HEROIC_DUNGEONS"]                               = "Show tracker in Heroic dungeons. When unset, uses the master dungeon toggle."
 -- L["TRACKER_HEROIC_RAIDS"]                                  = "Show tracker in Heroic raids. When unset, uses the master raid toggle."
@@ -1925,6 +1948,7 @@ L["ZONE_LABELS"]                                              = "Zone labels"
 -- L["ZONE_NAME_NEW_ZONE"]                                    = "Zone name still appears when entering a new zone."
 L["ZONE_TYPE_COLOURING"]                                      = "Zone type colouring"
 -- L["FOCUS_COMPLETED_CHECKMARK"]                             = "|TInterface\\\\Buttons\\\\UI-CheckBox-Check:12:12:0:0|t instead of green for done objectives."
+
 
 
 

--- a/localisation/horizon/ptBR.lua
+++ b/localisation/horizon/ptBR.lua
@@ -1,6 +1,6 @@
 if GetLocale() ~= "ptBR" then return end
 
-local addon = _G.HorizonSuite
+local addon = _G._HorizonSuite_Loading or _G.HorizonSuiteBeta or _G.HorizonSuite
 if not addon then return end
 
 local L = setmetatable({}, { __index = addon.L })
@@ -201,7 +201,17 @@ L["DASH_WELCOME_CONTRIBUTORS_BODY"]                           = [=[Thanks to eve
 -- L["DASH_WELCOME_SUPPORTERS_HEADING"]                       = "Supporters"
 -- L["DASH_WELCOME_SUPPORTERS_BODY"]                          = [=[Thank you to everyone who supports Horizon Suite through Ko-fi, Patreon, and other channels.]=]
 -- L["DASH_WELCOME_LOCALISATIONS_HEADING"]                    = "Localisations"
--- L["DASH_WELCOME_LOCALISATIONS_BODY"] = ... (falls back to enUS until retranslated against new path layout)
+-- L["DASH_WELCOME_LOCALISATIONS_BODY"]                       = [=[The addon UI is localised for:
+-- 
+-- • German (deDE) — `localisation/horizon/deDE.lua`
+-- • English (enUS) — `localisation/horizon/enUS.lua`
+-- • Spanish (esES) — `localisation/horizon/esES.lua`
+-- • French (frFR) — `localisation/horizon/frFR.lua`
+-- • Korean (koKR) — `localisation/horizon/koKR.lua`
+-- • Brazilian Portuguese (ptBR) — `localisation/horizon/ptBR.lua`
+-- • Chinese (zhCN) — `localisation/horizon/zhCN.lua`
+-- 
+-- See contributions/translate.md in the repo for how to contribute. Additional locales are welcome via Discord.]=]
 
 
 -- =====================================================================
@@ -315,6 +325,9 @@ L["FOCUS_CONTENT_TYPES"]                                      = "Tipos de Conte�
 -- L["FOCUS_DELVES"]                                          = "Delves"
 L["FOCUS_DELVES_DUNGEONS"]                                    = "Delves e Masmorras"
 L["FOCUS_DELVE_COMPLETE"]                                     = "Delve concluído"
+-- L["FOCUS_RITUAL_SITE_TITLE_COUNTERS"]                      = "Ritual Site Title Counters"
+-- L["FOCUS_RITUAL_SITE_TITLE_COUNTERS_DESC"]                 = "Show Ritual Site spoils and deaths beside the scenario title."
+-- L["FOCUS_RITUAL_SITE_TITLE_COUNTERS_TOOLTIP"]              = "Uses the same title-row counter style as Delves when the scenario provides header currency icons."
 L["FOCUS_INTERACTIONS"]                                       = "Interações"
 -- L["FOCUS_LAYOUT_TAB_DESC"]                                 = "Configure and customise settings related to layout."
 -- L["FOCUS_APPEARANCE_TAB_DESC"]                             = "Tracker panel look, fading, and list layout (header, sections, entries, timers, emphasis)."
@@ -375,6 +388,8 @@ L["AXIS_GLOBAL_TOGGLES"]                                      = "Global Toggles"
 -- L["AXIS_GLOBAL_FONT_SECTION"]                              = "Global Font (Coming Soon!)"
 -- L["AXIS_GLOBAL_SCALE_SECTION"]                             = "Global Scale"
 -- L["AXIS_MINIMAP_ICON_SECTION"]                             = "Minimap Icon"
+-- L["AXIS_MINIMAP_ICON_CIRCULAR"]                            = "Circular icon"
+-- L["AXIS_MINIMAP_ICON_CIRCULAR_DESC"]                       = "Round the Horizon minimap icon and add a gold ring border to match calendar, clock, and other circular minimap buttons."
 -- L["AXIS_CLASS_THEME_SECTION"]                              = "Class Theme"
 -- L["AXIS_GLOBAL_CLASS_THEME"]                               = "Global Class Theme"
 -- L["AXIS_CLASS_THEME_DASHBOARD"]                            = "Dashboard"
@@ -404,7 +419,7 @@ L["INSIGHT_SCALE"]                                            = "Escala do Insig
 L["AXIS_SCALE_INSIGHT_TOOLTIP_MODULE"]                        = "Escala do módulo de tooltip Insight (50–200%)."
 L["CACHE_SCALE"]                                              = "Escala do Cache"
 L["AXIS_SCALE_CACHE_LOOT_TOAST_MODULE"]                       = "Escala do módulo de notificação de saque Cache (50–200%)."
--- L["CACHE_FONT"]                                            = "Loot toast font"
+L["CACHE_FONT"]                                               = "Loot toast font"
 -- L["CACHE_FONT_FAMILY"]                                     = "Font family used for loot toast text. Use 'Use global font' to follow the addon-wide font."
 L["AXIS_ENABLE_HORIZON_INSIGHT_MODULE"]                       = "Ativar Módulo Horizon Insight"
 L["AXIS_CINEMATIC_TOOLTIPS_CLASS_COLOURS_SPEC_DISPLAY"]       = "Tooltips cinematográficos com cores de classe, exibição de especialização e ícones de facção."
@@ -985,6 +1000,11 @@ L["DASHBOARD_TYPO_OUTLINE"]                                   = "Dashboard text 
 L["DASHBOARD_TYPO_OUTLINE_DESC"]                              = "When on, dashboard UI text uses the standard outlined font style. Turn off for a softer, flat look."
 L["DASHBOARD_TYPO_SHADOW"]                                    = "Dashboard text shadow"
 L["DASHBOARD_TYPO_SHADOW_DESC"]                               = "Adds a subtle drop shadow behind dashboard text to improve readability on busy backgrounds."
+-- L["DASHBOARD_TYPO_HEADING_COLOR"]                          = "Heading Colour"
+-- L["DASHBOARD_TYPO_HEADING_COLOR_DESC"]                     = "Colour of the large headings on the Welcome and News tabs. Use a softer tone if pure white feels too bright on HDR displays."
+-- L["DASHBOARD_TYPO_HEADING_COLOR_WHITE"]                    = "White (default)"
+-- L["DASHBOARD_TYPO_HEADING_COLOR_CYAN"]                     = "Cyan (relaxed)"
+-- L["DASHBOARD_TYPO_HEADING_COLOR_GOLD"]                     = "Gold (relaxed)"
 L["FOCUS_BACKDROP_OPACITY"]                                   = "Opacidade do fundo"
 L["FOCUS_PANEL_BACKGROUND_OPACITY"]                           = "Opacidade do fundo do painel (0–1)."
 L["FOCUS_BORDER"]                                             = "Mostrar borda"
@@ -1236,6 +1256,9 @@ L["PRESENCE_SMALL_SECONDARY_SIZE"]                            = "Small secondary
 -- =====================================================================
 L["FOCUS_OUTLINE_NONE"]                                       = "Nenhum"
 L["FOCUS_THICK_OUTLINE"]                                      = "Contorno espesso"
+-- L["FOCUS_SLUG"]                                            = "SLUG"
+-- L["FOCUS_SLUG_OUTLINE"]                                    = "SLUG Outline"
+-- L["FOCUS_SLUG_THICK_OUTLINE"]                              = "SLUG Thick Outline"
 
 -- =====================================================================
 -- OptionsData.lua Dropdown options — Highlight style
@@ -1576,10 +1599,10 @@ L["VISTA_KEEP_MOUSEOVER_BAR_VISIBLE_TIMES_YOU"]               = "Mantém a barra
 L["VISTA_MOUSEOVER_BAR"]                                      = "Barra ao passar o mouse"
 L["VISTA_RIGHT_CLICK_PANEL"]                                  = "Painel com botão direito"
 L["VISTA_FLOATING_DRAWER"]                                    = "Gaveta flutuante"
--- L["VISTA_DRAWER_BUTTON_ICON"]                              = "Drawer button icon"
+L["VISTA_DRAWER_BUTTON_ICON"]                                 = "Drawer button icon"
 L["VISTA_DRAWER_BUTTON_ICON_DESC"]                            = "Enter a Blizzard icon file ID or texture path. Leave blank to use the default drawer icon."
 -- L["VISTA_CHOOSE_ICON"]                                     = "Choose icon"
-L["VISTA_CHOOSE_DRAWER_ICON"]                                 = "Choose Drawer Icon"
+-- L["VISTA_CHOOSE_DRAWER_ICON"]                              = "Choose Drawer Icon"
 L["VISTA_LOCK_DRAWER_BUTTON_POSITION"]                        = "Bloquear posição do botão gaveta"
 L["VISTA_PREVENT_DRAGGING_FLOATING_DRAWER_BUTTON"]            = "Impede arrastar o botão da gaveta flutuante."
 L["VISTA_LOCK_MOUSEOVER_BAR_POSITION"]                        = "Bloquear posição da barra ao passar o mouse"
@@ -1651,7 +1674,7 @@ L["AFFIX_ICONS"]                                              = "Affix icons"
 L["AFFIX_TOOLTIPS"]                                           = "Affix tooltips"
 -- L["AFFECTS_SCENARIO_PROGRESS_TIMER_BARS"]                  = "Also affects scenario progress and timer bars."
 L["ALWAYS"]                                                   = "Always show"
--- L["ALWAYS_M_TIMER"]                                        = "Always show M+ timer."
+L["ALWAYS_M_TIMER"]                                           = "Always show M+ timer."
 -- L["AUTO_ADD_WQS_YOUR_CURRENT_ZONE"]                        = "Auto-add WQs in your current zone."
 -- L["AUTO_CLOSE_DELAY_DISABLE"]                              = "Auto-close delay (0 to disable)."
 -- L["AUTO_UNTRACK_FINISHED_ACTIVITIES"]                      = "Auto-untrack finished activities."
@@ -1865,7 +1888,7 @@ L["FOCUS_AH_CRAFT_HINT_TIER"]                                 = "Crafting tier 1
 -- L["RECENT_PROGRESS_TOP"]                                   = "Show recent progress at the top."
 -- L["RECIPE_ICON_NEXT_TITLE_REQUIRES_QUEST"]                 = "Show recipe icon next to title. Requires quest type icons in Display."
 L["SECTION_DIVIDERS"]                                         = "Show section dividers"
--- L["M_BLOCK_WHENEVER_AN_ACTIVE_KEYSTONE"]                   = "Show the M+ block whenever an active keystone is running."
+L["M_BLOCK_WHENEVER_AN_ACTIVE_KEYSTONE"]                      = "Show the M+ block whenever an active keystone is running."
 -- L["TRACKED_PROFESSION_RECIPES_LIST"]                       = "Show tracked profession recipes in the list."
 -- L["TRACKER_HEROIC_DUNGEONS"]                               = "Show tracker in Heroic dungeons. When unset, uses the master dungeon toggle."
 -- L["TRACKER_HEROIC_RAIDS"]                                  = "Show tracker in Heroic raids. When unset, uses the master raid toggle."
@@ -1925,6 +1948,7 @@ L["ZONE_LABELS"]                                              = "Zone labels"
 -- L["ZONE_NAME_NEW_ZONE"]                                    = "Zone name still appears when entering a new zone."
 L["ZONE_TYPE_COLOURING"]                                      = "Zone type colouring"
 -- L["FOCUS_COMPLETED_CHECKMARK"]                             = "|TInterface\\\\Buttons\\\\UI-CheckBox-Check:12:12:0:0|t instead of green for done objectives."
+
 
 
 

--- a/localisation/horizon/ptBR.lua
+++ b/localisation/horizon/ptBR.lua
@@ -201,7 +201,7 @@ L["DASH_WELCOME_CONTRIBUTORS_BODY"]                           = [=[Thanks to eve
 -- L["DASH_WELCOME_SUPPORTERS_HEADING"]                       = "Supporters"
 -- L["DASH_WELCOME_SUPPORTERS_BODY"]                          = [=[Thank you to everyone who supports Horizon Suite through Ko-fi, Patreon, and other channels.]=]
 -- L["DASH_WELCOME_LOCALISATIONS_HEADING"]                    = "Localisations"
--- L["DASH_WELCOME_LOCALISATIONS_BODY"]                       = [=[The addon UI is localised for:
+L["DASH_WELCOME_LOCALISATIONS_BODY"]                          = [=[The addon UI is localised for:
 -- 
 -- • German (deDE) — `localisation/horizon/deDE.lua`
 -- • English (enUS) — `localisation/horizon/enUS.lua`
@@ -389,7 +389,7 @@ L["AXIS_GLOBAL_TOGGLES"]                                      = "Global Toggles"
 -- L["AXIS_GLOBAL_SCALE_SECTION"]                             = "Global Scale"
 -- L["AXIS_MINIMAP_ICON_SECTION"]                             = "Minimap Icon"
 -- L["AXIS_MINIMAP_ICON_CIRCULAR"]                            = "Circular icon"
--- L["AXIS_MINIMAP_ICON_CIRCULAR_DESC"]                       = "Round the Horizon minimap icon and add a gold ring border to match calendar, clock, and other circular minimap buttons."
+L["AXIS_MINIMAP_ICON_CIRCULAR_DESC"]                          = "Round the Horizon minimap icon and add a gold ring border to match calendar, clock, and other circular minimap buttons."
 -- L["AXIS_CLASS_THEME_SECTION"]                              = "Class Theme"
 -- L["AXIS_GLOBAL_CLASS_THEME"]                               = "Global Class Theme"
 -- L["AXIS_CLASS_THEME_DASHBOARD"]                            = "Dashboard"
@@ -1948,6 +1948,7 @@ L["ZONE_LABELS"]                                              = "Zone labels"
 -- L["ZONE_NAME_NEW_ZONE"]                                    = "Zone name still appears when entering a new zone."
 L["ZONE_TYPE_COLOURING"]                                      = "Zone type colouring"
 -- L["FOCUS_COMPLETED_CHECKMARK"]                             = "|TInterface\\\\Buttons\\\\UI-CheckBox-Check:12:12:0:0|t instead of green for done objectives."
+
 
 
 

--- a/localisation/horizon/zhCN.lua
+++ b/localisation/horizon/zhCN.lua
@@ -202,7 +202,7 @@ L["DASH_WELCOME_CONTRIBUTORS_BODY"]                           = [=[Thanks to eve
 -- L["DASH_WELCOME_SUPPORTERS_HEADING"]                       = "Supporters"
 -- L["DASH_WELCOME_SUPPORTERS_BODY"]                          = [=[Thank you to everyone who supports Horizon Suite through Ko-fi, Patreon, and other channels.]=]
 -- L["DASH_WELCOME_LOCALISATIONS_HEADING"]                    = "Localisations"
--- L["DASH_WELCOME_LOCALISATIONS_BODY"]                       = [=[The addon UI is localised for:
+L["DASH_WELCOME_LOCALISATIONS_BODY"]                          = [=[The addon UI is localised for:
 -- 
 -- • German (deDE) — `localisation/horizon/deDE.lua`
 -- • English (enUS) — `localisation/horizon/enUS.lua`
@@ -390,7 +390,7 @@ L["AXIS_GLOBAL_TOGGLES"]                                      = "Global Toggles"
 -- L["AXIS_GLOBAL_SCALE_SECTION"]                             = "Global Scale"
 -- L["AXIS_MINIMAP_ICON_SECTION"]                             = "Minimap Icon"
 -- L["AXIS_MINIMAP_ICON_CIRCULAR"]                            = "Circular icon"
--- L["AXIS_MINIMAP_ICON_CIRCULAR_DESC"]                       = "Round the Horizon minimap icon and add a gold ring border to match calendar, clock, and other circular minimap buttons."
+L["AXIS_MINIMAP_ICON_CIRCULAR_DESC"]                          = "Round the Horizon minimap icon and add a gold ring border to match calendar, clock, and other circular minimap buttons."
 -- L["AXIS_CLASS_THEME_SECTION"]                              = "Class Theme"
 -- L["AXIS_GLOBAL_CLASS_THEME"]                               = "Global Class Theme"
 -- L["AXIS_CLASS_THEME_DASHBOARD"]                            = "Dashboard"
@@ -1949,6 +1949,7 @@ L["ZONE_LABELS"]                                              = "Zone labels"
 -- L["ZONE_NAME_NEW_ZONE"]                                    = "Zone name still appears when entering a new zone."
 L["ZONE_TYPE_COLOURING"]                                      = "Zone type colouring"
 -- L["FOCUS_COMPLETED_CHECKMARK"]                             = "|TInterface\\\\Buttons\\\\UI-CheckBox-Check:12:12:0:0|t instead of green for done objectives."
+
 
 
 

--- a/localisation/horizon/zhCN.lua
+++ b/localisation/horizon/zhCN.lua
@@ -1,6 +1,6 @@
 if GetLocale() ~= "zhCN" then return end
 
-local addon = _G.HorizonSuite
+local addon = _G._HorizonSuite_Loading or _G.HorizonSuiteBeta or _G.HorizonSuite
 if not addon then return end
 
 local L = setmetatable({}, { __index = addon.L })
@@ -202,7 +202,17 @@ L["DASH_WELCOME_CONTRIBUTORS_BODY"]                           = [=[Thanks to eve
 -- L["DASH_WELCOME_SUPPORTERS_HEADING"]                       = "Supporters"
 -- L["DASH_WELCOME_SUPPORTERS_BODY"]                          = [=[Thank you to everyone who supports Horizon Suite through Ko-fi, Patreon, and other channels.]=]
 -- L["DASH_WELCOME_LOCALISATIONS_HEADING"]                    = "Localisations"
--- L["DASH_WELCOME_LOCALISATIONS_BODY"] = ... (falls back to enUS until retranslated against new path layout)
+-- L["DASH_WELCOME_LOCALISATIONS_BODY"]                       = [=[The addon UI is localised for:
+-- 
+-- • German (deDE) — `localisation/horizon/deDE.lua`
+-- • English (enUS) — `localisation/horizon/enUS.lua`
+-- • Spanish (esES) — `localisation/horizon/esES.lua`
+-- • French (frFR) — `localisation/horizon/frFR.lua`
+-- • Korean (koKR) — `localisation/horizon/koKR.lua`
+-- • Brazilian Portuguese (ptBR) — `localisation/horizon/ptBR.lua`
+-- • Chinese (zhCN) — `localisation/horizon/zhCN.lua`
+-- 
+-- See contributions/translate.md in the repo for how to contribute. Additional locales are welcome via Discord.]=]
 
 
 -- =====================================================================
@@ -316,6 +326,9 @@ L["FOCUS_CONTENT_TYPES"]                                      = "内容类型"
 L["FOCUS_DELVES"]                                             = "地下堡"
 L["FOCUS_DELVES_DUNGEONS"]                                    = "地下堡与地下城"
 L["FOCUS_DELVE_COMPLETE"]                                     = "地下堡完成"
+-- L["FOCUS_RITUAL_SITE_TITLE_COUNTERS"]                      = "Ritual Site Title Counters"
+-- L["FOCUS_RITUAL_SITE_TITLE_COUNTERS_DESC"]                 = "Show Ritual Site spoils and deaths beside the scenario title."
+-- L["FOCUS_RITUAL_SITE_TITLE_COUNTERS_TOOLTIP"]              = "Uses the same title-row counter style as Delves when the scenario provides header currency icons."
 L["FOCUS_INTERACTIONS"]                                       = "交互"
 -- L["FOCUS_LAYOUT_TAB_DESC"]                                 = "Configure and customise settings related to layout."
 -- L["FOCUS_APPEARANCE_TAB_DESC"]                             = "Tracker panel look, fading, and list layout (header, sections, entries, timers, emphasis)."
@@ -376,6 +389,8 @@ L["AXIS_GLOBAL_TOGGLES"]                                      = "Global Toggles"
 -- L["AXIS_GLOBAL_FONT_SECTION"]                              = "Global Font (Coming Soon!)"
 -- L["AXIS_GLOBAL_SCALE_SECTION"]                             = "Global Scale"
 -- L["AXIS_MINIMAP_ICON_SECTION"]                             = "Minimap Icon"
+-- L["AXIS_MINIMAP_ICON_CIRCULAR"]                            = "Circular icon"
+-- L["AXIS_MINIMAP_ICON_CIRCULAR_DESC"]                       = "Round the Horizon minimap icon and add a gold ring border to match calendar, clock, and other circular minimap buttons."
 -- L["AXIS_CLASS_THEME_SECTION"]                              = "Class Theme"
 -- L["AXIS_GLOBAL_CLASS_THEME"]                               = "Global Class Theme"
 -- L["AXIS_CLASS_THEME_DASHBOARD"]                            = "Dashboard"
@@ -405,7 +420,7 @@ L["INSIGHT_SCALE"]                                            = "洞察缩放"
 L["AXIS_SCALE_INSIGHT_TOOLTIP_MODULE"]                        = "洞察提示模块缩放(50-200%)"
 L["CACHE_SCALE"]                                              = "Cache缩放"
 L["AXIS_SCALE_CACHE_LOOT_TOAST_MODULE"]                       = "Cache战利品提示模块缩放(50-200%)"
--- L["CACHE_FONT"]                                            = "Loot toast font"
+L["CACHE_FONT"]                                               = "Loot toast font"
 -- L["CACHE_FONT_FAMILY"]                                     = "Font family used for loot toast text. Use 'Use global font' to follow the addon-wide font."
 L["AXIS_ENABLE_HORIZON_INSIGHT_MODULE"]                       = "启用Horizon洞察模块"
 L["AXIS_CINEMATIC_TOOLTIPS_CLASS_COLOURS_SPEC_DISPLAY"]       = "电影级提示框, 带有职业颜色, 专精显示和阵营图标."
@@ -986,6 +1001,11 @@ L["DASHBOARD_TYPO_OUTLINE"]                                   = "Dashboard text 
 L["DASHBOARD_TYPO_OUTLINE_DESC"]                              = "When on, dashboard UI text uses the standard outlined font style. Turn off for a softer, flat look."
 L["DASHBOARD_TYPO_SHADOW"]                                    = "Dashboard text shadow"
 L["DASHBOARD_TYPO_SHADOW_DESC"]                               = "Adds a subtle drop shadow behind dashboard text to improve readability on busy backgrounds."
+-- L["DASHBOARD_TYPO_HEADING_COLOR"]                          = "Heading Colour"
+-- L["DASHBOARD_TYPO_HEADING_COLOR_DESC"]                     = "Colour of the large headings on the Welcome and News tabs. Use a softer tone if pure white feels too bright on HDR displays."
+-- L["DASHBOARD_TYPO_HEADING_COLOR_WHITE"]                    = "White (default)"
+-- L["DASHBOARD_TYPO_HEADING_COLOR_CYAN"]                     = "Cyan (relaxed)"
+-- L["DASHBOARD_TYPO_HEADING_COLOR_GOLD"]                     = "Gold (relaxed)"
 L["FOCUS_BACKDROP_OPACITY"]                                   = "背景透明度"
 L["FOCUS_PANEL_BACKGROUND_OPACITY"]                           = "面板背景不透明度(0-1)"
 L["FOCUS_BORDER"]                                             = "显示边框"
@@ -1237,6 +1257,9 @@ L["PRESENCE_SMALL_SECONDARY_SIZE"]                            = "Small secondary
 -- =====================================================================
 L["FOCUS_OUTLINE_NONE"]                                       = "无"
 L["FOCUS_THICK_OUTLINE"]                                      = "粗轮廓"
+-- L["FOCUS_SLUG"]                                            = "SLUG"
+-- L["FOCUS_SLUG_OUTLINE"]                                    = "SLUG Outline"
+-- L["FOCUS_SLUG_THICK_OUTLINE"]                              = "SLUG Thick Outline"
 
 -- =====================================================================
 -- OptionsData.lua Dropdown options — Highlight style
@@ -1577,10 +1600,10 @@ L["VISTA_DISABLE_DONE"]                                       = "完成后禁用
 L["VISTA_MOUSEOVER_BAR"]                                      = "鼠标悬停条"
 L["VISTA_RIGHT_CLICK_PANEL"]                                  = "右键面板"
 L["VISTA_FLOATING_DRAWER"]                                    = "浮动抽屉"
--- L["VISTA_DRAWER_BUTTON_ICON"]                              = "Drawer button icon"
+L["VISTA_DRAWER_BUTTON_ICON"]                                 = "Drawer button icon"
 L["VISTA_DRAWER_BUTTON_ICON_DESC"]                            = "Enter a Blizzard icon file ID or texture path. Leave blank to use the default drawer icon."
 -- L["VISTA_CHOOSE_ICON"]                                     = "Choose icon"
-L["VISTA_CHOOSE_DRAWER_ICON"]                                 = "Choose Drawer Icon"
+-- L["VISTA_CHOOSE_DRAWER_ICON"]                              = "Choose Drawer Icon"
 L["VISTA_LOCK_DRAWER_BUTTON_POSITION"]                        = "锁定抽屉按钮位置"
 L["VISTA_PREVENT_DRAGGING_FLOATING_DRAWER_BUTTON"]            = "防止拖动浮动抽屉按钮"
 L["VISTA_LOCK_MOUSEOVER_BAR_POSITION"]                        = "锁定鼠标悬停条位置"
@@ -1652,7 +1675,7 @@ L["AFFIX_ICONS"]                                              = "Affix icons"
 L["AFFIX_TOOLTIPS"]                                           = "Affix tooltips"
 -- L["AFFECTS_SCENARIO_PROGRESS_TIMER_BARS"]                  = "Also affects scenario progress and timer bars."
 L["ALWAYS"]                                                   = "Always show"
--- L["ALWAYS_M_TIMER"]                                        = "Always show M+ timer."
+L["ALWAYS_M_TIMER"]                                           = "Always show M+ timer."
 -- L["AUTO_ADD_WQS_YOUR_CURRENT_ZONE"]                        = "Auto-add WQs in your current zone."
 -- L["AUTO_CLOSE_DELAY_DISABLE"]                              = "Auto-close delay (0 to disable)."
 -- L["AUTO_UNTRACK_FINISHED_ACTIVITIES"]                      = "Auto-untrack finished activities."
@@ -1866,7 +1889,7 @@ L["FOCUS_AH_CRAFT_HINT_TIER"]                                 = "Crafting tier 1
 -- L["RECENT_PROGRESS_TOP"]                                   = "Show recent progress at the top."
 -- L["RECIPE_ICON_NEXT_TITLE_REQUIRES_QUEST"]                 = "Show recipe icon next to title. Requires quest type icons in Display."
 L["SECTION_DIVIDERS"]                                         = "Show section dividers"
--- L["M_BLOCK_WHENEVER_AN_ACTIVE_KEYSTONE"]                   = "Show the M+ block whenever an active keystone is running."
+L["M_BLOCK_WHENEVER_AN_ACTIVE_KEYSTONE"]                      = "Show the M+ block whenever an active keystone is running."
 -- L["TRACKED_PROFESSION_RECIPES_LIST"]                       = "Show tracked profession recipes in the list."
 -- L["TRACKER_HEROIC_DUNGEONS"]                               = "Show tracker in Heroic dungeons. When unset, uses the master dungeon toggle."
 -- L["TRACKER_HEROIC_RAIDS"]                                  = "Show tracker in Heroic raids. When unset, uses the master raid toggle."
@@ -1926,6 +1949,7 @@ L["ZONE_LABELS"]                                              = "Zone labels"
 -- L["ZONE_NAME_NEW_ZONE"]                                    = "Zone name still appears when entering a new zone."
 L["ZONE_TYPE_COLOURING"]                                      = "Zone type colouring"
 -- L["FOCUS_COMPLETED_CHECKMARK"]                             = "|TInterface\\\\Buttons\\\\UI-CheckBox-Check:12:12:0:0|t instead of green for done objectives."
+
 
 
 

--- a/modules/Vista/VistaCore.lua
+++ b/modules/Vista/VistaCore.lua
@@ -3975,6 +3975,9 @@ function Vista.ApplyOptions(changedKey)
     if addon.MinimapButton_ApplyPosition then
         addon.MinimapButton_ApplyPosition()
     end
+    if addon.MinimapButton_ApplyShape then
+        addon.MinimapButton_ApplyShape()
+    end
 end
 
 --- Lightweight apply for position-lock toggles only: no proxy rebuild, no CollectMinimapButtons, no FullLayout (caller skips NotifyMainAddon).

--- a/modules/Vista/VistaCore.lua
+++ b/modules/Vista/VistaCore.lua
@@ -3975,9 +3975,6 @@ function Vista.ApplyOptions(changedKey)
     if addon.MinimapButton_ApplyPosition then
         addon.MinimapButton_ApplyPosition()
     end
-    if addon.MinimapButton_ApplyShape then
-        addon.MinimapButton_ApplyShape()
-    end
 end
 
 --- Lightweight apply for position-lock toggles only: no proxy rebuild, no CollectMinimapButtons, no FullLayout (caller skips NotifyMainAddon).

--- a/options/OptionsData.lua
+++ b/options/OptionsData.lua
@@ -1283,14 +1283,16 @@ local OptionCategories = {
                 C_Timer.After(0, function() setDB("minimapButtonLocked", v) end)
             end }
             opts[#opts + 1] = { type = "toggle", name = L["AXIS_MINIMAP_ICON_CIRCULAR"] or "Circular icon",
-                desc = L["AXIS_MINIMAP_ICON_CIRCULAR_DESC"] or "Round the Horizon minimap icon and add a gold ring border to match calendar, clock, and other circular minimap buttons.",
+                desc = L["AXIS_MINIMAP_ICON_CIRCULAR_DESC"] or "Round the Horizon icon, add a gold ring border, and snap it to the minimap's edge while dragging — matching calendar, clock, and other standard minimap buttons.",
                 dbKey = "minimapButtonCircular", visibleWhen = isMinimapStandalone,
                 get = function() return getDB("minimapButtonCircular", false) end,
                 set = function(v)
                     setDB("minimapButtonCircular", v)
                     if addon.MinimapButton_ApplyShape then addon.MinimapButton_ApplyShape() end
+                    -- Re-place the button: circular reads angle / square reads x/y.
+                    if addon.MinimapButton_ApplyPosition then addon.MinimapButton_ApplyPosition() end
                 end }
-            opts[#opts + 1] = { type = "button", dbKey = "__minimapButtonReset", name = L["PRESENCE_RESET_MINIMAP_BUTTON_POSITION"] or "Reset minimap button position", desc = L["PRESENCE_RESET_MINIMAP_BUTTON_DEFAULT_POSITION"] or "Reset the minimap button to the default position (bottom-left).", visibleWhen = isMinimapStandalone, onClick = function() setDB("minimapButtonX", nil); setDB("minimapButtonY", nil); if addon.MinimapButton_ApplyPosition then addon.MinimapButton_ApplyPosition() end end }
+            opts[#opts + 1] = { type = "button", dbKey = "__minimapButtonReset", name = L["PRESENCE_RESET_MINIMAP_BUTTON_POSITION"] or "Reset minimap button position", desc = L["PRESENCE_RESET_MINIMAP_BUTTON_DEFAULT_POSITION"] or "Reset the minimap button to the default position (bottom-left).", visibleWhen = isMinimapStandalone, onClick = function() setDB("minimapButtonX", nil); setDB("minimapButtonY", nil); setDB("minimapButtonAngle", nil); if addon.MinimapButton_ApplyPosition then addon.MinimapButton_ApplyPosition() end end }
             return opts
         end,
     },

--- a/options/OptionsData.lua
+++ b/options/OptionsData.lua
@@ -1282,6 +1282,14 @@ local OptionCategories = {
             opts[#opts + 1] = { type = "toggle", name = L["PRESENCE_LOCK_MINIMAP_BUTTON_POSITION"] or "Lock minimap button position", desc = L["PRESENCE_PREVENT_DRAGGING_HORIZON_MINIMAP_BUTTON"] or "Prevent dragging the Horizon minimap button.", dbKey = "minimapButtonLocked", visibleWhen = isMinimapStandalone, get = function() return getDB("minimapButtonLocked", false) end, set = function(v)
                 C_Timer.After(0, function() setDB("minimapButtonLocked", v) end)
             end }
+            opts[#opts + 1] = { type = "toggle", name = L["AXIS_MINIMAP_ICON_CIRCULAR"] or "Circular icon",
+                desc = L["AXIS_MINIMAP_ICON_CIRCULAR_DESC"] or "Round the Horizon minimap icon and add a gold ring border to match calendar, clock, and other circular minimap buttons.",
+                dbKey = "minimapButtonCircular", visibleWhen = isMinimapStandalone,
+                get = function() return getDB("minimapButtonCircular", false) end,
+                set = function(v)
+                    setDB("minimapButtonCircular", v)
+                    if addon.MinimapButton_ApplyShape then addon.MinimapButton_ApplyShape() end
+                end }
             opts[#opts + 1] = { type = "button", dbKey = "__minimapButtonReset", name = L["PRESENCE_RESET_MINIMAP_BUTTON_POSITION"] or "Reset minimap button position", desc = L["PRESENCE_RESET_MINIMAP_BUTTON_DEFAULT_POSITION"] or "Reset the minimap button to the default position (bottom-left).", visibleWhen = isMinimapStandalone, onClick = function() setDB("minimapButtonX", nil); setDB("minimapButtonY", nil); if addon.MinimapButton_ApplyPosition then addon.MinimapButton_ApplyPosition() end end }
             return opts
         end,


### PR DESCRIPTION
Closes #9

## Summary
Adds a new "Circular icon" toggle in **Axis → Minimap Icon** that turns the Horizon minimap icon into a stock-style minimap button: rounded silhouette, Blizzard's gold `MiniMap-TrackingBorder` ring, and magnetic-to-edge drag. Off by default — flip it on for the canonical look.

## What it does

**Shape & ring (when toggle is on):**
- Icon alpha-masked to a circle using `MASK_CIRCULAR_FILEDATAID` (`186178`, the same asset Vista uses on the minimap).
- LibDBIcon proportions: icon at 64% of button size with TOPLEFT(7/31, -5/31) inset; gold ring at 174% anchored TOPLEFT. The `MiniMap-TrackingBorder` texture's visible artwork is calibrated for these ratios — the icon now sits cleanly inside the ring.

**Magnetic positioning (when toggle is on):**
- Drag-stop snaps the button to the minimap edge at the cursor's angle.
- Position stored as `minimapButtonAngle` (radians). Legacy `minimapButtonX/Y` is migrated on first read so existing users land at the closest edge spot.
- `MinimapIsRoundShape()` honours Vista's `vistaCircular` when Vista is loaded, otherwise assumes round; `GetEdgePosition()` clamps the angle ray to the perimeter on a square minimap.
- A separate `dragHelper` frame carries the OnUpdate so it doesn't fight `FadeButton`'s own OnUpdate on `btn`.
- "Reset Minimap Button Position" clears x/y *and* angle.

**Off (default):** unchanged — square logo, free-drag x/y positioning. No surprise behaviour change for existing users.

## Decoupled from `vistaCircular`
The toggle is independent of Vista's circular-minimap option, so users can mix shapes (e.g. circular Horizon button on a square minimap, like calendar/clock always do regardless of minimap shape).

## Files
- `core/Config.lua` — exposes `addon.MASK_CIRCULAR_FILEDATAID = 186178`.
- `core/MinimapButton.lua` — `ApplyShape()`, `MinimapIsRoundShape()`, `GetEdgePosition()`, `ResolveButtonAngle()`, magnetic drag handlers.
- `options/OptionsData.lua` — new toggle in Axis → Minimap Icon; reset clears all three position keys.
- `Localisation/horizon/enUS.lua` — `AXIS_MINIMAP_ICON_CIRCULAR` / `_DESC` keys; non-enUS regenerated via `tools/restructure_locales.js`.

## Test plan
- [ ] Axis → Minimap Icon → toggle "Circular icon" on. The Horizon button immediately rounds, gains a gold ring, and snaps to its mode-appropriate spot. No `/reload` needed.
- [ ] Drag the circular button: it tracks the cursor along the minimap edge while holding, and stays on the edge after release.
- [ ] Toggle off: button reverts to the square logo and its previous free-drag x/y position.
- [ ] Resize the minimap (Vista → Minimap size slider) with circular on: the button stays on the edge as the minimap grows/shrinks.
- [ ] With Vista in square minimap mode (vistaCircular = false) and Horizon's circular icon on: the angle ray clamps to the square perimeter — drag corners and sides.
- [ ] Trigger an unread patch-notes state: green badge still pokes out of the top-right corner of the circular icon.
- [ ] Enable "Collect Horizon minimap button" in Axis: the collected proxy in Vista's bar keeps its existing shape (unaffected).
- [ ] "Reset minimap button position" clears all three position keys (x, y, angle) and the button returns to the bottom-left default in whichever mode is active.
- [ ] Existing users (with saved minimapButtonX/Y from a prior session) toggle circular on: the button lands at the closest edge spot, not the default corner — confirms migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)