### PR TITLE
fix(essence): resolve LSM font names in GetFontPath and guard Refresh against nil nameText

### DIFF
--- a/HorizonSuite.lua
+++ b/HorizonSuite.lua
@@ -144,10 +144,22 @@ function addon:EnsureModulesDB()
         db.modules.vista = { enabled = false }
         db.modules.essence = { enabled = false }
     end
-    -- Migrate old Vista (Presence) module key to Presence; repurpose vista for minimap
-    if db.modules.vista and not db.modules.presence then
-        db.modules.presence = { enabled = (db.modules.vista.enabled ~= false) }
-        db.modules.vista = { enabled = false }
+    -- One-shot: old "vista" key was the social/Presence module; new "vista" = minimap.
+    -- Gated by _vistaPresenceMigrated so this never fires more than once regardless of DB
+    -- state. Uses migratedToProfile to detect when vista is already the new minimap module,
+    -- preventing the migration from resetting a user's enabled minimap to disabled.
+    if not db._vistaPresenceMigrated then
+        db._vistaPresenceMigrated = true
+        if db.modules.vista and not db.modules.presence then
+            if db.modules.vista.migratedToProfile then
+                -- vista already ran as the new minimap module; preserve its state.
+                db.modules.presence = { enabled = false }
+            else
+                -- vista was the old social/Presence module. Move to presence, reset vista.
+                db.modules.presence = { enabled = (db.modules.vista.enabled ~= false) }
+                db.modules.vista = { enabled = false }
+            end
+        end
     end
     -- Ensure vista exists for existing installs (default enabled)
     if not db.modules.vista then

--- a/modules/Essence/EssenceCore.lua
+++ b/modules/Essence/EssenceCore.lua
@@ -98,10 +98,14 @@ local function SetDB(k, v)
 end
 
 local function GetFontPath()
-    if addon.GetDB then
-        return addon.GetDB("fontPath", addon.FONT_PATH or "Fonts\\FRIZQT__.TTF")
+    local raw = addon.GetDB
+        and addon.GetDB("fontPath", addon.FONT_PATH or "Fonts\\FRIZQT__.TTF")
+        or  (addon.FONT_PATH or "Fonts\\FRIZQT__.TTF")
+    if addon.ResolveFontPath then
+        local resolved = addon.ResolveFontPath(raw)
+        if resolved and resolved ~= "" then return resolved end
     end
-    return addon.FONT_PATH or "Fonts\\FRIZQT__.TTF"
+    return raw
 end
 
 local function GetItemQualityColor(quality)
@@ -412,6 +416,7 @@ end
 
 function Essence.Refresh()
     if not frame or not frame:IsShown() then return end
+    if not nameText then return end
 
     local fp = GetFontPath()
 


### PR DESCRIPTION
# Intent
Fixes two unrelated bugs bundled into one PR after the Vista fix was included in this branch.

## Reviewer Notes

**Fix 1 — Vista (minimap) module disabling itself on every login/reload**
Users with older installs were seeing the Vista minimap module show as disabled after each login or `/reload`. The startup migration that renames the old `vista` DB key (which used to represent the social/Presence module) to `presence` had no one-shot guard — it was gated only on `db.modules.presence` being absent. Under certain conditions (new characters, the early-load profile window, fresh profile creation) that condition could be true again after a previous run, causing the migration to reset `db.modules.vista = { enabled = false }` and wipe the `migratedToProfile` flag, permanently disabling the minimap for those users.

**Fix 2 — Essence errors with LibSharedMedia fonts**
Users with a LibSharedMedia font set as their global font (e.g. "Avantgarde (Demi)") saw two errors from Essence: a `SetFont()` invalid asset error logged hundreds of times, and a crash inside `Essence.Refresh()` when opening the Character frame. Both stem from Essence's local `GetFontPath()` returning the raw display name instead of a resolved file path.

## Developer Notes

**Vista — `HorizonSuite.lua` (`EnsureModulesDB`)**
- Added `db._vistaPresenceMigrated` one-shot flag: the migration block is skipped on every load after the first run, regardless of subsequent DB state.
- Added `migratedToProfile` check: if `db.modules.vista.migratedToProfile` is set, Vista has already initialised as the new minimap module — the migration preserves its enabled state and only creates `presence` as disabled. Without this check, the migration would reset a user's enabled minimap to `{ enabled = false }`.

**Essence — `EssenceCore.lua`**
- `GetFontPath()` now pipes the raw DB value through `addon.ResolveFontPath()`, matching the pattern used by every other module (PresenceCore, VistaCore, Config). This calls `LibSharedMedia:Fetch()` to turn display names into real file paths, preventing the `SetFont()` error entirely and allowing `BuildFrame()` to complete so all widget upvalues are assigned.
- `Essence.Refresh()` early-returns if `nameText` is nil. Defense-in-depth: `Essence._initialized` is set before `BuildFrame()` runs, so if `BuildFrame()` ever aborts mid-way, any later `Init()` call takes the early-return path and can install the CharacterFrame hook — leaving `nameText` nil when `Refresh()` fires. The guard silently no-ops in that impossible-under-normal-conditions state.

## Reviewer Checklist
- [x] Enable Vista, `/reload` multiple times — Vista should remain enabled
- [x] On a character that has never used Vista, enable it and confirm it persists after `/reload`
- [x] Confirm Presence module still initialises correctly
- [x] Set global font to a LibSharedMedia font, reload — no `SetFont` errors from Essence
- [x] Open the Character frame — Essence panel shows correctly with no Lua errors
- [x] Test with default (no LSM) font — confirm no regression in either module
- [x] Confirm no Lua errors on clean load