### PR TITLE
TEST/WIP : feature(focus): add Horizon-RareScanner integration

### DIFF
--- a/HorizonSuite.toc
+++ b/HorizonSuite.toc
@@ -133,6 +133,7 @@ options/modules/OptionsEssence.lua
 options/modules/OptionsVista.lua
 options/modules/OptionsCache.lua
 options/modules/OptionsPresenceTalkingHead.lua
+options/modules/OptionsFocusIntegrations.lua
 options/OptionsSearch.lua
 options/OptionsPanel.lua
 options/SettingsBridge.lua

--- a/locales/horizon/deDE.lua
+++ b/locales/horizon/deDE.lua
@@ -1,4 +1,4 @@
-if GetLocale() ~= "deDE" then return end
+﻿if GetLocale() ~= "deDE" then return end
 
 local addon = _G.HorizonSuite
 if not addon then return end
@@ -2140,3 +2140,17 @@ L["ZONE_NAME_NEW_ZONE"]                                       = "Der Zonenname e
 L["ZONE_TYPE_COLOURING"]                                      = "Färbung nach Zonentyp"
 L["FOCUS_COMPLETED_CHECKMARK"]                                = "|TInterface\\\\Buttons\\\\UI-CheckBox-Check:12:12:0:0|t anstelle von grüngefärbten abgeschlossenen Zielen."
 
+
+-- =====================================================================
+-- Integrations tab — Focus options
+-- =====================================================================
+-- L["FOCUS_INTEGRATION"]                                     = "Integrations"
+-- L["FOCUS_INTEGRATION_DESC"]                                = "Configure companion addon integrations for the Focus tracker."
+-- L["FOCUS_INTEGRATION_RARESCANNER"]                         = "RareScanner"
+-- L["FOCUS_INTEGRATION_RARESCANNER_INVALID"]               = "Horizon - RareScanner is not installed."
+-- L["FOCUS_INTEGRATION_RARESCANNER_SHOW_RARES"]              = "Show Rare Bosses"
+-- L["FOCUS_INTEGRATION_RARESCANNER_SHOW_RARES_DESC"]         = "Show rare NPC alerts from RareScanner inside the Focus tracker."
+-- L["FOCUS_INTEGRATION_RARESCANNER_SHOW_TREASURES"]          = "Show Treasures"
+-- L["FOCUS_INTEGRATION_RARESCANNER_SHOW_TREASURES_DESC"]     = "Show treasure and container alerts from RareScanner inside the Focus tracker."
+-- L["FOCUS_INTEGRATION_RARESCANNER_SHOW_EVENTS"]             = "Show Events"
+-- L["FOCUS_INTEGRATION_RARESCANNER_SHOW_EVENTS_DESC"]        = "Show rare event alerts from RareScanner inside the Focus tracker."

--- a/locales/horizon/enUS.lua
+++ b/locales/horizon/enUS.lua
@@ -2158,3 +2158,17 @@ L["ZONE_LABELS"]                                              = "Zone Labels"
 L["ZONE_NAME_NEW_ZONE"]                                       = "Zone name still appears when entering a new zone."
 L["ZONE_TYPE_COLOURING"]                                      = "Zone Type Colouring"
 L["FOCUS_COMPLETED_CHECKMARK"]                                = "|TInterface\\\\Buttons\\\\UI-CheckBox-Check:12:12:0:0|t instead of green for done objectives."
+
+-- =====================================================================
+-- Integrations tab — Focus options
+-- =====================================================================
+L["FOCUS_INTEGRATIONS"]                                       = "Integrations"
+L["FOCUS_INTEGRATIONS_DESC"]                                  = "Configure companion addon integrations for the Focus tracker."
+L["FOCUS_INTEGRATION_RARESCANNER"]                            = "RareScanner"
+L["FOCUS_INTEGRATION_RARESCANNER_NOT_INSTALLED"]              = "Horizon - RareScanner is not installed."
+L["FOCUS_INTEGRATION_RARESCANNER_SHOW_RARES"]                 = "Show Rare Bosses"
+L["FOCUS_INTEGRATION_RARESCANNER_SHOW_RARES_DESC"]            = "Show rare NPC alerts from RareScanner inside the Focus tracker."
+L["FOCUS_INTEGRATION_RARESCANNER_SHOW_TREASURES"]             = "Show Treasures"
+L["FOCUS_INTEGRATION_RARESCANNER_SHOW_TREASURES_DESC"]        = "Show treasure and container alerts from RareScanner inside the Focus tracker."
+L["FOCUS_INTEGRATION_RARESCANNER_SHOW_EVENTS"]                = "Show Events"
+L["FOCUS_INTEGRATION_RARESCANNER_SHOW_EVENTS_DESC"]           = "Show rare event alerts from RareScanner inside the Focus tracker."

--- a/locales/horizon/enUS.lua
+++ b/locales/horizon/enUS.lua
@@ -1,4 +1,4 @@
-local addon = _G.HorizonSuite
+﻿local addon = _G.HorizonSuite
 if not addon then return end
 
 local L = addon.L
@@ -2162,10 +2162,10 @@ L["FOCUS_COMPLETED_CHECKMARK"]                                = "|TInterface\\\\
 -- =====================================================================
 -- Integrations tab — Focus options
 -- =====================================================================
-L["FOCUS_INTEGRATIONS"]                                       = "Integrations"
-L["FOCUS_INTEGRATIONS_DESC"]                                  = "Configure companion addon integrations for the Focus tracker."
+L["FOCUS_INTEGRATION"]                                        = "Integrations"
+L["FOCUS_INTEGRATION_DESC"]                                   = "Configure companion addon integrations for the Focus tracker."
 L["FOCUS_INTEGRATION_RARESCANNER"]                            = "RareScanner"
-L["FOCUS_INTEGRATION_RARESCANNER_NOT_INSTALLED"]              = "Horizon - RareScanner is not installed."
+L["FOCUS_INTEGRATION_RARESCANNER_INVALID"]                  = "Horizon - RareScanner is not installed."
 L["FOCUS_INTEGRATION_RARESCANNER_SHOW_RARES"]                 = "Show Rare Bosses"
 L["FOCUS_INTEGRATION_RARESCANNER_SHOW_RARES_DESC"]            = "Show rare NPC alerts from RareScanner inside the Focus tracker."
 L["FOCUS_INTEGRATION_RARESCANNER_SHOW_TREASURES"]             = "Show Treasures"

--- a/locales/horizon/esES.lua
+++ b/locales/horizon/esES.lua
@@ -2137,3 +2137,17 @@ L["M_BLOCK_WHENEVER_AN_ACTIVE_KEYSTONE"]                      = "Show the M+ blo
 -- L["ZONE_TYPE_COLOURING"]                                   = "Zone Type Colouring"
 -- L["FOCUS_COMPLETED_CHECKMARK"]                             = "|TInterface\\\\Buttons\\\\UI-CheckBox-Check:12:12:0:0|t instead of green for done objectives."
 
+
+-- =====================================================================
+-- Integrations tab — Focus options
+-- =====================================================================
+-- L["FOCUS_INTEGRATION"]                                     = "Integrations"
+-- L["FOCUS_INTEGRATION_DESC"]                                = "Configure companion addon integrations for the Focus tracker."
+-- L["FOCUS_INTEGRATION_RARESCANNER"]                         = "RareScanner"
+-- L["FOCUS_INTEGRATION_RARESCANNER_INVALID"]               = "Horizon - RareScanner is not installed."
+-- L["FOCUS_INTEGRATION_RARESCANNER_SHOW_RARES"]              = "Show Rare Bosses"
+-- L["FOCUS_INTEGRATION_RARESCANNER_SHOW_RARES_DESC"]         = "Show rare NPC alerts from RareScanner inside the Focus tracker."
+-- L["FOCUS_INTEGRATION_RARESCANNER_SHOW_TREASURES"]          = "Show Treasures"
+-- L["FOCUS_INTEGRATION_RARESCANNER_SHOW_TREASURES_DESC"]     = "Show treasure and container alerts from RareScanner inside the Focus tracker."
+-- L["FOCUS_INTEGRATION_RARESCANNER_SHOW_EVENTS"]             = "Show Events"
+-- L["FOCUS_INTEGRATION_RARESCANNER_SHOW_EVENTS_DESC"]        = "Show rare event alerts from RareScanner inside the Focus tracker."

--- a/locales/horizon/frFR.lua
+++ b/locales/horizon/frFR.lua
@@ -2137,3 +2137,17 @@ L["M_BLOCK_WHENEVER_AN_ACTIVE_KEYSTONE"]                      = "Show the M+ blo
 -- L["ZONE_TYPE_COLOURING"]                                   = "Zone Type Colouring"
 -- L["FOCUS_COMPLETED_CHECKMARK"]                             = "|TInterface\\\\Buttons\\\\UI-CheckBox-Check:12:12:0:0|t instead of green for done objectives."
 
+
+-- =====================================================================
+-- Integrations tab — Focus options
+-- =====================================================================
+-- L["FOCUS_INTEGRATION"]                                     = "Integrations"
+-- L["FOCUS_INTEGRATION_DESC"]                                = "Configure companion addon integrations for the Focus tracker."
+-- L["FOCUS_INTEGRATION_RARESCANNER"]                         = "RareScanner"
+-- L["FOCUS_INTEGRATION_RARESCANNER_INVALID"]               = "Horizon - RareScanner is not installed."
+-- L["FOCUS_INTEGRATION_RARESCANNER_SHOW_RARES"]              = "Show Rare Bosses"
+-- L["FOCUS_INTEGRATION_RARESCANNER_SHOW_RARES_DESC"]         = "Show rare NPC alerts from RareScanner inside the Focus tracker."
+-- L["FOCUS_INTEGRATION_RARESCANNER_SHOW_TREASURES"]          = "Show Treasures"
+-- L["FOCUS_INTEGRATION_RARESCANNER_SHOW_TREASURES_DESC"]     = "Show treasure and container alerts from RareScanner inside the Focus tracker."
+-- L["FOCUS_INTEGRATION_RARESCANNER_SHOW_EVENTS"]             = "Show Events"
+-- L["FOCUS_INTEGRATION_RARESCANNER_SHOW_EVENTS_DESC"]        = "Show rare event alerts from RareScanner inside the Focus tracker."

--- a/locales/horizon/koKR.lua
+++ b/locales/horizon/koKR.lua
@@ -2137,3 +2137,17 @@ L["M_BLOCK_WHENEVER_AN_ACTIVE_KEYSTONE"]                      = "Show the M+ blo
 -- L["ZONE_TYPE_COLOURING"]                                   = "Zone Type Colouring"
 -- L["FOCUS_COMPLETED_CHECKMARK"]                             = "|TInterface\\\\Buttons\\\\UI-CheckBox-Check:12:12:0:0|t instead of green for done objectives."
 
+
+-- =====================================================================
+-- Integrations tab — Focus options
+-- =====================================================================
+-- L["FOCUS_INTEGRATION"]                                     = "Integrations"
+-- L["FOCUS_INTEGRATION_DESC"]                                = "Configure companion addon integrations for the Focus tracker."
+-- L["FOCUS_INTEGRATION_RARESCANNER"]                         = "RareScanner"
+-- L["FOCUS_INTEGRATION_RARESCANNER_INVALID"]               = "Horizon - RareScanner is not installed."
+-- L["FOCUS_INTEGRATION_RARESCANNER_SHOW_RARES"]              = "Show Rare Bosses"
+-- L["FOCUS_INTEGRATION_RARESCANNER_SHOW_RARES_DESC"]         = "Show rare NPC alerts from RareScanner inside the Focus tracker."
+-- L["FOCUS_INTEGRATION_RARESCANNER_SHOW_TREASURES"]          = "Show Treasures"
+-- L["FOCUS_INTEGRATION_RARESCANNER_SHOW_TREASURES_DESC"]     = "Show treasure and container alerts from RareScanner inside the Focus tracker."
+-- L["FOCUS_INTEGRATION_RARESCANNER_SHOW_EVENTS"]             = "Show Events"
+-- L["FOCUS_INTEGRATION_RARESCANNER_SHOW_EVENTS_DESC"]        = "Show rare event alerts from RareScanner inside the Focus tracker."

--- a/locales/horizon/ptBR.lua
+++ b/locales/horizon/ptBR.lua
@@ -2137,3 +2137,17 @@ L["M_BLOCK_WHENEVER_AN_ACTIVE_KEYSTONE"]                      = "Show the M+ blo
 -- L["ZONE_TYPE_COLOURING"]                                   = "Zone Type Colouring"
 -- L["FOCUS_COMPLETED_CHECKMARK"]                             = "|TInterface\\\\Buttons\\\\UI-CheckBox-Check:12:12:0:0|t instead of green for done objectives."
 
+
+-- =====================================================================
+-- Integrations tab — Focus options
+-- =====================================================================
+-- L["FOCUS_INTEGRATION"]                                     = "Integrations"
+-- L["FOCUS_INTEGRATION_DESC"]                                = "Configure companion addon integrations for the Focus tracker."
+-- L["FOCUS_INTEGRATION_RARESCANNER"]                         = "RareScanner"
+-- L["FOCUS_INTEGRATION_RARESCANNER_INVALID"]               = "Horizon - RareScanner is not installed."
+-- L["FOCUS_INTEGRATION_RARESCANNER_SHOW_RARES"]              = "Show Rare Bosses"
+-- L["FOCUS_INTEGRATION_RARESCANNER_SHOW_RARES_DESC"]         = "Show rare NPC alerts from RareScanner inside the Focus tracker."
+-- L["FOCUS_INTEGRATION_RARESCANNER_SHOW_TREASURES"]          = "Show Treasures"
+-- L["FOCUS_INTEGRATION_RARESCANNER_SHOW_TREASURES_DESC"]     = "Show treasure and container alerts from RareScanner inside the Focus tracker."
+-- L["FOCUS_INTEGRATION_RARESCANNER_SHOW_EVENTS"]             = "Show Events"
+-- L["FOCUS_INTEGRATION_RARESCANNER_SHOW_EVENTS_DESC"]        = "Show rare event alerts from RareScanner inside the Focus tracker."

--- a/locales/horizon/zhCN.lua
+++ b/locales/horizon/zhCN.lua
@@ -2138,3 +2138,17 @@ L["M_BLOCK_WHENEVER_AN_ACTIVE_KEYSTONE"]                      = "Show the M+ blo
 -- L["ZONE_TYPE_COLOURING"]                                   = "Zone Type Colouring"
 -- L["FOCUS_COMPLETED_CHECKMARK"]                             = "|TInterface\\\\Buttons\\\\UI-CheckBox-Check:12:12:0:0|t instead of green for done objectives."
 
+
+-- =====================================================================
+-- Integrations tab — Focus options
+-- =====================================================================
+-- L["FOCUS_INTEGRATION"]                                     = "Integrations"
+-- L["FOCUS_INTEGRATION_DESC"]                                = "Configure companion addon integrations for the Focus tracker."
+-- L["FOCUS_INTEGRATION_RARESCANNER"]                         = "RareScanner"
+-- L["FOCUS_INTEGRATION_RARESCANNER_INVALID"]               = "Horizon - RareScanner is not installed."
+-- L["FOCUS_INTEGRATION_RARESCANNER_SHOW_RARES"]              = "Show Rare Bosses"
+-- L["FOCUS_INTEGRATION_RARESCANNER_SHOW_RARES_DESC"]         = "Show rare NPC alerts from RareScanner inside the Focus tracker."
+-- L["FOCUS_INTEGRATION_RARESCANNER_SHOW_TREASURES"]          = "Show Treasures"
+-- L["FOCUS_INTEGRATION_RARESCANNER_SHOW_TREASURES_DESC"]     = "Show treasure and container alerts from RareScanner inside the Focus tracker."
+-- L["FOCUS_INTEGRATION_RARESCANNER_SHOW_EVENTS"]             = "Show Events"
+-- L["FOCUS_INTEGRATION_RARESCANNER_SHOW_EVENTS_DESC"]        = "Show rare event alerts from RareScanner inside the Focus tracker."

--- a/modules/Focus/FocusAggregator.lua
+++ b/modules/Focus/FocusAggregator.lua
@@ -11,6 +11,9 @@ local CATEGORY_SORT_FALLBACK = 99
 local DEFAULT_GROUP = "DEFAULT"
 local UNKNOWN_TITLE_PLACEHOLDER = "..."
 
+-- Sibling-addon entry providers registered via addon.RegisterFocusEntryProvider.
+local externalProviders = {}
+
 -- Entry sort mode: alpha, questType, zone, level (DB key entrySortMode, default questType)
 local VALID_ENTRY_SORT = { alpha = true, questType = true, zone = true, level = true }
 
@@ -695,11 +698,31 @@ local function ReadTrackedQuests()
         end
     end
 
+    -- 8. External providers (e.g. Horizon-RareScanner)
+    for _, provider in ipairs(externalProviders) do
+        local ok, entries = pcall(provider)
+        if ok and entries then
+            for _, e in ipairs(entries) do
+                quests[#quests + 1] = e
+            end
+        end
+    end
+
     if addon.testQuestItem then
         table.insert(quests, 1, addon.testQuestItem)
     end
 
     return quests
+end
+
+--- Register an external entry provider for the Focus tracker.
+--- The provider is a function() → table of normalized entry tables.
+--- Called once per tracker refresh; errors are caught and silently dropped.
+--- @param fn function
+function addon.RegisterFocusEntryProvider(fn)
+    if type(fn) == "function" then
+        externalProviders[#externalProviders + 1] = fn
+    end
 end
 
 addon.ReadTrackedQuests   = ReadTrackedQuests

--- a/options/modules/OptionsFocusIntegrations.lua
+++ b/options/modules/OptionsFocusIntegrations.lua
@@ -12,7 +12,6 @@ local L       = addon.L
 local Section = addon.Section
 local Toggle  = addon.Toggle
 
-local function getDB(k, d) return addon.GetDB(k, d) end
 local function setDB(k, v) addon.OptionsData_SetDB(k, v) end
 
 -- ============================================================================
@@ -30,8 +29,8 @@ end
 
 addon.OptionCategories[#addon.OptionCategories + 1] = {
     key       = "Integrations",
-    name      = L["FOCUS_INTEGRATIONS"],
-    desc      = L["FOCUS_INTEGRATIONS_DESC"],
+    name      = L["FOCUS_INTEGRATION"],
+    desc      = L["FOCUS_INTEGRATION_DESC"],
     moduleKey = "focus",
     options   = {
         -- ----------------------------------------------------------------
@@ -42,7 +41,7 @@ addon.OptionCategories[#addon.OptionCategories + 1] = {
         -- Shown only when the companion addon is absent, to guide the user.
         {
             type        = "section",
-            name        = L["FOCUS_INTEGRATION_RARESCANNER_NOT_INSTALLED"],
+            name        = L["FOCUS_INTEGRATION_RARESCANNER_INVALID"],
             visibleWhen = function() return not RareScannerIntegrationLoaded() end,
         },
 

--- a/options/modules/OptionsFocusIntegrations.lua
+++ b/options/modules/OptionsFocusIntegrations.lua
@@ -1,0 +1,97 @@
+--[[
+    Horizon Suite - Focus - Integrations options
+    Self-registers an "Integrations" category under the Focus options panel.
+    Each entry shows the status of a companion addon and exposes its toggles.
+    Controls are disabled when the corresponding addon is not installed.
+]]
+
+local addon = _G.HorizonSuite
+if not addon or not addon.OptionCategories then return end
+
+local L       = addon.L
+local Section = addon.Section
+local Toggle  = addon.Toggle
+
+local function getDB(k, d) return addon.GetDB(k, d) end
+local function setDB(k, v) addon.OptionsData_SetDB(k, v) end
+
+-- ============================================================================
+-- GUARDS
+-- ============================================================================
+
+--- True when the Horizon-RareScanner companion addon is loaded.
+local function RareScannerIntegrationLoaded()
+    return _G.HorizonRareScanner ~= nil
+end
+
+-- ============================================================================
+-- CATEGORY
+-- ============================================================================
+
+addon.OptionCategories[#addon.OptionCategories + 1] = {
+    key       = "Integrations",
+    name      = L["FOCUS_INTEGRATIONS"],
+    desc      = L["FOCUS_INTEGRATIONS_DESC"],
+    moduleKey = "focus",
+    options   = {
+        -- ----------------------------------------------------------------
+        -- RareScanner
+        -- ----------------------------------------------------------------
+        Section(L["FOCUS_INTEGRATION_RARESCANNER"]),
+
+        -- Shown only when the companion addon is absent, to guide the user.
+        {
+            type        = "section",
+            name        = L["FOCUS_INTEGRATION_RARESCANNER_NOT_INSTALLED"],
+            visibleWhen = function() return not RareScannerIntegrationLoaded() end,
+        },
+
+        Toggle(
+            L["FOCUS_INTEGRATION_RARESCANNER_SHOW_RARES"],
+            L["FOCUS_INTEGRATION_RARESCANNER_SHOW_RARES_DESC"],
+            "rs_showRares",
+            true,
+            {
+                id          = "rs_showRares",
+                visibleWhen = RareScannerIntegrationLoaded,
+                disabled    = function() return not RareScannerIntegrationLoaded() end,
+                set         = function(v)
+                    setDB("rs_showRares", v)
+                    if addon.ScheduleRefresh then addon.ScheduleRefresh() end
+                end,
+            }
+        ),
+
+        Toggle(
+            L["FOCUS_INTEGRATION_RARESCANNER_SHOW_TREASURES"],
+            L["FOCUS_INTEGRATION_RARESCANNER_SHOW_TREASURES_DESC"],
+            "rs_showTreasures",
+            true,
+            {
+                id          = "rs_showTreasures",
+                visibleWhen = RareScannerIntegrationLoaded,
+                disabled    = function() return not RareScannerIntegrationLoaded() end,
+                set         = function(v)
+                    setDB("rs_showTreasures", v)
+                    if addon.ScheduleRefresh then addon.ScheduleRefresh() end
+                end,
+            }
+        ),
+
+        Toggle(
+            L["FOCUS_INTEGRATION_RARESCANNER_SHOW_EVENTS"],
+            L["FOCUS_INTEGRATION_RARESCANNER_SHOW_EVENTS_DESC"],
+            "rs_showEvents",
+            true,
+            {
+                id          = "rs_showEvents",
+                visibleWhen = RareScannerIntegrationLoaded,
+                disabled    = function() return not RareScannerIntegrationLoaded() end,
+                set         = function(v)
+                    setDB("rs_showEvents", v)
+                    if addon.ScheduleRefresh then addon.ScheduleRefresh() end
+                end,
+            }
+        ),
+    },
+}


### PR DESCRIPTION
## Summary

- Adds an external entry provider hook to `FocusAggregator` so companion addons can inject Focus entries without modifying core files
- Adds `OptionsFocusIntegrations.lua` — an Integrations options tab under Focus, with per-type visibility toggles (Rares, Treasures, Events) for the Horizon-RareScanner companion; controls are hidden/disabled when the addon is not installed
- Adds enUS locale keys and the required TOC entry for the new file

The companion addon (https://github.com/ProgrammingSam/Horizon-RareScanner) hooks into the provider system to surface active RareScanner alerts inside the Focus tracker, respecting both the module enable toggle and the per-type DB flags exposed here.

## Test plan

- [ ] Load HorizonSuite alone — Integrations tab visible in Focus options, RareScanner section shows "not installed" message, toggles hidden
- [ ] Load HorizonSuite + Horizon-RareScanner (without RareScanner) — toggles appear, no alerts fire
- [ ] Load full stack (HorizonSuite + Horizon-RareScanner + RareScanner) — rare alert populates Focus tracker; disable each toggle and confirm the entry disappears on next refresh
- [ ] Disable the RareScanner module in the Modules tab — confirm no entries appear even with an active alert
- [ ] Confirm no Lua errors in all three load configurations