### PR TITLE
fix(dashboard): detect LibSharedMedia as installed when LoadOnDemand

### DIFF
--- a/options/dashboard/DashboardIntegrationsView.lua
+++ b/options/dashboard/DashboardIntegrationsView.lua
@@ -39,6 +39,12 @@ local function GetIntegrationState(name)
     if loadable == false and reason == "DISABLED" then
         return "disabled"
     end
+    -- LoadOnDemand libs (e.g. LibSharedMedia-3.0) are never auto-loaded when
+    -- the host addon bundles its own copy, so IsAddOnLoaded returns false even
+    -- when the standalone addon IS installed. DEMAND_LOADED means installed+enabled.
+    if loadable == false and reason == "DEMAND_LOADED" then
+        return "enabled"
+    end
     return "missing"
 end
 


### PR DESCRIPTION
## Intent

Fix a false "Not installed" status for LibSharedMedia in the Integrations dashboard card.

## Reviewer Notes

LibSharedMedia-3.0's standalone TOC declares `LoadOnDemand: 1`, so `C_AddOns.IsAddOnLoaded` always returns `false` for it — HorizonSuite loads the lib from its own bundled copy, and nobody ever demands the standalone one. `C_AddOns.GetAddOnInfo` returns `reason = "DEMAND_LOADED"` for installed-but-never-triggered LOD addons, but `GetIntegrationState` only checked for `"DISABLED"` and fell through to `"missing"` for everything else.

One-line change: treat `reason == "DEMAND_LOADED"` the same as a loaded addon — the user has it installed.

## Developer Notes

- Change is in `GetIntegrationState` (`DashboardIntegrationsView.lua:37-43`).
- The comment explains the invariant so the next reader doesn't revert it.
- Applies to any future LOD library integration entry, not just LibSharedMedia.

## Reviewer Checklist

- [x] `GetIntegrationState` returns `"enabled"` for a `DEMAND_LOADED` addon
- [x] `"DISABLED"` and `"missing"` paths are still correct
- [x] No other integration entries are LOD and would need different handling