### PR TITLE
chore(ci): populate Discord user-id map with contributors

### DIFF
--- a/.github/discord-user-map.json
+++ b/.github/discord-user-map.json
@@ -1,4 +1,7 @@
 {
   "_comment": "GitHub login -> Discord user ID. Used by .release/run-activity-post.sh to @mention assignees and requested reviewers. To add yourself: in Discord enable Developer Mode (Advanced settings), right-click your name, 'Copy User ID', then add a line below as \"GithubLogin\": \"DiscordUserId\". Logins are case-sensitive and match GitHub exactly. Discord IDs are 17-19 digit numeric strings.",
-  "TLL-Chris": ""
+  "TLL-Chris": "128996382194270208",
+  "nightofglass": "53735211015344128",
+  "ProgrammingSam": "1015992951182200943",
+  "Swiftmint": "330213693180608512"
 }


### PR DESCRIPTION
## Summary

Populates `.github/discord-user-map.json` with the four current contributor mappings so the activity-feed workflow can resolve GitHub logins into Discord pings on PR-opened (assignees) and review_requested events. Unmapped logins continue to fall back to plain `@login` text.

## Changes

- Replace the `TLL-Chris: ""` stub with real Discord IDs for TLL-Chris, nightofglass, ProgrammingSam, and Swiftmint

## Test plan

- `jq . .github/discord-user-map.json` — JSON parses; all four IDs are within the 17–19 digit range the schema comment documents
- The script's `discord_id_for` lookup is exercised by the existing dry-run smoke tests; this change only widens the dataset, doesn't alter logic

---

## Reviewer checklist

- [ ] Spot-check that the four GitHub logins are spelled exactly as they appear on github.com (case-sensitive — the lookup is a literal key match)
- [ ] Confirm each Discord ID belongs to the right person — pasting the wrong ID would silently @mention the wrong account on every PR they're assigned to
- [ ] Judgment call: are these four the right initial set, or should additional contributors be added in the same change to avoid a second round-trip?
