### PR TITLE
Fix minimap highlight clearing

### DIFF
--- a/core/MinimapButton.lua
+++ b/core/MinimapButton.lua
@@ -243,7 +243,11 @@ local function ApplyShape()
         btn.icon:SetTexCoord(0.08, 0.92, 0.08, 0.92)
         if iconMask then btn.icon:RemoveMaskTexture(iconMask) end
         if ringBorder then ringBorder:Hide() end
-        btn:SetHighlightTexture(nil)
+        local highlight = btn:GetHighlightTexture()
+        if highlight then
+            highlight:SetTexture(nil)
+            highlight:Hide()
+        end
     end
 end
 


### PR DESCRIPTION
## Summary
Fixes a minimap button regression from #204 where square minimap mode called `SetHighlightTexture(nil)`, which errors on current WoW clients.

## What changed
- Clears and hides the existing highlight texture instead of passing `nil` into `SetHighlightTexture`.
- Keeps circular minimap mode behavior unchanged.

## Validation
- Confirmed the change is limited to `core/MinimapButton.lua`.
- Verified local branch is clean before opening the PR.