### PR TITLE
fix(insight): guard aura spellId comparisons against secret number values

### DIFF
--- a/modules/Insight/InsightPlayerTooltip.lua
+++ b/modules/Insight/InsightPlayerTooltip.lua
@@ -203,14 +203,18 @@ local function UnitHasAuraBySpellID(unit, spellID)
         for i = 1, 40 do
             local ok, aura = pcall(C_UnitAuras.GetAuraDataByIndex, unit, i, "HELPFUL")
             if not ok or not aura then break end
-            if aura.spellId == spellID then return true end
+            local cmpOk, matched = pcall(function() return aura.spellId == spellID end)
+            if cmpOk and matched then return true end
+            if not cmpOk then break end  -- spellId is secret; all iterations will be, bail out
         end
     end
     if UnitAura then
         for i = 1, 40 do
             local ok, name, _, _, _, _, _, _, _, spellId = pcall(UnitAura, unit, i, "HELPFUL")
             if not ok or not name then break end
-            if spellId == spellID then return true end
+            local cmpOk, matched = pcall(function() return spellId == spellID end)
+            if cmpOk and matched then return true end
+            if not cmpOk then break end  -- spellId is secret; bail out
         end
     end
     if AuraUtil and AuraUtil.FindAuraByName then


### PR DESCRIPTION
## Summary

- `UnitHasAuraBySpellID` iterates auras to check for specific spell IDs (used by `IsDracthyrInVisageForm` via `RaceIconMarkup`)
- When the tooltip hook fires within a `SetWorldCursor` execution chain, `C_UnitAuras.GetAuraDataByIndex` returns an aura table whose `spellId` (and other numeric fields) are secret values
- The `pcall` previously only wrapped the API call itself — the `aura.spellId == spellID` comparison outside it threw `attempt to compare field 'spellId' (a secret number value, while execution tainted by 'HorizonSuite')`
- Same vulnerability existed in the `UnitAura` fallback path

## Fix

Wrap both `spellId == spellID` comparisons in `pcall`. Break immediately on the first secret-value failure — if `spellId` is secret on iteration 1, every subsequent iteration in the same execution context will be too.

## Test plan

- [x] Hover a Dracthyr player via world cursor — no taint error in chat
- [x] Hover a Dracthyr player normally — race icon still displays correctly (visage detection still works outside protected contexts)
- [x] Hover non-Dracthyr players — no change in behaviour

🤖 Generated with [Claude Code](https://claude.com/claude-code)