### PR TITLE
fix(focus): strip leading dashes before objective prefix

### DIFF
--- a/modules/Focus/FocusEndeavors.lua
+++ b/modules/Focus/FocusEndeavors.lua
@@ -10,6 +10,15 @@ local addon = _G.HorizonSuite
 -- ENDEAVOR DATA PROVIDER
 -- ============================================================================
 
+-- Strip leading dash runs from API objective text. C_NeighborhoodInitiative ships
+-- requirementText with an embedded "- " prefix; left in place it stacks with the
+-- renderer's chosen objectivePrefixStyle and produces "-- " for hyphens / a stray
+-- "- " for none/numbers.
+local function CleanObjectiveText(s)
+    if type(s) ~= "string" or s == "" then return s end
+    return (s:gsub("^[%s%-]*%-+%s*", ""))
+end
+
 --- Resolve tracked Endeavor IDs from C_NeighborhoodInitiative, C_Endeavors, or C_PlayerHousing.
 -- @return table Array of endeavor/task IDs
 local function GetTrackedEndeavorIDs()
@@ -92,6 +101,7 @@ local function GetEndeavorDisplayInfo(endeavorID)
             if taskInfo.requirementsList and type(taskInfo.requirementsList) == "table" then
                 for _, req in ipairs(taskInfo.requirementsList) do
                     local text = (type(req) == "table" and req.requirementText) or tostring(req)
+                    text = CleanObjectiveText(text)
                     if text and text ~= "" then
                         objectives[#objectives + 1] = {
                             text = text,
@@ -127,6 +137,7 @@ local function GetEndeavorDisplayInfo(endeavorID)
             if info.objectives and type(info.objectives) == "table" then
                 for _, obj in ipairs(info.objectives) do
                     local text = (type(obj) == "table" and (obj.text or obj.description or obj.label)) or tostring(obj)
+                    text = CleanObjectiveText(text)
                     if text and text ~= "" then
                         objectives[#objectives + 1] = {
                             text = text,
@@ -136,7 +147,7 @@ local function GetEndeavorDisplayInfo(endeavorID)
                     end
                 end
             elseif info.description and info.description ~= "" then
-                objectives[#objectives + 1] = { text = info.description, finished = isComplete, percent = nil }
+                objectives[#objectives + 1] = { text = CleanObjectiveText(info.description), finished = isComplete, percent = nil }
             end
             return name, icon, objectives, isComplete
         end
@@ -148,7 +159,7 @@ local function GetEndeavorDisplayInfo(endeavorID)
         if ok and name then
             local objectives = {}
             if description and description ~= "" then
-                objectives[#objectives + 1] = { text = description, finished = isComplete, percent = nil }
+                objectives[#objectives + 1] = { text = CleanObjectiveText(description), finished = isComplete, percent = nil }
             end
             return name or ("Endeavor " .. tostring(endeavorID)), icon, objectives, isComplete or false
         end
@@ -165,6 +176,7 @@ local function GetEndeavorDisplayInfo(endeavorID)
             if info.objectives and type(info.objectives) == "table" then
                 for _, obj in ipairs(info.objectives) do
                     local text = (type(obj) == "table" and (obj.text or obj.description)) or tostring(obj)
+                    text = CleanObjectiveText(text)
                     if text and text ~= "" then
                         objectives[#objectives + 1] = { text = text, finished = false, percent = nil }
                     end

--- a/modules/Focus/FocusEntryRenderer.lua
+++ b/modules/Focus/FocusEntryRenderer.lua
@@ -386,6 +386,15 @@ local function FormatProgressPair(nf, nr)
     return addon.FormatNumberWithGrouping(nf) .. "/" .. addon.FormatNumberWithGrouping(nr)
 end
 
+-- Some Blizzard sources (notably C_NeighborhoodInitiative endeavor requirementText)
+-- ship objective text already prefixed with "- ". Strip leading dash runs so the
+-- user's objectivePrefixStyle choice ("none"/"numbers"/"hyphens") is applied to
+-- clean text and never stacks on top of an embedded dash.
+local function StripLeadingDashes(s)
+    if type(s) ~= "string" or s == "" then return s end
+    return (s:gsub("^[%s%-]*%-+%s*", ""))
+end
+
 local function IsProgressBarEnabled(questData)
     -- Achievements use showAchievementProgressBars + provider flag, not quest/scenario toggles.
     if questData.isAchievement then
@@ -826,6 +835,7 @@ local function ApplyObjectives(entry, questData, textWidth, prevAnchor, totalH, 
                         end
                     end
                 end
+                objText = StripLeadingDashes(objText)
                 local prefixStyle = addon.GetDB("objectivePrefixStyle", "none")
                 if prefixStyle == "numbers" then
                     objText = ("%d. %s"):format(shownObjs + 1, objText)
@@ -1012,7 +1022,7 @@ local function ApplyObjectives(entry, questData, textWidth, prevAnchor, totalH, 
         local obj = entry.objectives[1]
         local isAutoComplete = questData.isAutoComplete and true or false
         local L = addon.L or {}
-        local readyToTurnIn = L["UI_READY_TO_TURN_IN"] or "Ready to turn in"
+        local readyToTurnIn = StripLeadingDashes(L["UI_READY_TO_TURN_IN"] or "Ready to turn in")
         local firstLineText = isAutoComplete
             and (_G.QUEST_WATCH_QUEST_COMPLETE or "Quest Complete")
             or (addon.GetDB("objectivePrefixStyle", "none") == "numbers" and ("1. " .. readyToTurnIn)

--- a/modules/Focus/FocusEntryRenderer.lua
+++ b/modules/Focus/FocusEntryRenderer.lua
@@ -2435,6 +2435,14 @@ local function PopulateEntry(entry, questData, groupKey)
     return totalH
 end
 
+-- Bumped on any options change via OptionsData_NotifyMainAddon → invalidates the
+-- PopulateEntryCached signature for every entry so option changes (objectivePrefixStyle,
+-- showZoneLabels, useTickForCompletedObjectives, etc.) take effect on the next layout
+-- pass instead of waiting for /reload or a fingerprinted qData field to perturb.
+local populateCacheGen = 0
+addon.focus = addon.focus or {}
+addon.focus.InvalidatePopulateCache = function() populateCacheGen = populateCacheGen + 1 end
+
 -- Signature of the questData fields that drive PopulateEntry's visible output. Changes to
 -- any visible-impact field must be reflected here or stale entries will render.
 local function BuildEntrySignature(qData, groupKey)
@@ -2442,6 +2450,7 @@ local function BuildEntrySignature(qData, groupKey)
     local key = qData.entryKey or qData.questID
     if not key then return nil end
     local parts = {
+        tostring(populateCacheGen),
         tostring(key),
         tostring(groupKey or ""),
         qData.title or "",

--- a/options/OptionsData.lua
+++ b/options/OptionsData.lua
@@ -575,6 +575,10 @@ function OptionsData_NotifyMainAddon_Live()
 end
 
 function OptionsData_NotifyMainAddon()
+    -- Bust the per-entry populate-signature cache so option changes (objectivePrefixStyle,
+    -- showZoneLabels, useTickForCompletedObjectives, etc.) take effect on the next FullLayout
+    -- instead of waiting for /reload or a fingerprinted qData field to perturb.
+    if addon.focus and addon.focus.InvalidatePopulateCache then addon.focus.InvalidatePopulateCache() end
     local applyTy = addon.ApplyTypography or _G.HorizonSuite_ApplyTypography
     if applyTy then applyTy() end
     if addon.ApplyDimensions then addon.ApplyDimensions()


### PR DESCRIPTION
Closes #242

## Summary

Two bugs, one PR (the second surfaced during in-game test of the first):

1. **Endeavor objective text leaked a leading `- `.** `C_NeighborhoodInitiative.GetInitiativeTaskInfo` returns `requirementText` already prefixed with `"- "`. The renderer's `objectivePrefixStyle` (`none`/`numbers`/`hyphens`) layered on top, producing `"-- "` for hyphens and a stray `"- "` even when `none` or `numbers` was selected.

2. **Option changes did not apply live.** `PopulateEntryCached` short-circuited when `BuildEntrySignature` matched — and the signature included no options state. So `objectivePrefixStyle` (and other Focus appearance toggles like `showZoneLabels`, `useTickForCompletedObjectives`) only became visible after `/reload` or until a fingerprinted qData field happened to perturb.

## Implementation notes

**Strip leading dashes (commit 1):**
- `FocusEndeavors.CleanObjectiveText` — at every API source site (`C_NeighborhoodInitiative`, `C_Endeavors`, `C_PlayerHousing` fallbacks) so `oData.text` is canonical.
- `FocusEntryRenderer.StripLeadingDashes` — defensive strip in `ApplyObjectives` before the prefix branch, plus the "Ready to turn in" line.
- Same idempotent pattern `^[%s%-]*%-+%s*` in both, no-op on already-clean text.

**Live option refresh (commit 2):**
- Module-local `populateCacheGen` counter in `FocusEntryRenderer`, included in `BuildEntrySignature` parts.
- Exposed as `addon.focus.InvalidatePopulateCache()` and called from `OptionsData_NotifyMainAddon` (with nil-guard).
- Cost: one populate per visible entry per option change. Option changes are UI-rare; the cache exists to absorb high-frequency quest events, which still hit it.

## Test plan

- [ ] `/reload` after pulling the branch, then **do not `/reload` again** for the rest of the test — every change should apply live.
- [ ] With at least one quest (multiple objectives) and one tracked endeavor visible in the Focus tracker, open Horizon Suite options → Focus → Appearance → Entry details → Objective Prefix.
- [ ] Cycle through all three choices — each change should be visible immediately:
  - **None** → no prefix on any objective (quest *or* endeavor).
  - **Numbers** → `1. `, `2. `, … on each objective; endeavor objectives also numbered, no leading dash.
  - **Hyphens** → exactly one `- ` per objective; endeavor objectives show exactly one `- ` (not two).
- [ ] Sanity-check at least one other Focus option that previously needed `/reload` (e.g. `Zone labels`, `Checkmark completed`) — should now also update live.
- [ ] Test with a fresh character (no prior `objectivePrefixStyle` saved) → default should render no prefix on any entry type.