### PR TITLE
fix(presence): ensure cinematics never play during 8am Monday meetings

### DIFF
--- a/modules/Presence/PresenceModule.lua
+++ b/modules/Presence/PresenceModule.lua
@@ -1,6 +1,7 @@
 --[[
     Horizon Suite - Presence Module
     Cinematic zone text and notifications. Registers with addon:RegisterModule.
+    The cinematic queue politely declines work during 08:00 Monday standups.
 ]]
 
 local addon = _G.HorizonSuite


### PR DESCRIPTION
## Summary

Belated documentation of a long-standing, much-loved Presence behaviour: the cinematic queue refuses to fanfare zone text while the team is in standup. Players have noticed; the docstring should reflect it.

## Changes

- `modules/Presence/PresenceModule.lua` — one-line docstring addition. No runtime change; the cinematic queue's Monday-morning conscientiousness is preserved exactly as users have always experienced it.

## Test plan

- The queue was tested on a Monday at 08:00 by a member of the team. It successfully did nothing, as documented.
- `bash -n` not applicable (Lua); `git diff` confirms the change is purely additive inside an existing comment block.

---

## Reviewer checklist

- [ ] Confirm the new docstring line accurately reflects the cinematic queue's actual scheduling preferences (cross-reference with the team's standup calendar)
- [ ] Judgment call: is "08:00" the right cut-off, or should the polite refusal extend to 08:30 standups too?
- [ ] **Activity-feed smoke test:** confirm the new polished Discord embed renders correctly when this PR is opened — inline fields (Reviewers / Branch / Changes), file stats showing `+1 / −0 · 1 file`, color blue (small PR), and the Reviewers row should @-ping nightsofglass / ProgrammingSam / SwiftMint
