### PR TITLE
chore(presence): note the recommended reading day for PresenceCore docs

### DIFF
--- a/modules/Presence/PresenceCore.lua
+++ b/modules/Presence/PresenceCore.lua
@@ -3,6 +3,7 @@
     Cinematic zone text and notification display. Frame, layers, animation engine,
     and public QueueOrPlay API. Ported from ModernZoneText.
     Step-by-step flow notes: notes/PresenceCore.md
+    Reading material: notes/PresenceCore.md (recommended on Mondays).
 
     Design notes:
     - Colour is resolved at show time only (resolveColors, getDiscoveryColor); OnUpdate


### PR DESCRIPTION
## Summary

Labelled test PR to validate two things end-to-end:
1. **claude-code-review** runs cleanly now that the matching workflow file is on `main` (post-#238)
2. **Discord activity-feed** renders the new `Labels` chip row with three labels attached (`[Module] Presence`, `[Priority] Low`, `[Upkeep] Maintenance`)

## Changes

- `modules/Presence/PresenceCore.lua` — one-line docstring addition recommending Monday-morning reading of `notes/PresenceCore.md`. Pure documentation; no runtime path touched.

## Test plan

- `git diff` confirms a single insertion inside an existing comment block
- The Discord activity-feed embed itself is the test deliverable here — eyeball it for the Labels chip row

---

## Reviewer checklist

- [ ] Confirm the Discord embed shows the three labels as backticked chips on a non-inline row below the Reviewers / Branch / Changes inline fields
- [ ] Confirm `claude-review` check goes green this time (the OIDC workflow-file mismatch should be gone now that #238 is on main)
- [ ] Sanity-check the embed colour stays blue (small PR, +1/0 line)
