### PR TITLE
chore(ci): auto-assign reviewers on dev PRs

### DIFF
--- a/.github/workflows/auto-assign-dev-reviewers.yml
+++ b/.github/workflows/auto-assign-dev-reviewers.yml
@@ -1,0 +1,37 @@
+name: Auto-assign reviewers on dev PRs
+
+# When a PR targets `dev`, auto-request review from every member of the
+# reviewer pool except the PR author. Only runs for PRs whose base is `dev`,
+# so promotion PRs to `main` are unaffected.
+#
+# Reviewer pool: Chris + the three named contributors. Update the list below
+# when collaborators join or leave.
+
+on:
+  pull_request_target:
+    types: [opened, ready_for_review, reopened]
+    branches:
+      - dev
+
+permissions:
+  pull-requests: write
+
+jobs:
+  assign:
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    steps:
+      - name: Request reviewers
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pool = ['TLL-Chris', 'nightsofglass', 'ProgrammingSam', 'SwiftMint'];
+            const author = context.payload.pull_request.user.login;
+            const reviewers = pool.filter(login => login.toLowerCase() !== author.toLowerCase());
+            if (reviewers.length === 0) return;
+            await github.rest.pulls.requestReviewers({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.payload.pull_request.number,
+              reviewers,
+            });


### PR DESCRIPTION
## Summary
Re-raise of #219 (which was wiped from dev by a force-push). Adds `.github/workflows/auto-assign-dev-reviewers.yml` — auto-requests review from the pool minus the PR author whenever a PR targets `dev`.

**Reviewer pool:** `TLL-Chris`, `nightsofglass`, `ProgrammingSam`, `SwiftMint`.

**Why dev only (no need to also be on main):** the workflow's `on.pull_request_target.branches: [dev]` filter scopes it to PRs targeting `dev`. The workflow definition is read from the base branch of the triggering PR, so as long as the file is on `dev`, dev PRs will run it. When this eventually lands on `main` via a promotion PR, the file sits inert on main — no PRs target main except promotion PRs (which originate from dev and don't match the filter anyway).

## Test plan
- [ ] Merge into `dev`.
- [ ] Open a throwaway feature PR into `dev` from a contributor account; confirm the three other pool members get auto-requested.
- [ ] Open a `dev → main` promotion PR; confirm the workflow does **not** run.