### PR TITLE
fix(options): defer Modules options builder to avoid load-order crash

### DIFF
--- a/options/OptionsData.lua
+++ b/options/OptionsData.lua
@@ -251,7 +251,8 @@ local OptionCategories = {
         key = "Modules",
         name = L["MODULES"],
         moduleKey = nil,
-        options = (function()
+        options = function()
+            local BM = addon.BrandModule
             local previewSuffix = " |cff228b22(" .. (L["PRESENCE_PREVIEW"]) .. ")|r"
             local previewDescSuffix = "\n\n" .. (L["MODULE_PREVIEW_DISCLAIMER"])
             local function setModuleFromOptions(moduleKey, v)
@@ -259,18 +260,17 @@ local OptionCategories = {
                 local defer = dash and dash:IsShown()
                 addon:SetModuleEnabled(moduleKey, v, defer and { deferReload = true } or nil)
             end
-            local opts = {
+            return {
                 { type = "section", name = L["MODULE_TOGGLES"] },
-                { type = "toggle", name = BrandModule("focus"), desc = L["DASH_OBJECTIVE_TRACKER_QUESTS_WORLD_QUESTS"], dbKey = "_module_focus", get = function() return addon:IsModuleEnabled("focus") end, set = function(v) setModuleFromOptions("focus", v) end },
-                { type = "toggle", name = BrandModule("presence"), desc = L["DASH_ZONE_TEXT_AND_NOTIFICATIONS"], dbKey = "_module_presence", get = function() return addon:IsModuleEnabled("presence") end, set = function(v) setModuleFromOptions("presence", v) end },
-                { type = "toggle", name = BrandModule("vista"), desc = L["DASH_MINIMAP_ZONE_TEXT_COORDS_BUTTON"], dbKey = "_module_vista", get = function() return addon:IsModuleEnabled("vista") end, set = function(v) setModuleFromOptions("vista", v) end },
-                { type = "toggle", name = BrandModule("insight"), desc = L["DASH_TOOLTIPS_CLASS_COLOURS_SPEC_FACTION"], dbKey = "_module_insight", get = function() return addon:IsModuleEnabled("insight") end, set = function(v) setModuleFromOptions("insight", v) end },
-                { type = "toggle", name = (BrandModule("cache") or "Cache") .. previewSuffix, desc = (L["DASH_LOOT_TOASTS_ITEMS_MONEY_CURRENCY"]) .. previewDescSuffix, dbKey = "_module_cache", get = function() return addon:IsModuleEnabled("cache") end, set = function(v) setModuleFromOptions("cache", v) end },
-                { type = "toggle", name = (BrandModule("essence") or "Essence") .. previewSuffix, desc = (L["DASH_ESSENCE_MODULE_SHORT_DESCRIPTION"]) .. previewDescSuffix, dbKey = "_module_essence", get = function() return addon:IsModuleEnabled("essence") end, set = function(v) setModuleFromOptions("essence", v) end },
+                { type = "toggle", name = BM and BM("focus"), desc = L["DASH_OBJECTIVE_TRACKER_QUESTS_WORLD_QUESTS"], dbKey = "_module_focus", get = function() return addon:IsModuleEnabled("focus") end, set = function(v) setModuleFromOptions("focus", v) end },
+                { type = "toggle", name = BM and BM("presence"), desc = L["DASH_ZONE_TEXT_AND_NOTIFICATIONS"], dbKey = "_module_presence", get = function() return addon:IsModuleEnabled("presence") end, set = function(v) setModuleFromOptions("presence", v) end },
+                { type = "toggle", name = BM and BM("vista"), desc = L["DASH_MINIMAP_ZONE_TEXT_COORDS_BUTTON"], dbKey = "_module_vista", get = function() return addon:IsModuleEnabled("vista") end, set = function(v) setModuleFromOptions("vista", v) end },
+                { type = "toggle", name = BM and BM("insight"), desc = L["DASH_TOOLTIPS_CLASS_COLOURS_SPEC_FACTION"], dbKey = "_module_insight", get = function() return addon:IsModuleEnabled("insight") end, set = function(v) setModuleFromOptions("insight", v) end },
+                { type = "toggle", name = (BM and BM("cache") or "Cache") .. previewSuffix, desc = (L["DASH_LOOT_TOASTS_ITEMS_MONEY_CURRENCY"]) .. previewDescSuffix, dbKey = "_module_cache", get = function() return addon:IsModuleEnabled("cache") end, set = function(v) setModuleFromOptions("cache", v) end },
+                { type = "toggle", name = (BM and BM("essence") or "Essence") .. previewSuffix, desc = (L["DASH_ESSENCE_MODULE_SHORT_DESCRIPTION"]) .. previewDescSuffix, dbKey = "_module_essence", get = function() return addon:IsModuleEnabled("essence") end, set = function(v) setModuleFromOptions("essence", v) end },
                 { type = "moduleReloadPrompt" },
             }
-            return opts
-        end)(),
+        end,
     },
     {
         key = "GlobalToggles",


### PR DESCRIPTION
## Summary

- The Modules entry in `OptionCategories` was calling `BrandModule()` eagerly inside an IIFE at load time
- `BrandModule` is a local in `OptionsHelpers.lua` exposed as `addon.BrandModule` — but `OptionsHelpers.lua` loads **after** `OptionsData.lua` in the TOC
- The IIFE crashed on `BrandModule("focus")` (nil call), which prevented `addon.OptionCategories` from ever being assigned at line 2809, causing the `bad argument #1 to 'ipairs'` crash in `Dashboard_BuildMainFrame`

**Fix:** convert the eager IIFE to a lazy `function()` — both `DashboardFrame` and `OptionsPanel` already handle `cat.options` as either a table or a function (`type(cat.options) == "function" and cat.options() or cat.options`).

## Test plan

- [ ] Open the options menu — no Lua errors on load
- [ ] Modules tab renders with correct branded module names
- [ ] Dashboard sidebar populates without nil-ipairs error
- [ ] Module enable/disable toggles work correctly