### PR TITLE
fix(vista): guard presence migration with one-shot flag and migratedToProfile check

### DIFF
--- a/HorizonSuite.lua
+++ b/HorizonSuite.lua
@@ -144,10 +144,22 @@ function addon:EnsureModulesDB()
         db.modules.vista = { enabled = false }
         db.modules.essence = { enabled = false }
     end
-    -- Migrate old Vista (Presence) module key to Presence; repurpose vista for minimap
-    if db.modules.vista and not db.modules.presence then
-        db.modules.presence = { enabled = (db.modules.vista.enabled ~= false) }
-        db.modules.vista = { enabled = false }
+    -- One-shot: old "vista" key was the social/Presence module; new "vista" = minimap.
+    -- Gated by _vistaPresenceMigrated so this never fires more than once regardless of DB
+    -- state. Uses migratedToProfile to detect when vista is already the new minimap module,
+    -- preventing the migration from resetting a user's enabled minimap to disabled.
+    if not db._vistaPresenceMigrated then
+        db._vistaPresenceMigrated = true
+        if db.modules.vista and not db.modules.presence then
+            if db.modules.vista.migratedToProfile then
+                -- vista already ran as the new minimap module; preserve its state.
+                db.modules.presence = { enabled = false }
+            else
+                -- vista was the old social/Presence module. Move to presence, reset vista.
+                db.modules.presence = { enabled = (db.modules.vista.enabled ~= false) }
+                db.modules.vista = { enabled = false }
+            end
+        end
     end
     -- Ensure vista exists for existing installs (default enabled)
     if not db.modules.vista then


### PR DESCRIPTION
# Intent
Fixes Vista (minimap) module disabling itself after each login/reload for affected users.

## Reviewer Notes
Users were reporting that the Vista minimap module would show as disabled in the options after each login or `/reload`, requiring them to re-enable it repeatedly. The bug was in the startup migration that renames the old `vista` DB key (which used to represent the social/Presence module) to the new `presence` key.

The migration had no one-shot guard — it was gated only on `db.modules.presence` being absent. In certain scenarios (new characters, fresh profiles, early-load timing), this condition could be true again after it had already run, causing the migration to reset `db.modules.vista = { enabled = false }` and wipe the `migratedToProfile` flag. Once that flag was gone, Vista's own `OnInit` migration would re-run on subsequent loads, further compounding the state corruption. The worst-case path: the migration fires during the early-load window → the early-load profile is seeded with `vista.enabled = false` → any new character or profile copies that false state → Vista stays disabled on every reload.

## Developer Notes
Two issues combined to produce the bug:

1. **No idempotency guard.** The old migration block was gated solely on `not db.modules.presence`. Any gap in that key's presence in `HorizonDB` (new characters seeded during the early-load profile window, etc.) would re-fire the block, replacing `db.modules.vista` with a fresh `{ enabled = false }` table.

2. **`migratedToProfile` silently wiped.** The migration always replaced `db.modules.vista` with a brand-new table, discarding the `migratedToProfile` flag set by `VistaModule.OnInit`. On the next load, `OnInit` would see `migratedToProfile = nil` and re-run its own settings migration, reading `src.enabled` from the now-false `db.modules.vista`.

**Fix (`HorizonSuite.lua` — `EnsureModulesDB`):**
- Added `db._vistaPresenceMigrated` one-shot flag: the entire migration block is skipped on every load after it first runs, regardless of subsequent DB state changes.
- Added `migratedToProfile` check inside the guard: if Vista's `OnInit` has previously stamped `db.modules.vista.migratedToProfile = true`, the module is already the new minimap — so we create `presence` as disabled but **leave `db.modules.vista` untouched**, preserving the user's enabled state. Only when `migratedToProfile` is nil (genuine old Presence-module data) do we reset vista to `{ enabled = false }`.

## Reviewer Checklist
- [ ] Enable Vista, `/reload` multiple times — Vista should remain enabled across all reloads
- [ ] On a character that has never used Vista, enable it and verify it persists after `/reload`
- [ ] Verify the Presence module still initialises correctly for users who had the old social module
- [ ] Confirm no lua errors on load