### PR TITLE
chore: remove empty OptionsDefaultsFlow and OptionsDefaultsMeridian stubs

### DIFF
--- a/HorizonSuite.toc
+++ b/HorizonSuite.toc
@@ -124,8 +124,6 @@ options/modules/defaults/OptionsDefaultsEssence.lua
 options/modules/defaults/OptionsDefaultsVista.lua
 options/modules/defaults/OptionsDefaultsFocus.lua
 options/modules/defaults/OptionsDefaultsAxis.lua
-options/modules/defaults/OptionsDefaultsFlow.lua
-options/modules/defaults/OptionsDefaultsMeridian.lua
 options/modules/OptionsAxis.lua
 options/modules/OptionsGlobal.lua
 options/modules/OptionsFocus.lua

--- a/options/modules/defaults/OptionsDefaultsFlow.lua
+++ b/options/modules/defaults/OptionsDefaultsFlow.lua
@@ -1,7 +1,0 @@
---[[
-    Horizon Suite - Flow - SetDB routing keys
-    Stub file for the future Flow module. Add routing key tables here when
-    Flow options and settings are implemented.
-]]
-local addon = _G.HorizonSuite
-if not addon then return end

--- a/options/modules/defaults/OptionsDefaultsMeridian.lua
+++ b/options/modules/defaults/OptionsDefaultsMeridian.lua
@@ -1,7 +1,0 @@
---[[
-    Horizon Suite - Meridian - SetDB routing keys
-    Stub file for the future Meridian module. Add routing key tables here when
-    Meridian options and settings are implemented.
-]]
-local addon = _G.HorizonSuite
-if not addon then return end


### PR DESCRIPTION
# Intent
Remove two empty stub files — `OptionsDefaultsFlow.lua` and `OptionsDefaultsMeridian.lua` — and their entries in `HorizonSuite.toc`. Neither file contained any logic or data; both were added prematurely before the corresponding modules exist.


## Reviewer Notes
Two files under `options/modules/defaults/` were added in anticipation of future Flow and Meridian modules. Both contain only the module header block and a guard — no tables, no keys, no actual defaults. Nothing in the codebase reads or requires them. This PR deletes them and removes their two `.toc` entries, leaving no other changes.


## Developer Notes
A search across the entire codebase (`git grep`) confirms that `OptionsDefaultsFlow.lua` and `OptionsDefaultsMeridian.lua` are referenced solely by `HorizonSuite.toc`. The word `meridian` appears in `core/Config.lua` (module display name string) and `core/PatchNotesData.lua` (patch notes copy), neither of which relates to the defaults files. The word `flow` appears only in Blizzard locale strings. No defaults system, no options panel, and no feature code references either file.

When Flow or Meridian modules are eventually built out, their defaults files should be created alongside the actual option descriptors, not ahead of them.


## Reviewer Checklist

- [ ] Confirm `OptionsDefaultsFlow.lua` and `OptionsDefaultsMeridian.lua` are absent from the repo
- [ ] Confirm neither filename appears in `HorizonSuite.toc`
- [ ] Confirm no other file references either stub