### PR TITLE
chore(codeowners): require director approval on main

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,3 @@
-# Default code owner for the entire repository
-* @TLL-Chris
+# Default code owners for the entire repository
+# Approvals on `main` must come from a director (enforced via `require_code_owner_review`)
+* @TLL-Chris @TLL-Joe @TLL-Arnaud


### PR DESCRIPTION
## Summary
- Updates `.github/CODEOWNERS` to list all three directors (`@TLL-Chris @TLL-Joe @TLL-Arnaud`).
- Pairs with the new `protect-main` repo ruleset (`require_code_owner_review: true`) — once this lands on `main`, only director approvals satisfy the 1-approval requirement on `dev → main` promotion PRs.
- The `protect-dev` ruleset has `require_code_owner_review: false`, so feature → dev PRs continue to accept approvals from any Write+ collaborator.

## Test plan
- [ ] Merge into `dev`.
- [ ] Open a follow-up `dev → main` promotion PR and confirm the required-reviewers list shows the directors.
- [ ] Verify a non-director collaborator's approval does **not** satisfy the requirement on a `main` PR (any director will need to approve, or Chris bypasses).