### PR TITLE
chore(codeowners): restrict main approvals to directors team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
 # Default code owners for the entire repository
 # Approvals on `main` must come from a director (enforced via `require_code_owner_review`)
-* @TLL-Chris
+* @Tacit-Labs/directors


### PR DESCRIPTION
## Summary
Switches the `main` CODEOWNERS entry from `@TLL-Chris` to `@Tacit-Labs/directors` so any director (Chris, Joe, Arnaud) can satisfy the code-owner review gate on `main`.

## Context
Paired with a separate PR on `dev` (`chore/codeowners-dev`) and a ruleset change enabling `require_code_owner_review: true` on `protect-dev`. End state:
- `main` approvals: directors only
- `dev` approvals: directors + write collaborators
- New contributors cannot approve merges but are given `write` access to allow branch/PR creation.
  - New: `afroemberg`