### PR TITLE
fix(ci): show auto-assigned reviewers + polish PR-opened embed

### DIFF
--- a/.github/discord-user-map.json
+++ b/.github/discord-user-map.json
@@ -1,7 +1,7 @@
 {
   "_comment": "GitHub login -> Discord user ID. Used by .release/run-activity-post.sh to @mention assignees and requested reviewers. To add yourself: in Discord enable Developer Mode (Advanced settings), right-click your name, 'Copy User ID', then add a line below as \"GithubLogin\": \"DiscordUserId\". Logins are case-sensitive and match GitHub exactly. Discord IDs are 17-19 digit numeric strings.",
   "TLL-Chris": "128996382194270208",
-  "nightofglass": "53735211015344128",
+  "nightsofglass": "53735211015344128",
   "ProgrammingSam": "1015992951182200943",
-  "Swiftmint": "330213693180608512"
+  "SwiftMint": "330213693180608512"
 }

--- a/.github/workflows/activity-feed.yml
+++ b/.github/workflows/activity-feed.yml
@@ -41,4 +41,5 @@ jobs:
         env:
           WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_ACTIVITY }}
           GITHUB_REPOSITORY: ${{ github.repository }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: bash .release/run-activity-post.sh

--- a/.release/run-activity-post.sh
+++ b/.release/run-activity-post.sh
@@ -101,8 +101,51 @@ trim() {
   fi
 }
 
+# Strips a leading "## Summary" heading and any subsequent "## " section, so
+# the description in Discord is just the first prose paragraph rather than a
+# full markdown PR template. Falls back to the raw body if no headings exist.
+clean_pr_body() {
+  local body="$1"
+  if [ -z "$body" ]; then
+    printf ''
+    return
+  fi
+  # Drop the leading "## Summary" line (case-insensitive) plus any blank lines
+  # immediately after it, then cut off at the next "## " heading.
+  printf '%s' "$body" | awk '
+    BEGIN { stripping_summary = 0; saw_first_line = 0 }
+    !saw_first_line && /^[[:space:]]*##[[:space:]]+[Ss]ummary[[:space:]]*$/ {
+      stripping_summary = 1
+      saw_first_line = 1
+      next
+    }
+    stripping_summary && /^[[:space:]]*$/ { next }
+    /^##[[:space:]]/ && saw_first_line { exit }
+    { saw_first_line = 1; stripping_summary = 0; print }
+  ' | sed -E ':a;/^[[:space:]]*$/{$d;N;ba;}'
+}
+
+# Picks an embed color for a non-draft PR based on diff size. Small PRs get
+# the existing "opened blue" so nothing changes for routine work; medium
+# turns blue→teal, large turns orange, huge turns red. Drafts override this.
+color_for_pr_size() {
+  local changes="${1:-0}"
+  if [ "$changes" -ge 1000 ]; then
+    printf '%s' "$COLOR_PR_HUGE"
+  elif [ "$changes" -ge 250 ]; then
+    printf '%s' "$COLOR_PR_LARGE"
+  elif [ "$changes" -ge 50 ]; then
+    printf '%s' "$COLOR_PR_MEDIUM"
+  else
+    printf '%s' "$COLOR_OPENED"
+  fi
+}
+
 # --- Color palette (decimal) ---
-COLOR_OPENED=3447003          # blue
+COLOR_OPENED=3447003          # blue (small PRs)
+COLOR_PR_MEDIUM=1752220       # teal (50–249 changes)
+COLOR_PR_LARGE=15105570       # orange (250–999 changes)
+COLOR_PR_HUGE=15548997        # red (1000+ changes)
 COLOR_DRAFT=9807270           # slate gray
 COLOR_CLOSED_DONE=5763719     # green (completed)
 COLOR_CLOSED_DROP=9807270     # gray (not_planned / unmerged)
@@ -189,71 +232,93 @@ case "$EVENT_NAME" in
     mapfile -t ASSIGNEES < <(jq -r '.pull_request.assignees[].login' "$EVENT_PATH")
     case "$ACTION" in
       opened)
+        # Auto-assigned reviewers (added by another workflow's GITHUB_TOKEN)
+        # don't appear in this event's snapshot — and they don't fire a
+        # follow-up `review_requested` event either, because GitHub suppresses
+        # event recursion from GITHUB_TOKEN-driven actions. Sleep briefly to
+        # let any auto-assign workflow land, then refetch the live PR state
+        # so reviewers + diff stats + labels reflect the actual current PR.
+        sleep 8
+        LIVE_PR=$(gh api "repos/${REPO}/pulls/${NUMBER}" 2>/dev/null || echo "")
+        ADDS=0; DELS=0; FILES=0; LABELS_CHIPS=""
+        if [ -n "$LIVE_PR" ] && echo "$LIVE_PR" | jq -e . >/dev/null 2>&1; then
+          mapfile -t ASSIGNEES < <(echo "$LIVE_PR" | jq -r '.assignees[]?.login // empty')
+          mapfile -t REVIEWERS < <(echo "$LIVE_PR" | jq -r '.requested_reviewers[]?.login // empty')
+          ADDS=$(echo "$LIVE_PR"  | jq -r '.additions    // 0')
+          DELS=$(echo "$LIVE_PR"  | jq -r '.deletions    // 0')
+          FILES=$(echo "$LIVE_PR" | jq -r '.changed_files // 0')
+          LABELS_CHIPS=$(echo "$LIVE_PR" | jq -r '[.labels[]?.name] | map("`" + . + "`") | join(" ")')
+        else
+          REVIEWERS=()
+        fi
+        CHANGES=$((ADDS + DELS))
+
         if [ "$DRAFT" = "true" ]; then
           TITLE="📝 PR #${NUMBER} opened (draft) — $(trim "$PTITLE" 200)"
           COLOR=$COLOR_DRAFT
         else
           TITLE="🚀 PR #${NUMBER} opened — $(trim "$PTITLE" 200)"
-          COLOR=$COLOR_OPENED
-        fi
-        # Auto-assigned reviewers (added by another workflow's GITHUB_TOKEN)
-        # don't appear in this event's snapshot — and they don't fire a
-        # follow-up `review_requested` event either, because GitHub suppresses
-        # event recursion from GITHUB_TOKEN-driven actions. Sleep briefly to
-        # let any auto-assign workflow land, then refetch the live PR state.
-        sleep 8
-        LIVE_PR=$(gh api "repos/${REPO}/pulls/${NUMBER}" 2>/dev/null || echo "")
-        if [ -n "$LIVE_PR" ] && echo "$LIVE_PR" | jq -e . >/dev/null 2>&1; then
-          mapfile -t ASSIGNEES < <(echo "$LIVE_PR" | jq -r '.assignees[]?.login // empty')
-          mapfile -t REVIEWERS < <(echo "$LIVE_PR" | jq -r '.requested_reviewers[]?.login // empty')
-        else
-          REVIEWERS=()
+          COLOR=$(color_for_pr_size "$CHANGES")
         fi
 
-        # Build the assignee + reviewer lines. Pings only fire on opened, and
-        # only for users who aren't the PR author (skip self-pings).
+        # Resolve mention strings for the embed fields. Pings only fire on
+        # opened, and only for users who aren't the PR author (skip self-pings).
         ASSIGNEE_LINE=""
-        if [ "${#ASSIGNEES[@]}" -gt 0 ]; then
-          ASSIGNEE_LINE=$(mentions_for_logins "$AUTHOR_LOGIN" "${ASSIGNEES[@]}")
-        fi
+        [ "${#ASSIGNEES[@]}" -gt 0 ] && ASSIGNEE_LINE=$(mentions_for_logins "$AUTHOR_LOGIN" "${ASSIGNEES[@]}")
         REVIEWER_LINE=""
-        if [ "${#REVIEWERS[@]}" -gt 0 ]; then
-          REVIEWER_LINE=$(mentions_for_logins "$AUTHOR_LOGIN" "${REVIEWERS[@]}")
-        fi
+        [ "${#REVIEWERS[@]}" -gt 0 ] && REVIEWER_LINE=$(mentions_for_logins "$AUTHOR_LOGIN" "${REVIEWERS[@]}")
 
-        # Description block: one line for each non-empty role.
-        if [ -n "$ASSIGNEE_LINE" ]; then
-          DESCRIPTION="**Assigned:** ${ASSIGNEE_LINE}"
-        elif [ "${#ASSIGNEES[@]}" -gt 0 ]; then
-          DESCRIPTION="**Assigned:** _self-assigned to author_"
-        else
-          DESCRIPTION="**Assigned:** _unassigned_"
-        fi
+        # Description: just the cleaned body excerpt. Roles/branch/stats live
+        # in fields below for a key/value grid layout instead of stacked text.
+        BODY_CLEAN=$(clean_pr_body "$BODY")
+        DESCRIPTION=$(trim "$BODY_CLEAN" 400)
+
+        # Build the inline-fields grid. Order matters: people first
+        # (Reviewers, then Assigned if any), then context (Branch, Changes).
+        FIELDS_JSON='[]'
+        push_field() {  # name, value, inline (true|false)
+          FIELDS_JSON=$(jq -n \
+            --argjson arr "$FIELDS_JSON" \
+            --arg name "$1" --arg value "$2" \
+            --argjson inline "${3:-true}" \
+            '$arr + [{name: $name, value: $value, inline: $inline}]')
+        }
         if [ -n "$REVIEWER_LINE" ]; then
-          DESCRIPTION="${DESCRIPTION}"$'\n'"**Reviewers:** ${REVIEWER_LINE}"
+          push_field "Reviewers" "$REVIEWER_LINE" true
         elif [ "${#REVIEWERS[@]}" -gt 0 ]; then
-          DESCRIPTION="${DESCRIPTION}"$'\n'"**Reviewers:** _author requested own review_"
+          push_field "Reviewers" "_author requested own review_" true
         fi
+        # Skip the Assigned line entirely when nobody's assigned — most PRs
+        # in this repo use reviewers, not assignees, so an empty "_unassigned_"
+        # field is just noise.
+        if [ -n "$ASSIGNEE_LINE" ]; then
+          push_field "Assigned" "$ASSIGNEE_LINE" true
+        elif [ "${#ASSIGNEES[@]}" -gt 0 ]; then
+          push_field "Assigned" "_self-assigned to author_" true
+        fi
+        push_field "Branch" "\`${HEAD}\` → \`${BASE}\`" true
+        if [ "$FILES" -gt 0 ]; then
+          file_word="files"
+          [ "$FILES" -eq 1 ] && file_word="file"
+          push_field "Changes" "+${ADDS} / −${DELS} · ${FILES} ${file_word}" true
+        fi
+        # Labels render as backticked chips on a final non-inline row.
+        if [ -n "$LABELS_CHIPS" ]; then
+          push_field "Labels" "$LABELS_CHIPS" false
+        fi
+        EMBED_FIELDS="$FIELDS_JSON"
 
-        # Single ping line covers everyone the post wants attention from —
-        # assignees and reviewers, dedup'd via jq so a user assigned AND
-        # reviewing only pings once.
+        # Single ping line covers everyone we want to notify — assignees and
+        # reviewers, deduped so a user in both roles only pings once.
         PING_PARTS=""
         [ -n "$ASSIGNEE_LINE" ] && PING_PARTS="$ASSIGNEE_LINE"
         if [ -n "$REVIEWER_LINE" ]; then
-          if [ -n "$PING_PARTS" ]; then
-            PING_PARTS="$PING_PARTS $REVIEWER_LINE"
-          else
-            PING_PARTS="$REVIEWER_LINE"
-          fi
+          PING_PARTS="${PING_PARTS:+$PING_PARTS }$REVIEWER_LINE"
         fi
         if [ -n "$PING_PARTS" ]; then
+          # shellcheck disable=SC2086 # word-splitting is intentional here
           CONTENT=$(printf '%s\n' $PING_PARTS | awk '!seen[$0]++' | tr '\n' ' ' | sed 's/ $//')
         fi
-
-        DESCRIPTION="${DESCRIPTION}"$'\n'"**Branch:** \`${HEAD}\` → \`${BASE}\`"
-        BODY_TRIM=$(trim "$BODY" 500)
-        [ -n "$BODY_TRIM" ] && DESCRIPTION="${DESCRIPTION}"$'\n\n'"${BODY_TRIM}"
         ;;
       closed)
         MERGED=$(jq -r '.pull_request.merged // false' "$EVENT_PATH")
@@ -369,10 +434,11 @@ EMBED=$(jq -n \
   --arg author_icon "$AUTHOR_AVATAR" \
   --arg footer "${REPO}" \
   --arg ts "$TIMESTAMP" \
+  --argjson fields "${EMBED_FIELDS:-[]}" \
   '{
     title: $title,
     url: $url,
-    description: $desc,
+    description: (if $desc != "" then $desc else null end),
     color: $color,
     author: (
       if $author != "@" then
@@ -381,6 +447,7 @@ EMBED=$(jq -n \
          + (if $author_icon != "" then {icon_url: $author_icon} else {} end))
       else null end
     ),
+    fields: (if ($fields | length) > 0 then $fields else null end),
     footer: {text: $footer},
     timestamp: $ts
   } | with_entries(select(.value != null))')

--- a/.release/run-activity-post.sh
+++ b/.release/run-activity-post.sh
@@ -196,19 +196,61 @@ case "$EVENT_NAME" in
           TITLE="🚀 PR #${NUMBER} opened — $(trim "$PTITLE" 200)"
           COLOR=$COLOR_OPENED
         fi
-        # Build the assignee line. Pings only fire on opened, and only for
-        # assignees who aren't the author (skip self-pings).
+        # Auto-assigned reviewers (added by another workflow's GITHUB_TOKEN)
+        # don't appear in this event's snapshot — and they don't fire a
+        # follow-up `review_requested` event either, because GitHub suppresses
+        # event recursion from GITHUB_TOKEN-driven actions. Sleep briefly to
+        # let any auto-assign workflow land, then refetch the live PR state.
+        sleep 8
+        LIVE_PR=$(gh api "repos/${REPO}/pulls/${NUMBER}" 2>/dev/null || echo "")
+        if [ -n "$LIVE_PR" ] && echo "$LIVE_PR" | jq -e . >/dev/null 2>&1; then
+          mapfile -t ASSIGNEES < <(echo "$LIVE_PR" | jq -r '.assignees[]?.login // empty')
+          mapfile -t REVIEWERS < <(echo "$LIVE_PR" | jq -r '.requested_reviewers[]?.login // empty')
+        else
+          REVIEWERS=()
+        fi
+
+        # Build the assignee + reviewer lines. Pings only fire on opened, and
+        # only for users who aren't the PR author (skip self-pings).
+        ASSIGNEE_LINE=""
         if [ "${#ASSIGNEES[@]}" -gt 0 ]; then
           ASSIGNEE_LINE=$(mentions_for_logins "$AUTHOR_LOGIN" "${ASSIGNEES[@]}")
-          if [ -n "$ASSIGNEE_LINE" ]; then
-            CONTENT="$ASSIGNEE_LINE"
-            DESCRIPTION="**Assigned:** ${ASSIGNEE_LINE}"
-          else
-            DESCRIPTION="**Assigned:** _self-assigned to author_"
-          fi
+        fi
+        REVIEWER_LINE=""
+        if [ "${#REVIEWERS[@]}" -gt 0 ]; then
+          REVIEWER_LINE=$(mentions_for_logins "$AUTHOR_LOGIN" "${REVIEWERS[@]}")
+        fi
+
+        # Description block: one line for each non-empty role.
+        if [ -n "$ASSIGNEE_LINE" ]; then
+          DESCRIPTION="**Assigned:** ${ASSIGNEE_LINE}"
+        elif [ "${#ASSIGNEES[@]}" -gt 0 ]; then
+          DESCRIPTION="**Assigned:** _self-assigned to author_"
         else
           DESCRIPTION="**Assigned:** _unassigned_"
         fi
+        if [ -n "$REVIEWER_LINE" ]; then
+          DESCRIPTION="${DESCRIPTION}"$'\n'"**Reviewers:** ${REVIEWER_LINE}"
+        elif [ "${#REVIEWERS[@]}" -gt 0 ]; then
+          DESCRIPTION="${DESCRIPTION}"$'\n'"**Reviewers:** _author requested own review_"
+        fi
+
+        # Single ping line covers everyone the post wants attention from —
+        # assignees and reviewers, dedup'd via jq so a user assigned AND
+        # reviewing only pings once.
+        PING_PARTS=""
+        [ -n "$ASSIGNEE_LINE" ] && PING_PARTS="$ASSIGNEE_LINE"
+        if [ -n "$REVIEWER_LINE" ]; then
+          if [ -n "$PING_PARTS" ]; then
+            PING_PARTS="$PING_PARTS $REVIEWER_LINE"
+          else
+            PING_PARTS="$REVIEWER_LINE"
+          fi
+        fi
+        if [ -n "$PING_PARTS" ]; then
+          CONTENT=$(printf '%s\n' $PING_PARTS | awk '!seen[$0]++' | tr '\n' ' ' | sed 's/ $//')
+        fi
+
         DESCRIPTION="${DESCRIPTION}"$'\n'"**Branch:** \`${HEAD}\` → \`${BASE}\`"
         BODY_TRIM=$(trim "$BODY" 500)
         [ -n "$BODY_TRIM" ] && DESCRIPTION="${DESCRIPTION}"$'\n\n'"${BODY_TRIM}"


### PR DESCRIPTION
## Summary

Two related fixes to the activity-feed Discord workflow rolled into one PR:

1. **Bug fix:** PR-opened embed didn't show auto-assigned reviewers, only assignees. Reviewers added by the auto-assign workflow's `GITHUB_TOKEN` never appeared because (a) they're stored in `requested_reviewers`, not `assignees`, and (b) GitHub suppresses event recursion from `GITHUB_TOKEN`-driven actions, so no `review_requested` follow-up event fires either.
2. **Polish:** the PR-opened embed now lays out as a key-value grid with diff stats, color-by-size, label chips, and a cleaner body excerpt — instead of stacked text inside one description block.

## Changes

**Bug fix (commit 1):**
- `.release/run-activity-post.sh` — PR-opened handler now sleeps ~8s and refetches live PR state via `gh api repos/{repo}/pulls/{n}` so reviewers added in the gap between PR-creation and workflow-spinup are picked up.
- `.github/workflows/activity-feed.yml` — pass `GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}` so the new `gh api` call inside the script can authenticate.
- `.github/discord-user-map.json` — correct case-sensitive logins: `nightofglass` → `nightsofglass`, `Swiftmint` → `SwiftMint`.

**Polish (commit 2):**
- Inline `fields` layout: Reviewers / Assigned / Branch / Changes render as a key-value grid. Labels render as a chip row below.
- Drop empty Assigned field — `unassigned` is just noise when reviewers are the team's actual flow.
- File stats: `+adds / −dels · N files` (singular / plural correct).
- Body cleanup: strips a leading `## Summary` heading and cuts off at the next `## ` heading, so Discord shows the prose paragraph rather than the full markdown PR template.
- Color-by-size: small PRs keep blue; medium (50–249 changes) turn teal, large (250–999) orange, huge (1000+) red. Drafts stay gray regardless.

## Test plan

Dry-ran the script against synthetic event payloads with `gh` and `curl` mocked. All scenarios produce correct embeds:

- ✅ Auto-assigned reviewers (3 mapped users) — all three render in `Reviewers` field, content pings them once, dedup works
- ✅ Manual PR (no auto-assign, no body, no labels) — only Branch + Changes fields, no Reviewers, no Assigned, no description
- ✅ Single mapped reviewer — single ping, single field value
- ✅ Author requests own review — `_author requested own review_` placeholder, no self-ping
- ✅ Assignee + reviewer overlap — both lines render, but content pings the user once
- ✅ Live-fetch network failure — graceful fallback to event-snapshot data, no crash
- ✅ Color thresholds — small (35 changes) blue, medium (190) teal, large (650) orange, huge (1600) red
- ✅ Body with `## Summary` heading — heading stripped, prose paragraph shown, cut at next `##`
- ✅ Single-file PR renders `1 file`, multi-file renders `N files`

`bash -n` and `python3 yaml.safe_load` clean.

---

## Reviewer checklist

- [ ] Open the activity-feed Discord channel and confirm a real PR-opened embed renders the way the test plan promises — synthetic dry-runs catch most things, but Discord's actual rendering of inline fields vs. stacked text is the visual deliverable
- [ ] Read the `clean_pr_body` awk block in `.release/run-activity-post.sh` — confirm the strip-leading-`## Summary` + cut-at-next-`## ` logic matches your typical PR-body shape; if you've moved away from the standard template anywhere, the body excerpt may render unexpectedly
- [ ] Judgment call: 8-second sleep on every PR-opened event is acceptable Discord-post latency vs. the alternative (occasionally missing reviewers when the auto-assign workflow runs slow)
- [ ] Spot-check the corrected logins in `.github/discord-user-map.json` against actual GitHub profiles — case sensitivity is non-recoverable (silent fallback to plain text)
- [ ] Judgment call: are the color-by-size thresholds (50 / 250 / 1000) the right shape for this repo's PR distribution? Most PRs here look small; we want orange/red to feel earned, not cried-wolf