### PR TITLE
chore: backport main → dev (v4.17.7 + CODEOWNERS)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
 # Default code owners for the entire repository
 # Approvals on `main` must come from a director (enforced via `require_code_owner_review`)
-* @TLL-Chris @TLL-Joe @TLL-Arnaud
+* @TLL-Chris

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,21 @@ All notable changes to Horizon Suite are documented here.
 
 ---
 
+## [4.17.7] – 2026-05-09
+
+### 🔧 Improvements
+
+- **(Vista) Circular Horizon button** — A round minimap-button variant so the Horizon icon matches addons like SexyMap and HidingBar that style their buttons round.
+- **(Presence) Font outline options** — Presence text gains the same outline picker as the rest of the addon (None, Thin Outline, Thick Outline, Monochrome Outline, SLUG).
+- **(Insight) Character titles and title colour** — Suffix titles now render correctly (including comma-prefixed forms like *"Aragorn, the Argent Champion"*), and a new Title Colour dropdown lets you pick **Match Name**, **Match Name (Gradient)**, or **Custom**.
+
+### 🐛 Fixes
+
+- **(Insight)** Guild rank now displays correctly in player tooltips — no more realm name leaking into the rank slot, and the rank sits inline beside the guild name.
+- **(Vista)** Square minimap mode no longer errors when clearing the Horizon button's highlight texture.
+
+---
+
 ## [4.17.6] – 2026-05-08
 
 ### 🔧 Improvements

--- a/HorizonSuite.toc
+++ b/HorizonSuite.toc
@@ -2,7 +2,7 @@
 ## Title: Horizon Suite
 ## Notes: Core addon with pluggable modules.
 ## Author: Crystilac
-## Version: 4.17.6
+## Version: 4.17.7
 ## SavedVariables: HorizonDB
 ## OptionalDeps: Auctionator, IconBrowser
 ## IconTexture: Interface\AddOns\HorizonSuite\HorizonLogo

--- a/core/PatchNotesData.lua
+++ b/core/PatchNotesData.lua
@@ -14,6 +14,25 @@ local addon = _G.HorizonSuite
 
 addon.PATCH_NOTES = {
 
+    ["4.17.7"] = {
+        date = "2026-05-09",
+        {
+            section = "Improvements",
+            bullets = {
+                "Vista: circular Horizon button variant to match SexyMap and HidingBar-style round minimap buttons.",
+                "Presence: font outline options (None, Thin Outline, Thick Outline, Monochrome Outline, SLUG).",
+                "Insight: suffix character titles now render correctly (including comma forms), with a new Title Colour mode picker (Match Name / Match Name (Gradient) / Custom).",
+            },
+        },
+        {
+            section = "Fixes",
+            bullets = {
+                "Insight: guild rank now displays correctly in player tooltips without realm name leakage.",
+                "Vista: square minimap mode no longer errors when clearing the Horizon button's highlight texture.",
+            },
+        },
+    },
+
     ["4.17.6"] = {
         date = "2026-05-08",
         {


### PR DESCRIPTION
## Summary

Backport PR: `main → dev`. Brings dev in line with main after the v4.17.7 release and the CODEOWNERS direct-to-main update that bypassed dev.

## Changes

- v4.17.7 release artifacts: CHANGELOG entry, TOC version bump, PatchNotesData entry (from #217).
- CODEOWNERS simplified to `@TLL-Chris` only (from #216).

This is a one-way infrastructure sync — no product code differs between main and dev (the Insight + outline + circular-button changes were already on dev via #211, #206, #204). Per the org's backport rule, infrastructure files (CODEOWNERS, release manifests) on main must not drift from dev.

## Test plan

- File-level diff `git diff origin/dev..origin/main` confirmed: only CHANGELOG, TOC, PatchNotesData, and CODEOWNERS differ — no module/code drift.

## Reviewer checklist

- [ ] Confirm the PR diff matches the four files listed above and nothing else (no accidental product-code carryover).
- [ ] Judgment call: any reason to delay merging? (e.g. another feature mid-flight on dev that this would conflict with on rebase)