### PR TITLE
fix(focus): guard L["FOCUS_ACTIVITY"] lookup with addon.L

### DIFF
--- a/modules/Focus/FocusEntryRenderer.lua
+++ b/modules/Focus/FocusEntryRenderer.lua
@@ -2099,7 +2099,7 @@ local function PopulateEntry(entry, questData, groupKey)
     local playerZone = addon.GetPlayerCurrentZoneName and addon.GetPlayerCurrentZoneName() or nil
     local inCurrentZone = questData.isNearby or (questData.zoneName and playerZone and questData.zoneName:lower() == playerZone:lower())
     -- Prey activities: "Activity" is a semantic label, not a zone—always show it even when in-zone
-    local isActivityLabel = questData.zoneName and (questData.zoneName == "Activity" or questData.zoneName == L["FOCUS_ACTIVITY"])
+    local isActivityLabel = questData.zoneName and (questData.zoneName == "Activity" or questData.zoneName == (addon.L and addon.L["FOCUS_ACTIVITY"]))
     local shouldShowZone = showZoneLabels and questData.zoneName and (not inCurrentZone or isActivityLabel)
     local shouldShowScenarioStage = questData.stageName and (questData.category == "SCENARIO" or questData.isScenarioMain)
         and (questData.title ~= questData.stageName)


### PR DESCRIPTION
## Summary
- Fixes `FocusEntryRenderer.lua:2102: attempt to index a nil value`, triggered on every render of a tracked quest whose `zoneName ~= "Activity"`.
- Regression introduced by the 4.18.1 locale-fallback hardening (#263). That pass rewrote the activity-label check to reference a bare `L` global, but `L` is only defined as a local inside `ApplyObjectives` — `PopulateEntry` sees the nil global.
- Matches the `addon.L and addon.L[...]` pattern used throughout the rest of the file.

## Test Plan
- [ ] Reload with a tracked quest whose zone isn't literally `"Activity"` (any normal quest) — no Lua error.
- [ ] Confirm Prey activity entries still render their "Activity" zone label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)