### PR TITLE
fix(options): add missing local L = addon.L in OptionsData.lua

### DIFF
--- a/options/OptionsData.lua
+++ b/options/OptionsData.lua
@@ -8,6 +8,7 @@
 local addon = _G.HorizonSuite
 if not addon then return end
 if not _G[addon.DATABASE] then _G[addon.DATABASE] = {} end
+local L = addon.L
 
 -- ---------------------------------------------------------------------------
 -- Migration: early global-font implementation used fontPath as the override key.


### PR DESCRIPTION
## Summary

- `OptionsData.lua` was using `L["PRESENCE_PREVIEW"]` and other locale keys without declaring `local L = addon.L`, leaving `L` as an undefined global
- This caused a nil-concatenation error at load time, which prevented `addon.OptionCategories` from ever being assigned (it is set later in the same file), cascading into a `bad argument #1 to 'ipairs'` crash in the Dashboard

Introduced in ae3de7b (Refactor/options Part 2).

## Test plan

- [ ] Open the options menu — no Lua errors on load
- [ ] Modules tab renders correctly with locale strings
- [ ] Dashboard sidebar populates without nil-ipairs error