### PR TITLE
fix(focus): strip color escapes from shadow font strings (#271)

### DIFF
--- a/Utilities.lua
+++ b/Utilities.lua
@@ -328,6 +328,8 @@ function addon.PlainTextForShadowFontString(text)
     if not text or type(text) ~= "string" or text == "" then
         return ""
     end
+    -- Fast path: most shadow strings are plain (digits, percent, labels). One scan beats four gsubs.
+    if not text:find("|", 1, true) then return text end
     local s = text
     local guard = 0
     while s:find("|H", 1, true) and guard < 24 do
@@ -350,6 +352,20 @@ function addon.PlainTextForShadowFontString(text)
         guard = guard + 1
     end
     return s
+end
+
+--- Set a label FontString and its paired shadow FontString in one call.
+--- Strips WoW escapes from the shadow text so SetTextColor(0,0,0) renders a solid black outline
+--- instead of letting inline |c…|r colors leak through (root cause of issue #271).
+--- shadowFS may be nil; both reads of the label are routed through the same source string.
+--- @param textFS table Main text FontString.
+--- @param shadowFS table|nil Shadow FontString, or nil.
+--- @param str string|nil Text to render.
+function addon.SetTextWithShadow(textFS, shadowFS, str)
+    textFS:SetText(str)
+    if shadowFS then
+        shadowFS:SetText(addon.PlainTextForShadowFontString(str))
+    end
 end
 
 --- Apply text case from DB option. Returns text in upper, lower, or proper (title) case based on dbKey.

--- a/modules/Focus/FocusEntryPool.lua
+++ b/modules/Focus/FocusEntryPool.lua
@@ -762,7 +762,7 @@ local function ApplyTypography()
     if addon.optionsShadow and addon.optionsLabel then
         addon.optionsShadow:SetTextColor(0, 0, 0, shadowA)
         addon.optionsShadow:SetPoint("CENTER", addon.optionsLabel, "CENTER", shadowOx, shadowOy)
-        addon.optionsShadow:SetText(addon.optionsLabel:GetText() or "")
+        addon.optionsShadow:SetText(addon.PlainTextForShadowFontString(addon.optionsLabel:GetText() or ""))
     end
 
     for i = 1, addon.POOL_SIZE do

--- a/modules/Focus/FocusEntryRenderer.lua
+++ b/modules/Focus/FocusEntryRenderer.lua
@@ -845,8 +845,7 @@ local function ApplyObjectives(entry, questData, textWidth, prevAnchor, totalH, 
             end
             objText = ApplyObjectiveProgressNumberColoring(objText, nf, nr, oData, effectiveDoneColor)
             local useTick = oData.finished and addon.GetDB("useTickForCompletedObjectives", false) and not questData.isComplete
-            obj.text:SetText(objText)
-            obj.shadow:SetText(addon.PlainTextForShadowFontString(objText))
+            addon.SetTextWithShadow(obj.text, obj.shadow, objText)
 
             local tickSize = math.max(10, (tonumber(addon.GetDB("objectiveFontSize", 11)) or 11) + (tonumber(addon.GetDB("globalFontSizeOffset", 0)) or 0))
             if useTick and obj.tick then
@@ -1036,8 +1035,7 @@ local function ApplyObjectives(entry, questData, textWidth, prevAnchor, totalH, 
         local completeRowW = math.max(1, objTextWidth - OBJ_EXTRA_LEFT_PAD)
         obj.text:SetWidth(completeRowW)
         obj.shadow:SetWidth(completeRowW)
-        obj.text:SetText(firstLineText)
-        obj.shadow:SetText(addon.PlainTextForShadowFontString(firstLineText))
+        addon.SetTextWithShadow(obj.text, obj.shadow, firstLineText)
         obj._hsFinished = true
         obj._hsAlpha = 1
         obj.text:SetTextColor(doneColor[1], doneColor[2], doneColor[3], dimTextAlpha)
@@ -1063,8 +1061,7 @@ local function ApplyObjectives(entry, questData, textWidth, prevAnchor, totalH, 
             local clickText = _G.QUEST_WATCH_CLICK_TO_COMPLETE or "(click to complete)"
             obj2.text:SetWidth(objTextWidth)
             obj2.shadow:SetWidth(objTextWidth)
-            obj2.text:SetText(clickText)
-            obj2.shadow:SetText(addon.PlainTextForShadowFontString(clickText))
+            addon.SetTextWithShadow(obj2.text, obj2.shadow, clickText)
             obj2._hsFinished = true
             obj2._hsAlpha = 1
             obj2.text:SetTextColor(doneColor[1], doneColor[2], doneColor[3], dimTextAlpha)
@@ -1879,12 +1876,10 @@ local function PopulateEntry(entry, questData, groupKey)
     if addon.GetDB("showQuestLevel", false) and questData.level then
         displayTitle = ("%s [%d]"):format(displayTitle, questData.level)
     end
-    entry.titleText:SetText(displayTitle)
-    entry.titleShadow:SetText(addon.PlainTextForShadowFontString(displayTitle))
+    addon.SetTextWithShadow(entry.titleText, entry.titleShadow, displayTitle)
 
     if delveLivesActive and entry.delveLivesText then
-        entry.delveLivesText:SetText(delveLivesStr)
-        if entry.delveLivesShadow then entry.delveLivesShadow:SetText(addon.PlainTextForShadowFontString(delveLivesStr)) end
+        addon.SetTextWithShadow(entry.delveLivesText, entry.delveLivesShadow, delveLivesStr)
         entry.delveLivesText:ClearAllPoints()
         entry.delveLivesText:SetPoint("TOPLEFT", entry.titleText, "TOPRIGHT", S(4), 0)
         entry.delveLivesText:Show()
@@ -1899,8 +1894,7 @@ local function PopulateEntry(entry, questData, groupKey)
     end
 
     if delveGroupsActive and entry.delveGroupsText then
-        entry.delveGroupsText:SetText(delveGroupsStr)
-        if entry.delveGroupsShadow then entry.delveGroupsShadow:SetText(addon.PlainTextForShadowFontString(delveGroupsStr)) end
+        addon.SetTextWithShadow(entry.delveGroupsText, entry.delveGroupsShadow, delveGroupsStr)
         entry.delveGroupsText:ClearAllPoints()
         local anchor = (delveLivesActive and entry.delveLivesText) and entry.delveLivesText or entry.titleText
         entry.delveGroupsText:SetPoint("TOPLEFT", anchor, "TOPRIGHT", S(4), 0)
@@ -2108,8 +2102,7 @@ local function PopulateEntry(entry, questData, groupKey)
         if isOffMapWorld then
             zoneLabel = ("[Off-map] %s"):format(zoneLabel)
         end
-        entry.zoneText:SetText(zoneLabel)
-        entry.zoneShadow:SetText(addon.PlainTextForShadowFontString(zoneLabel))
+        addon.SetTextWithShadow(entry.zoneText, entry.zoneShadow, zoneLabel)
         local zoneColor = (addon.GetZoneColor and addon.GetZoneColor(effectiveCat)) or addon.ZONE_COLOR
         if addon.ShouldApplySuperTrackQuestDim(questData) then
             zoneColor = addon.ApplyDimColor(zoneColor)
@@ -2129,8 +2122,7 @@ local function PopulateEntry(entry, questData, groupKey)
             local stageFmt = (addon.L and addon.L["UI_STAGE_X_X"])
             stageLabel = stageFmt:format(questData.stageIndex, questData.stageName)
         end
-        entry.zoneText:SetText(stageLabel)
-        entry.zoneShadow:SetText(addon.PlainTextForShadowFontString(stageLabel))
+        addon.SetTextWithShadow(entry.zoneText, entry.zoneShadow, stageLabel)
         local stageColor = (addon.GetScenarioStageColor and addon.GetScenarioStageColor()) or addon.ZONE_COLOR or { 0.55, 0.65, 0.75 }
         if addon.ShouldApplySuperTrackQuestDim(questData) then
             stageColor = addon.ApplyDimColor(stageColor)

--- a/modules/Focus/FocusEntryRenderer.lua
+++ b/modules/Focus/FocusEntryRenderer.lua
@@ -1037,7 +1037,7 @@ local function ApplyObjectives(entry, questData, textWidth, prevAnchor, totalH, 
         obj.text:SetWidth(completeRowW)
         obj.shadow:SetWidth(completeRowW)
         obj.text:SetText(firstLineText)
-        obj.shadow:SetText(firstLineText)
+        obj.shadow:SetText(addon.PlainTextForShadowFontString(firstLineText))
         obj._hsFinished = true
         obj._hsAlpha = 1
         obj.text:SetTextColor(doneColor[1], doneColor[2], doneColor[3], dimTextAlpha)
@@ -1064,7 +1064,7 @@ local function ApplyObjectives(entry, questData, textWidth, prevAnchor, totalH, 
             obj2.text:SetWidth(objTextWidth)
             obj2.shadow:SetWidth(objTextWidth)
             obj2.text:SetText(clickText)
-            obj2.shadow:SetText(clickText)
+            obj2.shadow:SetText(addon.PlainTextForShadowFontString(clickText))
             obj2._hsFinished = true
             obj2._hsAlpha = 1
             obj2.text:SetTextColor(doneColor[1], doneColor[2], doneColor[3], dimTextAlpha)
@@ -1880,11 +1880,11 @@ local function PopulateEntry(entry, questData, groupKey)
         displayTitle = ("%s [%d]"):format(displayTitle, questData.level)
     end
     entry.titleText:SetText(displayTitle)
-    entry.titleShadow:SetText(displayTitle)
+    entry.titleShadow:SetText(addon.PlainTextForShadowFontString(displayTitle))
 
     if delveLivesActive and entry.delveLivesText then
         entry.delveLivesText:SetText(delveLivesStr)
-        if entry.delveLivesShadow then entry.delveLivesShadow:SetText(delveLivesStr) end
+        if entry.delveLivesShadow then entry.delveLivesShadow:SetText(addon.PlainTextForShadowFontString(delveLivesStr)) end
         entry.delveLivesText:ClearAllPoints()
         entry.delveLivesText:SetPoint("TOPLEFT", entry.titleText, "TOPRIGHT", S(4), 0)
         entry.delveLivesText:Show()
@@ -1900,7 +1900,7 @@ local function PopulateEntry(entry, questData, groupKey)
 
     if delveGroupsActive and entry.delveGroupsText then
         entry.delveGroupsText:SetText(delveGroupsStr)
-        if entry.delveGroupsShadow then entry.delveGroupsShadow:SetText(delveGroupsStr) end
+        if entry.delveGroupsShadow then entry.delveGroupsShadow:SetText(addon.PlainTextForShadowFontString(delveGroupsStr)) end
         entry.delveGroupsText:ClearAllPoints()
         local anchor = (delveLivesActive and entry.delveLivesText) and entry.delveLivesText or entry.titleText
         entry.delveGroupsText:SetPoint("TOPLEFT", anchor, "TOPRIGHT", S(4), 0)
@@ -2109,7 +2109,7 @@ local function PopulateEntry(entry, questData, groupKey)
             zoneLabel = ("[Off-map] %s"):format(zoneLabel)
         end
         entry.zoneText:SetText(zoneLabel)
-        entry.zoneShadow:SetText(zoneLabel)
+        entry.zoneShadow:SetText(addon.PlainTextForShadowFontString(zoneLabel))
         local zoneColor = (addon.GetZoneColor and addon.GetZoneColor(effectiveCat)) or addon.ZONE_COLOR
         if addon.ShouldApplySuperTrackQuestDim(questData) then
             zoneColor = addon.ApplyDimColor(zoneColor)
@@ -2130,7 +2130,7 @@ local function PopulateEntry(entry, questData, groupKey)
             stageLabel = stageFmt:format(questData.stageIndex, questData.stageName)
         end
         entry.zoneText:SetText(stageLabel)
-        entry.zoneShadow:SetText(stageLabel)
+        entry.zoneShadow:SetText(addon.PlainTextForShadowFontString(stageLabel))
         local stageColor = (addon.GetScenarioStageColor and addon.GetScenarioStageColor()) or addon.ZONE_COLOR or { 0.55, 0.65, 0.75 }
         if addon.ShouldApplySuperTrackQuestDim(questData) then
             stageColor = addon.ApplyDimColor(stageColor)

--- a/modules/Focus/FocusLayout.lua
+++ b/modules/Focus/FocusLayout.lua
@@ -380,8 +380,7 @@ local function FullLayout()
         if hideOptBtn then
             addon.optionsBtn:Hide()
         else
-            addon.optionsLabel:SetText(addon.L["PRESENCE_OPTIONS"])
-            if addon.optionsShadow then addon.optionsShadow:SetText(addon.PlainTextForShadowFontString(addon.L["PRESENCE_OPTIONS"])) end
+            addon.SetTextWithShadow(addon.optionsLabel, addon.optionsShadow, addon.L["PRESENCE_OPTIONS"])
             addon.optionsBtn:SetWidth(math.max(addon.optionsLabel:GetStringWidth() + 4, 44))
             addon.optionsBtn:Show()
             -- Visible on hover only: use alpha so frames stay in layout and remain clickable
@@ -397,8 +396,7 @@ local function FullLayout()
         addon.headerText:Show()
         addon.headerShadow:Show()
         local headerStr = addon.ApplyTextCase(addon.L["PRESENCE_OBJECTIVES"], "headerTextCase", "upper")
-        addon.headerText:SetText(headerStr)
-        addon.headerShadow:SetText(addon.PlainTextForShadowFontString(headerStr))
+        addon.SetTextWithShadow(addon.headerText, addon.headerShadow, headerStr)
         if addon.GetDB("showQuestCount", true) then addon.countText:Show(); addon.countShadow:Show() else addon.countText:Hide(); addon.countShadow:Hide() end
         addon.chevron:Show()
         if hideOptBtn then
@@ -406,8 +404,7 @@ local function FullLayout()
         else
             addon.optionsBtn:SetAlpha(1)
             addon.optionsBtn:Show()
-            addon.optionsLabel:SetText(addon.L["PRESENCE_OPTIONS"])
-            if addon.optionsShadow then addon.optionsShadow:SetText(addon.PlainTextForShadowFontString(addon.L["PRESENCE_OPTIONS"])) end
+            addon.SetTextWithShadow(addon.optionsLabel, addon.optionsShadow, addon.L["PRESENCE_OPTIONS"])
             addon.optionsBtn:SetWidth(math.max(addon.optionsLabel:GetStringWidth() + 4, 44))
         end
         local showDiv = addon.GetDB("showHeaderDivider", true)

--- a/modules/Focus/FocusLayout.lua
+++ b/modules/Focus/FocusLayout.lua
@@ -381,7 +381,7 @@ local function FullLayout()
             addon.optionsBtn:Hide()
         else
             addon.optionsLabel:SetText(addon.L["PRESENCE_OPTIONS"])
-            if addon.optionsShadow then addon.optionsShadow:SetText(addon.L["PRESENCE_OPTIONS"]) end
+            if addon.optionsShadow then addon.optionsShadow:SetText(addon.PlainTextForShadowFontString(addon.L["PRESENCE_OPTIONS"])) end
             addon.optionsBtn:SetWidth(math.max(addon.optionsLabel:GetStringWidth() + 4, 44))
             addon.optionsBtn:Show()
             -- Visible on hover only: use alpha so frames stay in layout and remain clickable
@@ -398,7 +398,7 @@ local function FullLayout()
         addon.headerShadow:Show()
         local headerStr = addon.ApplyTextCase(addon.L["PRESENCE_OBJECTIVES"], "headerTextCase", "upper")
         addon.headerText:SetText(headerStr)
-        addon.headerShadow:SetText(headerStr)
+        addon.headerShadow:SetText(addon.PlainTextForShadowFontString(headerStr))
         if addon.GetDB("showQuestCount", true) then addon.countText:Show(); addon.countShadow:Show() else addon.countText:Hide(); addon.countShadow:Hide() end
         addon.chevron:Show()
         if hideOptBtn then
@@ -407,7 +407,7 @@ local function FullLayout()
             addon.optionsBtn:SetAlpha(1)
             addon.optionsBtn:Show()
             addon.optionsLabel:SetText(addon.L["PRESENCE_OPTIONS"])
-            if addon.optionsShadow then addon.optionsShadow:SetText(addon.L["PRESENCE_OPTIONS"]) end
+            if addon.optionsShadow then addon.optionsShadow:SetText(addon.PlainTextForShadowFontString(addon.L["PRESENCE_OPTIONS"])) end
             addon.optionsBtn:SetWidth(math.max(addon.optionsLabel:GetStringWidth() + 4, 44))
         end
         local showDiv = addon.GetDB("showHeaderDivider", true)

--- a/modules/Focus/FocusSectionHeaders.lua
+++ b/modules/Focus/FocusSectionHeaders.lua
@@ -49,8 +49,7 @@ local function AcquireSectionHeader(groupKey, focusedGroupKey)
     local label = addon.L[addon.SECTION_LABELS[groupKey] or groupKey]
     label = addon.ApplyTextCase(label, "sectionHeaderTextCase", "upper")
     local color = addon.GetSectionHeaderDisplayColor(groupKey, focusedGroupKey)
-    s.text:SetText(label)
-    s.shadow:SetText(addon.PlainTextForShadowFontString(label))
+    addon.SetTextWithShadow(s.text, s.shadow, label)
     local secA = addon.SECTION_COLOR_A or 1
     if addon.ShouldDimSectionHeaderForSuperTrack(groupKey, focusedGroupKey) then
         secA = secA * addon.GetDimAlpha()

--- a/modules/Focus/FocusSectionHeaders.lua
+++ b/modules/Focus/FocusSectionHeaders.lua
@@ -50,7 +50,7 @@ local function AcquireSectionHeader(groupKey, focusedGroupKey)
     label = addon.ApplyTextCase(label, "sectionHeaderTextCase", "upper")
     local color = addon.GetSectionHeaderDisplayColor(groupKey, focusedGroupKey)
     s.text:SetText(label)
-    s.shadow:SetText(label)
+    s.shadow:SetText(addon.PlainTextForShadowFontString(label))
     local secA = addon.SECTION_COLOR_A or 1
     if addon.ShouldDimSectionHeaderForSuperTrack(groupKey, focusedGroupKey) then
         secA = secA * addon.GetDimAlpha()

--- a/modules/Focus/scenarios/FocusMplusBlock.lua
+++ b/modules/Focus/scenarios/FocusMplusBlock.lua
@@ -379,7 +379,7 @@ local function UpdateMplusBlockDisplay(data)
     local level = data.level > 0 and (" (+" .. data.level .. ")") or ""
     local heroStr = dungeonName .. level
     mplusHeroText:SetText(heroStr)
-    mplusHeroShadow:SetText(heroStr)
+    mplusHeroShadow:SetText(addon.PlainTextForShadowFontString(heroStr))
 
     -- Line 2: Timer (elapsed / target + penalty)
     local timerStr = "—"
@@ -449,9 +449,9 @@ local function UpdateMplusBlockDisplay(data)
             addon.FormatNumberWithGrouping(data.enemyForces.current),
             addon.FormatNumberWithGrouping(data.enemyForces.total))
         progressPercentLabel:SetText(pctStr)
-        progressPercentShadow:SetText(pctStr)
+        progressPercentShadow:SetText(addon.PlainTextForShadowFontString(pctStr))
         progressCountLabel:SetText(cntStr)
-        progressCountShadow:SetText(cntStr)
+        progressCountShadow:SetText(addon.PlainTextForShadowFontString(cntStr))
 
         -- Color: user-picked bar fill; switches to "done" color at 100%
         if data.enemyForces.percent >= 100 then

--- a/modules/Focus/scenarios/FocusMplusBlock.lua
+++ b/modules/Focus/scenarios/FocusMplusBlock.lua
@@ -378,8 +378,7 @@ local function UpdateMplusBlockDisplay(data)
     local dungeonName = data.dungeonName ~= "" and data.dungeonName or "Mythic+"
     local level = data.level > 0 and (" (+" .. data.level .. ")") or ""
     local heroStr = dungeonName .. level
-    mplusHeroText:SetText(heroStr)
-    mplusHeroShadow:SetText(addon.PlainTextForShadowFontString(heroStr))
+    addon.SetTextWithShadow(mplusHeroText, mplusHeroShadow, heroStr)
 
     -- Line 2: Timer (elapsed / target + penalty)
     local timerStr = "—"
@@ -448,10 +447,8 @@ local function UpdateMplusBlockDisplay(data)
         local cntStr  = ("(%s/%s)"):format(
             addon.FormatNumberWithGrouping(data.enemyForces.current),
             addon.FormatNumberWithGrouping(data.enemyForces.total))
-        progressPercentLabel:SetText(pctStr)
-        progressPercentShadow:SetText(addon.PlainTextForShadowFontString(pctStr))
-        progressCountLabel:SetText(cntStr)
-        progressCountShadow:SetText(addon.PlainTextForShadowFontString(cntStr))
+        addon.SetTextWithShadow(progressPercentLabel, progressPercentShadow, pctStr)
+        addon.SetTextWithShadow(progressCountLabel, progressCountShadow, cntStr)
 
         -- Color: user-picked bar fill; switches to "done" color at 100%
         if data.enemyForces.percent >= 100 then


### PR DESCRIPTION
Closes #271

## Summary
Achievement progress counters appeared doubled when text shadow was on because shadow FontStrings rendered embedded `|cffRRGGBB…|r` color escapes in their inline color rather than the solid black `SetTextColor(0,0,0)` they'd been configured with. Visible duplicate digits were the shadow rendering the colored portion at its offset.

## Implementation notes
**Commit 1 — `fix(focus): strip color escapes from shadow font strings`**
Wrap every Focus `*Shadow:SetText(...)` callsite with the existing `addon.PlainTextForShadowFontString` helper (which strips `|c…|r` colors, `|T…|t` textures, and `|H…|h` hyperlinks). Matches the established pattern already in use at one site in FocusEntryRenderer.

**Commit 2 — `refactor(focus): hoist text+shadow pair into helper, add fast-path`**
After the rote wrap, three review agents converged on the same finding: the 14-line repetition was itself the footgun that produced #271. Introduce `addon.SetTextWithShadow(textFS, shadowFS, str)` so callers cannot forget the shadow strip, and migrate 15 paired text/shadow sites in Focus to use it. Also add a `if not s:find("|") then return s end` fast-path to `PlainTextForShadowFontString` so the M+ counter-tick callsites skip four `gsub` scans for plain strings.

Left one site inline: `FocusEntryPool.lua:765` is a typography-apply shadow refresh that reads the label text back from the FontString itself (no local source string to share with the helper). Separate cleanup.

Non-Focus modules audited — none share this bug class. Vista, Cache, Essence, and Presence never let `|c…|r` flow into their shadow FontStrings (Presence pre-strips at the producer).

## Test plan
- [ ] `/reload`
- [ ] Track an achievement with a multi-step counter (e.g. *Critter Kill Squad*); confirm a single coloured `X/Y` with clean black shadow — no doubled digits.
- [ ] Focus → Typography → Shadow → toggle **Show Text Shadow** + vary offsets — counters stay clean at all offsets.
- [ ] Toggle **Objective Progress Number Colors** off and on — no regression in either state.
- [ ] Toggle **Show Completed Count** on for a non-achievement category — same clean behaviour.
- [ ] Track an endeavor with a counter — same behaviour expected.
- [ ] Open a delve — confirm lives/groups indicators render with clean shadows.
- [ ] Run a Mythic+ key — confirm dungeon name, %, and enemy-forces count shadows are clean and not visibly more expensive.
- [ ] Confirm zone labels, scenario stage labels, section headers, and the Focus header/options labels all still render with proper shadows.