### PR TITLE
chore(codeowners): restore main directors-only approval rule

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,3 @@
 # Default code owners for the entire repository
-# Approvals on `dev` must come from a director or trusted write collaborator
-# (enforced via `require_code_owner_review` on the `protect-dev` ruleset).
-# Note: `main` has its own CODEOWNERS on the `main` branch restricting approvals to directors only.
-* @Tacit-Labs/directors @nightsofglass @ProgrammingSam @SwiftMint
+# Approvals on `main` must come from a director (enforced via `require_code_owner_review`)
+* @Tacit-Labs/directors


### PR DESCRIPTION
## Why

The v5.0.0 promotion (#306) squash-merged `dev`'s branch-specific `.github/CODEOWNERS` onto `main`, which reverted #268. `main` is now showing the broader dev approval pool (directors + trusted write collaborators) instead of directors-only.

This restores `main`'s intended rule: **approvals on `main` must come from a director**. `dev` keeps its broader pool unchanged on the `dev` branch (CODEOWNERS only governs its own branch's PRs).

## Changes

- `.github/CODEOWNERS` → `* @Tacit-Labs/directors`

## Test Plan

- [ ] After merge, confirm a non-director's approval no longer satisfies the `main` code-owner gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)