### PR TITLE
fix(taint): defer Hide() in Blizzard frame suppression to break CooldownViewer taint chain

### DIFF
--- a/modules/Focus/FocusBlizzard.lua
+++ b/modules/Focus/FocusBlizzard.lua
@@ -16,7 +16,13 @@ local WQT_ADDON_ALREADY_LOADED_DELAY = 1
 local hiddenParent = CreateFrame("Frame")
 hiddenParent:Hide()
 
+-- Tracks which frames are currently kill-suppressed; checked by persistent HookScript hooks.
+local killedFrames = {}
+
 -- Hides a frame by reparenting to hidden parent and blocking OnShow.
+-- Uses HookScript (not SetScript) to avoid replacing Blizzard's handler, and defers
+-- self:Hide() via C_Timer.After(0) to break the Show call chain, preventing execution
+-- taint from propagating into EditMode-managed frames like Blizzard_CooldownViewer.
 local function KillBlizzardFrame(frame)
     if not frame then return end
     -- pcall: frame methods can throw on protected or invalid frames.
@@ -25,8 +31,19 @@ local function KillBlizzardFrame(frame)
         frame:SetParent(hiddenParent)
         frame:Hide()
         frame:SetAlpha(0)
-        frame:SetScript("OnShow", function(self) self:Hide() end)
     end)
+    killedFrames[frame] = true
+    if not frame._focusKillHooked then
+        frame._focusKillHooked = true
+        pcall(function()
+            -- HookScript persists; killedFrames[self] gates whether to act.
+            frame:HookScript("OnShow", function(self)
+                if killedFrames[self] then
+                    C_Timer.After(0, function() self:Hide() end)
+                end
+            end)
+        end)
+    end
 end
 
 local trackerSuppressed = false
@@ -91,9 +108,10 @@ end
 
 --- Restore the default objective tracker and WQT panel when Focus is disabled.
 local function RestoreTracker()
-    -- WQT OnShow hook is left in place: HookScript can't be removed and it no-ops when disabled.
+    -- HookScript hooks can't be removed; killedFrames[frame] = nil makes them no-op instead.
     if not trackerSuppressed then return end
     if ObjectiveTrackerFrame then
+        killedFrames[ObjectiveTrackerFrame] = nil
         -- pcall: frame methods can throw on protected or invalid frames.
         pcall(function()
             ObjectiveTrackerFrame:SetParent(UIParent)
@@ -101,19 +119,18 @@ local function RestoreTracker()
             ObjectiveTrackerFrame:SetPoint("TOPRIGHT", MinimapCluster or UIParent, "BOTTOMRIGHT", 0, 0)
             ObjectiveTrackerFrame:SetAlpha(1)
             ObjectiveTrackerFrame:Show()
-            ObjectiveTrackerFrame:SetScript("OnShow", nil)
         end)
         trackerSuppressed = false
     end
     if wqtSuppressed then
         local wqtFrame = _G.WorldQuestTrackerScreenPanel
         if wqtFrame then
+            killedFrames[wqtFrame] = nil
             -- pcall: frame methods can throw on protected or invalid frames.
             pcall(function()
                 wqtFrame:SetParent(UIParent)
                 wqtFrame:SetAlpha(1)
                 wqtFrame:Show()
-                wqtFrame:SetScript("OnShow", nil)
             end)
             wqtSuppressed = false
         end

--- a/modules/Presence/PresenceBlizzard.lua
+++ b/modules/Presence/PresenceBlizzard.lua
@@ -47,7 +47,15 @@ local function KillBlizzardFrame(frame)
     end)
     if not ok1 and addon.HSPrint then addon.HSPrint("Presence KillBlizzardFrame hide failed: " .. tostring(err1)) end
     local ok2, err2 = pcall(function()
-        frame:SetScript("OnShow", function(self) self:Hide() end)
+        -- HookScript instead of SetScript: adds a hook without replacing Blizzard's handler.
+        -- C_Timer.After(0) defers the Hide out of the Show call chain to prevent execution
+        -- taint from propagating into EditMode-managed frames like Blizzard_CooldownViewer.
+        -- suppressedFrames[self] guard lets RestoreBlizzardFrame re-enable Show.
+        frame:HookScript("OnShow", function(self)
+            if suppressedFrames[self] then
+                C_Timer.After(0, function() self:Hide() end)
+            end
+        end)
     end)
     if not ok2 and addon.HSPrint then addon.HSPrint("Presence KillBlizzardFrame OnShow hook failed: " .. tostring(err2)) end
     if not hookedShowFrames[frame] then
@@ -55,7 +63,7 @@ local function KillBlizzardFrame(frame)
         pcall(function()
             hooksecurefunc(frame, "Show", function(self)
                 if suppressedFrames[self] then
-                    self:Hide()
+                    C_Timer.After(0, function() self:Hide() end)
                 end
             end)
         end)
@@ -66,7 +74,6 @@ end
 local function RestoreBlizzardFrame(frame)
     if not frame or not suppressedFrames[frame] then return end
     local ok, err = pcall(function()
-        frame:SetScript("OnShow", nil)
         frame:SetParent(originalParents[frame] or UIParent)
         frame:SetAlpha(originalAlphas[frame] or 1)
         local pt = originalPoints[frame]


### PR DESCRIPTION
## Summary

- `SetScript("OnShow")` in both `KillBlizzardFrame` functions was **replacing** Blizzard's OnShow handler on EditMode-managed frames (`ObjectiveTrackerFrame`, `BossBanner`, `ObjectiveTrackerBonusBannerFrame`, etc.) with HorizonSuite's Lua function
- When Blizzard or EditMode triggered `Show()` on those frames, HorizonSuite's code was in the C call stack — its immediate `self:Hide()` cascaded into EditMode layout updates that refreshed `Blizzard_CooldownViewer` and `Blizzard_DamageMeter` while execution was tagged as **"tainted by HorizonSuite"**
- Protected C API reads (`GetSpellCharges`, `GetTotemInfo`, `C_UnitAuras.GetAuraDataByIndex`, `GetSpellChargeInfo`) returned "secret" values in the tainted context, producing the 300+ taint errors users reported

## Changes

- **`FocusBlizzard.lua`** — `KillBlizzardFrame`: `SetScript` → `HookScript` with deferred `C_Timer.After(0, self:Hide)`, gated by a `killedFrames` table so the persistent hook no-ops after `RestoreTracker`; removed the now-unnecessary `SetScript("OnShow", nil)` from `RestoreTracker`
- **`PresenceBlizzard.lua`** — `KillBlizzardFrame`: same `SetScript` → `HookScript` + deferred hide with `suppressedFrames[self]` guard; `hooksecurefunc` hook also now defers its `Hide()`; removed `SetScript("OnShow", nil)` from `RestoreBlizzardFrame`

## Test plan

- [ ] Load with Focus module enabled — `ObjectiveTrackerFrame` should be hidden, no taint errors in `Blizzard_CooldownViewer` or `Blizzard_DamageMeter`
- [ ] Load with Presence module enabled — zone/boss/banner frames suppressed, no taint errors
- [ ] Disable Focus mid-session — `ObjectiveTrackerFrame` should reappear correctly
- [ ] Disable Presence mid-session — suppressed frames should restore
- [ ] Enter and leave combat — verify DamageMeter taint errors no longer appear
- [ ] UNIT_AURA stress test (target/untarget, cast spells) — verify CooldownViewer taint errors gone

🤖 Generated with [Claude Code](https://claude.com/claude-code)