### PR TITLE
chore(ci): auto-assign reviewers on dev PRs

### DIFF
--- a/.github/workflows/auto-assign-dev-reviewers.yml
+++ b/.github/workflows/auto-assign-dev-reviewers.yml
@@ -1,0 +1,37 @@
+name: Auto-assign reviewers on dev PRs
+
+# When a PR targets `dev`, auto-request review from every member of the
+# reviewer pool except the PR author. Only runs for PRs whose base is `dev`,
+# so promotion PRs to `main` are unaffected.
+#
+# Reviewer pool: Chris + the three named contributors. Update the list below
+# when collaborators join or leave.
+
+on:
+  pull_request_target:
+    types: [opened, ready_for_review, reopened]
+    branches:
+      - dev
+
+permissions:
+  pull-requests: write
+
+jobs:
+  assign:
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    steps:
+      - name: Request reviewers
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pool = ['TLL-Chris', 'nightsofglass', 'ProgrammingSam', 'SwiftMint'];
+            const author = context.payload.pull_request.user.login;
+            const reviewers = pool.filter(login => login.toLowerCase() !== author.toLowerCase());
+            if (reviewers.length === 0) return;
+            await github.rest.pulls.requestReviewers({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.payload.pull_request.number,
+              reviewers,
+            });


### PR DESCRIPTION
## Summary
Adds `.github/workflows/auto-assign-dev-reviewers.yml`. When a PR targets `dev`, the workflow requests review from every member of the reviewer pool except the PR author.

**Reviewer pool:** `TLL-Chris`, `nightsofglass`, `ProgrammingSam`, `SwiftMint`.

**Why a workflow and not CODEOWNERS:** CODEOWNERS on `dev` would also land on `main` via promotion PRs, conflicting with main's directors-only `* @TLL-Chris` rule. A workflow scoped to `branches: [dev]` keeps the assignment logic separate from the merge-time approval rules.

**Properties:**
- Triggers on `pull_request_target` (opened, ready_for_review, reopened) so it works for fork-based PRs from outside contributors.
- Skips drafts.
- Filters the author out of the request list (you can't request review from yourself anyway, but the explicit filter avoids a 422 from the API).
- Updates required when contributors join/leave — edit the `pool` array.

## Test plan
- [ ] Merge into `dev`.
- [ ] Open a throwaway feature PR into `dev` from a non-author and confirm the three other pool members get requested.
- [ ] Open a `dev → main` promotion PR and confirm the workflow does **not** run (its `branches: [dev]` filter excludes main).