### PR TITLE
release: promote dev — Discord user-id map

### DIFF
--- a/.github/discord-user-map.json
+++ b/.github/discord-user-map.json
@@ -1,4 +1,7 @@
 {
   "_comment": "GitHub login -> Discord user ID. Used by .release/run-activity-post.sh to @mention assignees and requested reviewers. To add yourself: in Discord enable Developer Mode (Advanced settings), right-click your name, 'Copy User ID', then add a line below as \"GithubLogin\": \"DiscordUserId\". Logins are case-sensitive and match GitHub exactly. Discord IDs are 17-19 digit numeric strings.",
-  "TLL-Chris": ""
+  "TLL-Chris": "128996382194270208",
+  "nightofglass": "53735211015344128",
+  "ProgrammingSam": "1015992951182200943",
+  "Swiftmint": "330213693180608512"
 }


### PR DESCRIPTION
## Summary

Promotion PR: `dev → main`. Releases the Discord user-id map population so the activity-feed workflow can resolve contributor logins to @mentions in production.

## Contents

- #224 — chore(ci): populate Discord user-id map with contributors

## Deploy implications

- No application/addon changes. CI-only data file.
- Repo's `delete_branch_on_merge` is now disabled — the previous promotion auto-deleted `dev`, which is undesirable for a permanent branch. After this merge, `dev` will persist (this is the first promotion under the new setting).

---

## Reviewer checklist

- [ ] Spot-check the four GitHub logins in `.github/discord-user-map.json` — names are case-sensitive and a typo silently ghost-pings nobody (or the wrong person)
- [ ] Confirm `delete_branch_on_merge=false` is now active on the repo (Settings → General → Pull Requests) so this promotion doesn't delete `dev` again
- [ ] Judgment call: are these four contributors the current set, or should anyone else be added in a follow-up?
