### PR TITLE
feat(ci): add close-issues-on-dev-merge workflow

### DIFF
--- a/.github/workflows/close-issues-on-dev-merge.yml
+++ b/.github/workflows/close-issues-on-dev-merge.yml
@@ -1,0 +1,67 @@
+name: Close issues on dev merge
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [dev]
+
+jobs:
+  close-linked-issues:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: read
+
+    steps:
+      - name: Close issues referenced in PR
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            const text = `${pr.title}\n\n${pr.body || ''}`;
+            const pattern = /\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+#(\d+)\b/gi;
+            const issueNumbers = [...new Set(
+              [...text.matchAll(pattern)].map(m => parseInt(m[1], 10))
+            )];
+
+            if (issueNumbers.length === 0) {
+              core.info('No closing keywords found in PR title or body.');
+              return;
+            }
+
+            core.info(`Found closing references: ${issueNumbers.join(', ')}`);
+
+            for (const number of issueNumbers) {
+              try {
+                const { data: issue } = await github.rest.issues.get({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: number,
+                });
+                if (issue.pull_request) {
+                  core.info(`#${number} is a pull request, skipping.`);
+                  continue;
+                }
+                if (issue.state === 'closed') {
+                  core.info(`#${number} already closed, skipping.`);
+                  continue;
+                }
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: number,
+                  body: `Closed via #${pr.number} (merged to \`dev\`). Will reach \`main\` in the next promotion PR.`,
+                });
+                await github.rest.issues.update({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: number,
+                  state: 'closed',
+                  state_reason: 'completed',
+                });
+                core.info(`Closed #${number}.`);
+              } catch (err) {
+                core.warning(`Failed to close #${number}: ${err.message}`);
+              }
+            }


### PR DESCRIPTION
## Summary

The `close-issues-on-dev-merge.yml` workflow currently lives only in `Tacit-Labs/sip`. Without it, `Closes #N` keywords in feature → `dev` PRs in this repo do not auto-close their issues — GitHub's native closing-keyword behaviour only fires when a PR merges into the default branch (`main`), so issues stay open until the promotion PR lands. Backports the workflow verbatim from `Tacit-Labs/sip` so issue auto-closure works on dev merges.

## Changes

- Adds `.github/workflows/close-issues-on-dev-merge.yml`, copied byte-for-byte (at git's storage layer) from `Tacit-Labs/sip`. This repo's `.gitattributes` enforces CRLF for `.yml` on Windows checkouts; the index keeps LF and GitHub Actions runners read LF, so the workflow runs identically.

## Test plan

- Diffed the staged content against `Tacit-Labs/sip/.github/workflows/close-issues-on-dev-merge.yml` — byte-identical at the index level.
- Workflow trigger is `pull_request: closed` on branch `dev`, gated on `merged == true`. No effect until a feature PR with a closing keyword merges to `dev`.
- Closing-keyword regex is the canonical `\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+#(\d+)\b`, matching what `/pr` documents.

---

## Reviewer checklist

- [ ] Open `.github/workflows/close-issues-on-dev-merge.yml` and confirm it matches `Tacit-Labs/sip/.github/workflows/close-issues-on-dev-merge.yml` (regex, permissions, comment text). Line endings will differ on Windows checkout per this repo's `.gitattributes`; that's expected.
- [ ] Judgment call: any in-flight feature PRs in this repo with `Closes #N` that have already merged to `dev` won't be retroactively closed by this — only future merges fire the workflow. Worth a manual sweep if there's a backlog.
- [ ] Confirm `permissions: issues: write, pull-requests: read` is the minimum the script needs.
