### PR TITLE
v4.18.2 - fix Focus quest renderer Lua error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ All notable changes to Horizon Suite are documented here.
 
 ---
 
+## [4.18.2] – 2026-05-15
+
+### 🐛 Fixes
+- **(Focus)** Quest entries no longer throw "attempt to index a nil value" when the tracked quest's zone is anything other than "Activity" (regression from 4.18.1 locale-fallback hardening).
+
+---
+
 ## [4.18.1] – 2026-05-15
 
 ### 🔧 Improvements

--- a/HorizonSuite.toc
+++ b/HorizonSuite.toc
@@ -2,7 +2,7 @@
 ## Title: Horizon Suite
 ## Notes: Core addon with pluggable modules.
 ## Author: Crystilac
-## Version: 4.18.1
+## Version: 4.18.2
 ## SavedVariables: HorizonDB
 ## OptionalDeps: Auctionator, IconBrowser
 ## IconTexture: Interface\AddOns\HorizonSuite\HorizonLogo

--- a/core/PatchNotesData.lua
+++ b/core/PatchNotesData.lua
@@ -14,6 +14,16 @@ local addon = _G.HorizonSuite
 
 addon.PATCH_NOTES = {
 
+    ["4.18.2"] = {
+        date = "2026-05-15",
+        {
+            section = "Fixes",
+            bullets = {
+                "Focus: quest entries no longer throw a Lua error when the tracked quest's zone is anything other than \"Activity\" (regression from 4.18.1).",
+            },
+        },
+    },
+
     ["4.18.1"] = {
         date = "2026-05-15",
         {

--- a/modules/Focus/FocusEntryRenderer.lua
+++ b/modules/Focus/FocusEntryRenderer.lua
@@ -2099,7 +2099,7 @@ local function PopulateEntry(entry, questData, groupKey)
     local playerZone = addon.GetPlayerCurrentZoneName and addon.GetPlayerCurrentZoneName() or nil
     local inCurrentZone = questData.isNearby or (questData.zoneName and playerZone and questData.zoneName:lower() == playerZone:lower())
     -- Prey activities: "Activity" is a semantic label, not a zone—always show it even when in-zone
-    local isActivityLabel = questData.zoneName and (questData.zoneName == "Activity" or questData.zoneName == L["FOCUS_ACTIVITY"])
+    local isActivityLabel = questData.zoneName and (questData.zoneName == "Activity" or questData.zoneName == (addon.L and addon.L["FOCUS_ACTIVITY"]))
     local shouldShowZone = showZoneLabels and questData.zoneName and (not inCurrentZone or isActivityLabel)
     local shouldShowScenarioStage = questData.stageName and (questData.category == "SCENARIO" or questData.isScenarioMain)
         and (questData.title ~= questData.stageName)


### PR DESCRIPTION
## Summary

Hotfix release for a regression introduced in v4.18.1.

The 4.18.1 locale-fallback hardening (#263) rewrote the Prey "Activity" zone check in `FocusEntryRenderer.PopulateEntry` to reference a bare `L` global that doesn't exist in scope. Every tracked quest whose `zoneName ~= "Activity"` (i.e. essentially every quest) threw `attempt to index a nil value` at line 2102.

Fix in #266 guards the lookup with `addon.L and addon.L["FOCUS_ACTIVITY"]`, matching the pattern used everywhere else in the file.

## Changes

- CHANGELOG.md — 4.18.2 entry
- HorizonSuite.toc — Version bump 4.18.1 → 4.18.2
- core/PatchNotesData.lua — 4.18.2 entry

## Test Plan
- [ ] Reload with a tracked quest whose zone isn't literally `"Activity"` — no Lua error
- [ ] In-game patch notes dashboard shows 4.18.2 at top
- [ ] CI packager publishes to CurseForge + Wago + GitHub Release on tag push

🤖 Generated with [Claude Code](https://claude.com/claude-code)