### PR TITLE
v4.17.7 - Insight tooltip fixes, Presence outlines, circular Horizon button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,21 @@ All notable changes to Horizon Suite are documented here.
 
 ---
 
+## [4.17.7] – 2026-05-09
+
+### 🔧 Improvements
+
+- **(Vista) Circular Horizon button** — A round minimap-button variant so the Horizon icon matches addons like SexyMap and HidingBar that style their buttons round.
+- **(Presence) Font outline options** — Presence text gains the same outline picker as the rest of the addon (None, Thin Outline, Thick Outline, Monochrome Outline, SLUG).
+- **(Insight) Character titles and title colour** — Suffix titles now render correctly (including comma-prefixed forms like *"Aragorn, the Argent Champion"*), and a new Title Colour dropdown lets you pick **Match Name**, **Match Name (Gradient)**, or **Custom**.
+
+### 🐛 Fixes
+
+- **(Insight)** Guild rank now displays correctly in player tooltips — no more realm name leaking into the rank slot, and the rank sits inline beside the guild name.
+- **(Vista)** Square minimap mode no longer errors when clearing the Horizon button's highlight texture.
+
+---
+
 ## [4.17.6] – 2026-05-08
 
 ### 🔧 Improvements

--- a/HorizonSuite.toc
+++ b/HorizonSuite.toc
@@ -2,7 +2,7 @@
 ## Title: Horizon Suite
 ## Notes: Core addon with pluggable modules.
 ## Author: Crystilac
-## Version: 4.17.6
+## Version: 4.17.7
 ## SavedVariables: HorizonDB
 ## OptionalDeps: Auctionator, IconBrowser
 ## IconTexture: Interface\AddOns\HorizonSuite\HorizonLogo

--- a/core/PatchNotesData.lua
+++ b/core/PatchNotesData.lua
@@ -14,6 +14,25 @@ local addon = _G.HorizonSuite
 
 addon.PATCH_NOTES = {
 
+    ["4.17.7"] = {
+        date = "2026-05-09",
+        {
+            section = "Improvements",
+            bullets = {
+                "Vista: circular Horizon button variant to match SexyMap and HidingBar-style round minimap buttons.",
+                "Presence: font outline options (None, Thin Outline, Thick Outline, Monochrome Outline, SLUG).",
+                "Insight: suffix character titles now render correctly (including comma forms), with a new Title Colour mode picker (Match Name / Match Name (Gradient) / Custom).",
+            },
+        },
+        {
+            section = "Fixes",
+            bullets = {
+                "Insight: guild rank now displays correctly in player tooltips without realm name leakage.",
+                "Vista: square minimap mode no longer errors when clearing the Horizon button's highlight texture.",
+            },
+        },
+    },
+
     ["4.17.6"] = {
         date = "2026-05-08",
         {


### PR DESCRIPTION
## Summary

Release v4.17.7. Patch bump — three improvements and two fixes since v4.17.6.

## Contents

- #210 — Insight player tooltip: guild rank fix + suffix title rendering + Title Colour mode picker (via #211 / #214).
- #205 — Presence font outline options (via #206).
- #9 — Vista circular Horizon button variant (via #204).
- #209 — Vista minimap highlight clearing fix (no associated issue).

## Deploy implications

Tag push triggers `release.yml` (BigWigs packager → CurseForge + Wago + GitHub Release).

## Reviewer checklist

- [ ] CHANGELOG.md entry reads naturally — bullets are user-facing, no internal jargon.
- [ ] PatchNotesData key `["4.17.7"]` matches `## Version: 4.17.7` in the TOC.
- [ ] No new SavedVariables migration required for users on v4.17.6.