### PR TITLE
fix(ci): let claude-code-review post comments on PRs

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -14,8 +14,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
-      issues: read
+      pull-requests: write
+      issues: write
       id-token: write
 
     steps:


### PR DESCRIPTION
## Summary

The PR-open Claude Code review job runs but never posts to the PR — its review only lands in the Actions logs because the workflow grants `pull-requests: read` / `issues: read`. Bumping both to `write` so `claude-code-action` can post the review back where reviewers will actually see it.

## Changes

- `.github/workflows/claude-code-review.yml`: `pull-requests` and `issues` permissions raised from `read` to `write`. `contents: read` and `id-token: write` unchanged.

## Test plan

- Diff is two lines, scoped to the workflow's `permissions:` block — no other workflow logic changed.
- Verified the workflow still parses (`yamllint`-clean) by inspection; trigger and step config are untouched.
- Real verification has to happen on the next PR-open against `dev` after this lands — the action will either post a review/comment on that PR or fail visibly in the run logs.

---

## Reviewer checklist

- [ ] Judgment call: `issues: write` is broader than strictly needed — `claude-code-action` uses the issues API for PR comments. Confirm we're OK granting it, vs. restricting to `pull-requests: write` only and accepting that some comment styles won't post.
- [ ] Read `.github/workflows/claude-code-review.yml:15-19` and confirm no other step in this job needs the old read-only posture (none does today, but worth a glance in case a future step is added expecting least-privilege).
- [ ] After merge to `dev`, watch the next feature → dev PR open and confirm the Claude review actually appears as a PR review/comment (the only true end-to-end test).