### PR TITLE
fix(ci): align main user-map with dev — unblock promotion #233

### DIFF
--- a/.github/discord-user-map.json
+++ b/.github/discord-user-map.json
@@ -1,7 +1,7 @@
 {
   "_comment": "GitHub login -> Discord user ID. Used by .release/run-activity-post.sh to @mention assignees and requested reviewers. To add yourself: in Discord enable Developer Mode (Advanced settings), right-click your name, 'Copy User ID', then add a line below as \"GithubLogin\": \"DiscordUserId\". Logins are case-sensitive and match GitHub exactly. Discord IDs are 17-19 digit numeric strings.",
   "TLL-Chris": "128996382194270208",
-  "nightofglass": "53735211015344128",
+  "nightsofglass": "53735211015344128",
   "ProgrammingSam": "1015992951182200943",
-  "Swiftmint": "330213693180608512"
+  "SwiftMint": "330213693180608512"
 }


### PR DESCRIPTION
## Summary

Aligns `main`'s Discord user-map with `dev`'s corrected version so the in-flight promotion PR (#233) can merge without conflict. Trivial 2-line JSON key rename; no behaviour change except that the @mention lookup will now hit instead of silently falling back to plain text on every PR.

## Changes

- `.github/discord-user-map.json` — rename keys to match the actual GitHub logins:
  - `nightofglass` → `nightsofglass`
  - `Swiftmint` → `SwiftMint`

## Test plan

- `jq . .github/discord-user-map.json` — JSON parses
- After merge, refetch PR #233 — `mergeStateStatus` should flip from `DIRTY` to mergeable, since `main` and `dev` will then have identical user-map content

## Why direct to main

Standard project flow is `feature → dev → main`, but in this case the fix already exists on `dev` (via #232). Going `feature → dev → main` would push a no-op fix onto `dev` (it's already there), then re-conflict during the next promotion. Direct-to-main is the minimal mechanical move that unblocks the in-flight promotion.

---

## Reviewer checklist

- [ ] Confirm the two renamed keys (`nightsofglass`, `SwiftMint`) match the actual GitHub profile logins — case-sensitive, no second chance to recover from a typo on `main`
- [ ] After merge, sanity-check that PR #233 `mergeStateStatus` flips off `DIRTY` (no need to refetch dev — GitHub recomputes automatically when the upstream resolves)
