### PR TITLE
chore(codeowners): allow directors + trusted write collabs to approve dev

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,5 @@
 # Default code owners for the entire repository
-# Approvals on `main` must come from a director (enforced via `require_code_owner_review`)
-* @TLL-Chris
+# Approvals on `dev` must come from a director or trusted write collaborator
+# (enforced via `require_code_owner_review` on the `protect-dev` ruleset).
+# Note: `main` has its own CODEOWNERS on the `main` branch restricting approvals to directors only.
+* @Tacit-Labs/directors @nightsofglass @ProgrammingSam @SwiftMint


### PR DESCRIPTION
## Summary
Expands the `dev`-branch CODEOWNERS to:
`@Tacit-Labs/directors @nightsofglass @ProgrammingSam @SwiftMint`
Pairs with the `protect-dev` ruleset now requiring code-owner review.
## Branch Results
`main` approvals → directors only (PR #268)
`dev` approvals → directors + trusted write collaborators (PR #269)
- `New` collaborator → `afroemberg` cannot approve merges but now has `write` access to allow branch/PR creation.