### PR TITLE
FIX THE DAMN IMPROPER LOCALE CALLS

### DIFF
--- a/Utilities.lua
+++ b/Utilities.lua
@@ -4,7 +4,7 @@
 ]]
 
 local addon = _G.HorizonSuite
-
+local L = addon.L
 -- ============================================================================
 -- DESIGN TOKENS
 -- ============================================================================
@@ -1166,7 +1166,7 @@ local function IsPreyQuest(questID)
     if not questID or not C_QuestLog or not C_QuestLog.GetTitleForQuestID then return false end
     local ok, title = pcall(C_QuestLog.GetTitleForQuestID, questID)
     if not ok or not title then return false end
-    local preyLabel = (addon.L and addon.L["UI_PREY"])
+    local preyLabel = L["UI_PREY"]
     return title:find(preyLabel, 1, true) ~= nil
 end
 

--- a/core/Config.lua
+++ b/core/Config.lua
@@ -5,7 +5,7 @@
 
 local addon = _G.HorizonSuite
 if not addon then return end
-
+local L = addon.L
 -- ============================================================================
 -- CONFIGURATION (constants, colors, fonts, labels, group order)
 -- ============================================================================
@@ -647,25 +647,25 @@ addon.BrandDisplay = {
     productName = "Horizon Suite",
     horizonInsight = "Horizon Insight",
     module = {
-        axis = addon.L["NAME_ADDON_DASHBOARD"],
-        focus = addon.L["NAME_ADDON_OBJECTIVES"],
-        presence = addon.L["NAME_ADDON_TOASTS"],
-        vista = addon.L["NAME_ADDON_MINIMAP"],
-        insight = addon.L["NAME_ADDON_TOOLTIPS"],
-        augment = addon.L["NAME_ADDON_LOOT"],
-        essence = addon.L["NAME_ADDON_CHARACTER"],
-        meridian = addon.L["NAME_ADDON_C-----S"],
+        axis = L["NAME_ADDON_DASHBOARD"],
+        focus = L["NAME_ADDON_OBJECTIVES"],
+        presence = L["NAME_ADDON_TOASTS"],
+        vista = L["NAME_ADDON_MINIMAP"],
+        insight = L["NAME_ADDON_TOOLTIPS"],
+        augment = L["NAME_ADDON_LOOT"],
+        essence = L["NAME_ADDON_CHARACTER"],
+        meridian = L["NAME_ADDON_C-----S"],
     },
     -- Human-readable descriptions shown in "Subtitle" and "simple" name modes.
     simple = {
-        axis     = addon.L["AXIS_MODULE_NAME_SIMPLE_DASHBOARD"],
-        focus    = addon.L["AXIS_MODULE_NAME_SIMPLE_OBJECTIVES"],
-        presence = addon.L["AXIS_MODULE_NAME_SIMPLE_NOTIFICATIONS"],
-        vista    = addon.L["AXIS_MODULE_NAME_SIMPLE_MINIMAP"],
-        insight  = addon.L["AXIS_MODULE_NAME_SIMPLE_TOOLTIPS"],
-        augment  = addon.L["AXIS_MODULE_NAME_SIMPLE_LOOT"],
-        essence  = addon.L["AXIS_MODULE_NAME_SIMPLE_CHARACTER"],
-        meridian = addon.L["AXIS_MODULE_NAME_SIMPLE_C-----S"],
+        axis     = L["AXIS_MODULE_NAME_SIMPLE_DASHBOARD"],
+        focus    = L["AXIS_MODULE_NAME_SIMPLE_OBJECTIVES"],
+        presence = L["AXIS_MODULE_NAME_SIMPLE_NOTIFICATIONS"],
+        vista    = L["AXIS_MODULE_NAME_SIMPLE_MINIMAP"],
+        insight  = L["AXIS_MODULE_NAME_SIMPLE_TOOLTIPS"],
+        augment  = L["AXIS_MODULE_NAME_SIMPLE_LOOT"],
+        essence  = L["AXIS_MODULE_NAME_SIMPLE_CHARACTER"],
+        meridian = L["AXIS_MODULE_NAME_SIMPLE_C-----S"],
     },
 }
 

--- a/core/Core.lua
+++ b/core/Core.lua
@@ -5,7 +5,7 @@
 ]]
 
 local addon = _G.HorizonSuite
-
+local L = addon.L
 -- ---------------------------------------------------------------------------
 -- Forward declarations (Lua local scoping)
 -- ---------------------------------------------------------------------------
@@ -1397,7 +1397,7 @@ local headerShadow = HS:CreateFontString(nil, "BORDER")
 headerShadow:SetFontObject(addon.HeaderFont)
 headerShadow:SetTextColor(0, 0, 0, addon.SHADOW_A)
 headerShadow:SetJustifyH("LEFT")
-headerShadow:SetText(addon.L["PRESENCE_OBJECTIVES"])
+headerShadow:SetText(L["PRESENCE_OBJECTIVES"])
 
 local headerText = HS:CreateFontString(nil, "OVERLAY")
 headerText:SetFontObject(addon.HeaderFont)
@@ -1407,7 +1407,7 @@ do
 end
 headerText:SetJustifyH("LEFT")
 headerText:SetPoint("TOPLEFT", HS, "TOPLEFT", addon.PADDING, -addon.PADDING)
-headerText:SetText(addon.L["PRESENCE_OBJECTIVES"])
+headerText:SetText(L["PRESENCE_OBJECTIVES"])
 headerShadow:SetPoint("CENTER", headerText, "CENTER", addon.SHADOW_OX, addon.SHADOW_OY)
 
 local countText = HS:CreateFontString(nil, "OVERLAY")
@@ -1443,7 +1443,7 @@ do
     optionsLabel:SetTextColor(ch[1], ch[2], ch[3], 1)
 end
 optionsLabel:SetJustifyH("RIGHT")
-optionsLabel:SetText(addon.L["PRESENCE_OPTIONS"])
+optionsLabel:SetText(L["PRESENCE_OPTIONS"])
 optionsBtn:SetSize(math.max(optionsLabel:GetStringWidth() + 4, 44), 20)
 optionsBtn:SetPoint("RIGHT", chevron, "LEFT", -6, 0)
 optionsLabel:SetPoint("RIGHT", optionsBtn, "RIGHT", -2, 0)
@@ -1452,7 +1452,7 @@ local optionsShadow = optionsBtn:CreateFontString(nil, "BORDER")
 optionsShadow:SetFontObject(addon.OptionsFont)
 optionsShadow:SetTextColor(0, 0, 0, addon.SHADOW_A)
 optionsShadow:SetJustifyH("RIGHT")
-optionsShadow:SetText(addon.L["PRESENCE_OPTIONS"])
+optionsShadow:SetText(L["PRESENCE_OPTIONS"])
 optionsShadow:SetPoint("CENTER", optionsLabel, "CENTER", addon.SHADOW_OX, addon.SHADOW_OY)
 
 -- Delayed tooltip hide: cancels if mouse re-enters within 0.15s (stops flicker when cursor briefly leaves)
@@ -1475,7 +1475,7 @@ optionsBtn:SetScript("OnEnter", function(self)
     end
     if GameTooltip then
         GameTooltip:SetOwner(self, "ANCHOR_LEFT")
-        GameTooltip:SetText(addon.L["PRESENCE_OPTIONS"], nil, nil, nil, nil, true)
+        GameTooltip:SetText(L["PRESENCE_OPTIONS"], nil, nil, nil, nil, true)
         GameTooltip:Show()
     end
 end)
@@ -1878,7 +1878,7 @@ resizeHandle:EnableMouse(true)
 resizeHandle:SetScript("OnEnter", function(self)
     if GameTooltip then
         GameTooltip:SetOwner(self, "ANCHOR_TOPLEFT")
-        GameTooltip:SetText(addon.L["FOCUS_DRAG_RESIZE"], nil, nil, nil, nil, true)
+        GameTooltip:SetText(L["FOCUS_DRAG_RESIZE"], nil, nil, nil, nil, true)
         GameTooltip:Show()
     end
 end)

--- a/core/NewSettings.lua
+++ b/core/NewSettings.lua
@@ -9,7 +9,7 @@
 ]]
 
 local addon = _G.HorizonSuite
-
+local L = addon.L
 local function EnsureRootDB()
     local db = _G[addon.DATABASE]
     if not db then
@@ -69,7 +69,7 @@ function addon.NewSettings_ResolveDisplayName(opt, optId)
         return raw
     end
     if opt.isNew and addon.NewSettings_IsUnread(optId, opt.isNew) then
-        local suffix = (addon.L and addon.L["DASH_WHATS_NEW_UNREAD_SUFFIX"])
+        local suffix = L["DASH_WHATS_NEW_UNREAD_SUFFIX"]
         -- Matches the Patch Notes sidebar green (WHATSNEW_GREEN in core/PatchNotes.lua:105).
         return base .. "|cff52e680" .. suffix .. "|r"
     end

--- a/core/UrlCopyDialog.lua
+++ b/core/UrlCopyDialog.lua
@@ -200,7 +200,7 @@ function addon.ShowURLCopyBox(url, accentSubtitle)
         f.accentStrip:SetColorTexture(ar, ag, ab, 1)
     end
     if f.subtitleLbl then
-        f.subtitleLbl:SetText(accentSubtitle or (L["FOCUS_COPY_LINK"]))
+        f.subtitleLbl:SetText(accentSubtitle or L["FOCUS_COPY_LINK"])
         f.subtitleLbl:SetTextColor(ar, ag, ab)
     end
     f.editBox:SetText(url)

--- a/core/UrlCopyDialog.lua
+++ b/core/UrlCopyDialog.lua
@@ -7,7 +7,7 @@
 
 local addon = _G.HorizonSuite
 if not addon then return end
-
+local L = addon.L
 -- ==========================================================================
 -- URL COPY BOX (Horizon-themed)
 -- ==========================================================================
@@ -90,7 +90,7 @@ local function BuildURLCopyFrame()
     local subtitleLbl = dragZone:CreateFontString(nil, "OVERLAY")
     subtitleLbl:SetFont(URL_COPY_F_BODY, 10, "")
     subtitleLbl:SetPoint("TOPLEFT", suiteLbl, "BOTTOMLEFT", 0, -3)
-    subtitleLbl:SetText((addon.L and addon.L["FOCUS_COPY_LINK"]))
+    subtitleLbl:SetText(L["FOCUS_COPY_LINK"])
     subtitleLbl:SetTextColor(ar, ag, ab)
     f.subtitleLbl = subtitleLbl
 
@@ -127,7 +127,7 @@ local function BuildURLCopyFrame()
     hintLbl:SetPoint("RIGHT", f, "RIGHT", -URL_COPY_PAD, 0)
     hintLbl:SetWordWrap(true)
     hintLbl:SetNonSpaceWrap(false)
-    hintLbl:SetText((addon.L and addon.L["FOCUS_COPY_URL_BELOW_CTRL_C_PASTE"]))
+    hintLbl:SetText(L["FOCUS_COPY_URL_BELOW_CTRL_C_PASTE"])
     hintLbl:SetTextColor(0.42, 0.42, 0.50)
 
     local eb = CreateFrame("EditBox", nil, f)
@@ -200,7 +200,7 @@ function addon.ShowURLCopyBox(url, accentSubtitle)
         f.accentStrip:SetColorTexture(ar, ag, ab, 1)
     end
     if f.subtitleLbl then
-        f.subtitleLbl:SetText(accentSubtitle or ((addon.L and addon.L["FOCUS_COPY_LINK"])))
+        f.subtitleLbl:SetText(accentSubtitle or (L["FOCUS_COPY_LINK"]))
         f.subtitleLbl:SetTextColor(ar, ag, ab)
     end
     f.editBox:SetText(url)

--- a/modules/Augment/AugmentCore.lua
+++ b/modules/Augment/AugmentCore.lua
@@ -5,7 +5,7 @@
 
 local addon = _G.HorizonSuite
 if not addon or not addon.Augment then return end
-
+local L = addon.L
 local Augment = addon.Augment
 local state = addon.augment
 
@@ -634,7 +634,7 @@ local function BuildMergedText(data, effectiveKey, totalCount)
         if totalCount == 1 then
             return data.baseName or data.text
         end
-        return (addon.L and addon.L["AUGMENT_JUNK_LABEL"] or "Junk") .. " x" .. totalCount
+        return L["AUGMENT_JUNK_LABEL"] .. " x" .. totalCount
     end
     if data.kind == "item" then
         return totalCount > 1 and (data.baseName .. " x" .. totalCount) or data.baseName

--- a/modules/Focus/FocusAggregator.lua
+++ b/modules/Focus/FocusAggregator.lua
@@ -5,7 +5,7 @@
 ]]
 
 local addon = _G.HorizonSuite
-
+local L = addon.L
 local DEFAULT_SORT_MODE = "questType"
 local CATEGORY_SORT_FALLBACK = 99
 local DEFAULT_GROUP = "DEFAULT"
@@ -504,7 +504,7 @@ local function ReadTrackedQuests()
         local isSuper = (questID == superTracked)
         local zoneName = addon.GetQuestZoneName(questID)
         if category == "PREY" and (addon.IsQuestWorldQuest and addon.IsQuestWorldQuest(questID)) and (not zoneName or zoneName == "") then
-            zoneName = (addon.L and addon.L["FOCUS_ACTIVITY"])
+            zoneName = L["FOCUS_ACTIVITY"]
         end
         local isNearby = (nearbySet[questID] or false) and (not filterByZone or questMapMatchesPlayer(questID))
         local isDungeonQuest = opts.isDungeonQuest or (addon.IsInPartyDungeon and addon.IsInPartyDungeon() and isNearby)

--- a/modules/Focus/FocusCategories.lua
+++ b/modules/Focus/FocusCategories.lua
@@ -5,7 +5,7 @@
 ]]
 
 local addon = _G.HorizonSuite
-
+local L = addon.L
 local function GetQuestCategory(questID)
     if not questID or questID <= 0 then return "DEFAULT" end
     if C_QuestLog and C_QuestLog.IsComplete and C_QuestLog.IsComplete(questID) then
@@ -103,7 +103,7 @@ local function GetQuestZoneName(questID)
      -- For non-world quests: prefer quest log header (waypoint often = current zone).
      -- Skip non-geographic headers (e.g. "Prey") so the waypoint fallback below
      -- can resolve the actual zone name.
-     local preyLabel = (addon.L and addon.L["UI_PREY"])
+     local preyLabel = L["UI_PREY"]
      if C_QuestLog.GetLogIndexForQuestID then
          local logIndex = C_QuestLog.GetLogIndexForQuestID(questID)
          if logIndex then

--- a/modules/Focus/FocusEntryPool.lua
+++ b/modules/Focus/FocusEntryPool.lua
@@ -4,8 +4,9 @@
 ]]
 
 local addon = _G.HorizonSuite
+local L = addon.L
 local function T(key)
-    return (addon.L and addon.L[key]) or key
+    return (L[key]) or key
 end
 
 -- ============================================================================
@@ -232,7 +233,6 @@ local function CreateQuestEntry(parent, index)
         self:SetAlpha(1)
         self.icon:SetAlpha(1)
         if not addon.GetDB("focusShowTooltipOnHover", false) then return end
-        local L = addon.L
         addon.focus.AnchorTooltip(GameTooltip, self)
         GameTooltip:AddLine((L and L["FOCUS_AH_SEARCH_TITLE"]), 1, 1, 1)
         GameTooltip:AddLine((L and L["FOCUS_AH_SEARCH_TOOLTIP"]), 0.7, 0.7, 0.7, true)

--- a/modules/Focus/FocusEntryRenderer.lua
+++ b/modules/Focus/FocusEntryRenderer.lua
@@ -362,14 +362,14 @@ end
 --- True if text contains the localized "abundance held" phrase (case-insensitive). Used for Abundance scenario.
 local function isAbundanceHeld(text)
     if not text or type(text) ~= "string" then return false end
-    local phrase = (addon.L and addon.L["UI_ABUNDANCE_HELD"])
+    local phrase = L["UI_ABUNDANCE_HELD"]
     return text:lower():find(phrase:lower(), 1, true) ~= nil
 end
 
 --- True if text contains the localized "Abundance Bag" phrase (case-insensitive). Hide from inline; bar shows abundance held.
 local function isAbundanceBag(text)
     if not text or type(text) ~= "string" then return false end
-    local phrase = (addon.L and addon.L["UI_ABUNDANCE_BAG"])
+    local phrase = L["UI_ABUNDANCE_BAG"]
     return text:lower():find(phrase:lower(), 1, true) ~= nil
 end
 
@@ -1027,7 +1027,6 @@ local function ApplyObjectives(entry, questData, textWidth, prevAnchor, totalH, 
     if questData.isComplete and shownObjs == 0 then
         local obj = entry.objectives[1]
         local isAutoComplete = questData.isAutoComplete and true or false
-        local L = addon.L or {}
         local readyToTurnIn = StripLeadingDashes(L["UI_READY_TO_TURN_IN"])
         local firstLineText = isAutoComplete
             and (_G.QUEST_WATCH_QUEST_COMPLETE or "Quest Complete")
@@ -1454,17 +1453,17 @@ local function ApplyScenarioOrWQTimerBar(entry, questData, textWidth, prevAnchor
             if firstPercent ~= nil then
                 barLabel = barLabel .. " (" .. tostring(firstPercent) .. "%)"
             end
-            if isAbundanceBagSel then barLabel = (addon.L and addon.L["UI_ABUNDANCE_BAG"]) .. ": " .. barLabel end
-            if isAbundanceHeldSel then barLabel = barLabel .. " " .. (addon.L and addon.L["UI_ABUNDANCE_HELD"]) end
+            if isAbundanceBagSel then barLabel = L["UI_ABUNDANCE_BAG"] .. ": " .. barLabel end
+            if isAbundanceHeldSel then barLabel = barLabel .. " " .. L["UI_ABUNDANCE_HELD"] end
         elseif useXyFormat then
             local nf = math.min(selectedObj.numFulfilled, selectedObj.numRequired)
             barLabel = FormatProgressPair(nf, selectedObj.numRequired)
-            if isAbundanceBagSel then barLabel = (addon.L and addon.L["UI_ABUNDANCE_BAG"]) .. ": " .. barLabel end
-            if isAbundanceHeldSel then barLabel = barLabel .. " " .. (addon.L and addon.L["UI_ABUNDANCE_HELD"]) end
+            if isAbundanceBagSel then barLabel = L["UI_ABUNDANCE_BAG"] .. ": " .. barLabel end
+            if isAbundanceHeldSel then barLabel = barLabel .. " " .. L["UI_ABUNDANCE_HELD"] end
         else
             barLabel = firstPercent ~= nil and (tostring(firstPercent) .. "%") or ""
-            if isAbundanceBagSel then barLabel = (addon.L and addon.L["UI_ABUNDANCE_BAG"]) .. ": " .. barLabel end
-            if isAbundanceHeldSel then barLabel = barLabel .. " " .. (addon.L and addon.L["UI_ABUNDANCE_HELD"]) end
+            if isAbundanceBagSel then barLabel = L["UI_ABUNDANCE_BAG"] .. ": " .. barLabel end
+            if isAbundanceHeldSel then barLabel = barLabel .. " " .. L["UI_ABUNDANCE_HELD"] end
         end
         entry.wqProgressText:SetText(barLabel)
         entry.wqProgressText:ClearAllPoints()
@@ -2121,7 +2120,7 @@ local function PopulateEntry(entry, questData, groupKey)
     elseif shouldShowScenarioStage then
         local stageLabel = questData.stageName
         if questData.stageIndex and questData.stageIndex > 0 then
-            local stageFmt = (addon.L and addon.L["UI_STAGE_X_X"])
+            local stageFmt = L["UI_STAGE_X_X"]
             stageLabel = stageFmt:format(questData.stageIndex, questData.stageName)
         end
         addon.SetTextWithShadow(entry.zoneText, entry.zoneShadow, stageLabel)

--- a/modules/Focus/FocusInteractions.lua
+++ b/modules/Focus/FocusInteractions.lua
@@ -4,7 +4,7 @@
 ]]
 
 local addon = _G.HorizonSuite
-
+local L = addon.L
 -- INTERACTIONS
 -- ============================================================================
 
@@ -89,10 +89,10 @@ local function AppendWoWheadLineToTooltip(entry)
     if not addon.GetDB("focusShowWoWheadLink", true) then return end
     local url = addon.GetWoWheadURL(entry)
     if not url then return end
-    local text = (addon.L and addon.L["FOCUS_VIEW_WOWHEAD"])
+    local text = L["FOCUS_VIEW_WOWHEAD"]
     local hint = addon.focus.GetWoWheadClickBindingHint and addon.focus.GetWoWheadClickBindingHint() or ""
     if hint == "" then
-        hint = (addon.L and addon.L["FOCUS_WOWHEAD_TOOLTIP_HINT_FALLBACK"])
+        hint = L["FOCUS_WOWHEAD_TOOLTIP_HINT_FALLBACK"]
     end
     local line = ("|cff00b4ff|Hurl:%s|h[%s]|h|r |cff888888(%s)|r"):format(url, text, hint)
     GameTooltip:AddLine(" ")
@@ -159,7 +159,6 @@ end
 --- @param anchor frame|nil Frame to anchor menu to; if nil, uses cursor
 local function ShowQuestContextMenu(questID, questName, anchor)
     if not questID then return end
-    local L = addon.L or {}
     local menuList = {}
     if C_QuestLog and C_QuestLog.IsPushableQuest and C_QuestLog.IsPushableQuest(questID) then
         local inGroup = (GetNumGroupMembers and GetNumGroupMembers() > 1) or (UnitInParty and UnitInParty("player"))
@@ -431,7 +430,6 @@ end
 --- @param anchor Frame|nil Pool entry frame (for cached item link when opening dressing room).
 local function ShowAppearanceContextMenu(appearanceID, anchor)
     if not appearanceID then return end
-    local L = addon.L or {}
     local menuList = {
         {
             text = L["FOCUS_SHOW_APPEARANCE_WARDROBE"],
@@ -794,7 +792,6 @@ local function RunEasyMenuTracked(menuList, frameName, anchor)
 end
 
 local function ShowTrackedAchievementContextMenu(entry, anchor)
-    local L = addon.L or {}
     local aid = entry.achievementID
     if not aid then return end
     RunEasyMenuTracked({
@@ -812,7 +809,6 @@ local function ShowTrackedAchievementContextMenu(entry, anchor)
 end
 
 local function ShowTrackedEndeavorContextMenu(entry, anchor)
-    local L = addon.L or {}
     if not entry.endeavorID then return end
     RunEasyMenuTracked({
         {
@@ -829,7 +825,6 @@ local function ShowTrackedEndeavorContextMenu(entry, anchor)
 end
 
 local function ShowTrackedRecipeContextMenu(entry, anchor)
-    local L = addon.L or {}
     if not entry.recipeID then return end
     -- Copy IDs now: pool entry may be cleared before the menu item runs.
     local recipeID = entry.recipeID
@@ -849,7 +844,6 @@ local function ShowTrackedRecipeContextMenu(entry, anchor)
 end
 
 local function ShowTrackedDecorContextMenu(entry, anchor)
-    local L = addon.L or {}
     if not entry.decorID then return end
     RunEasyMenuTracked({
         {
@@ -876,7 +870,6 @@ local function ShowTrackedDecorContextMenu(entry, anchor)
 end
 
 local function ShowTrackedAdventureGuideContextMenu(entry, anchor)
-    local L = addon.L or {}
     if not entry.adventureGuideID then return end
     RunEasyMenuTracked({
         {
@@ -893,7 +886,6 @@ local function ShowTrackedAdventureGuideContextMenu(entry, anchor)
 end
 
 local function ShowTrackedRareContextMenu(entry, anchor)
-    local L = addon.L or {}
     RunEasyMenuTracked({
         {
             text = L["FOCUS_CONTEXT_SET_RARE_WAYPOINT"],
@@ -1054,7 +1046,6 @@ local function ExecuteTrackedContentAction(action, kind, entry)
         end
     elseif action == "share" then
         local printFn = addon.HSPrint or print
-        local L = addon.L or {}
         printFn("|cffffcc00" .. (L["FOCUS_TRACKED_CONTENT_CANNOT_SHARE"]) .. "|r")
     elseif action == "preview" then
         -- Mirror native Ctrl+Click previews: decor opens the housing preview, recipes open the inspect frame.
@@ -1547,7 +1538,6 @@ QUEST_ACTIONS["openDetails"] = function(entry)
     if InCombatLockdown() then
         QueueOpenQuestDetailsAfterCombat(entry.questID)
         local printFn = addon.HSPrint or print
-        local L = addon.L or {}
         printFn("|cFF00CCFF" .. (L["FOCUS_QUEST_DETAILS_AFTER_COMBAT"]) .. "|r")
         return
     end
@@ -1602,7 +1592,6 @@ end
 
 QUEST_ACTIONS["share"] = function(entry)
     local printFn = addon.HSPrint or print
-    local L = addon.L or {}
     if C_QuestLog and C_QuestLog.IsPushableQuest and C_QuestLog.IsPushableQuest(entry.questID) then
         local inGroup = (GetNumGroupMembers and GetNumGroupMembers() > 1) or (UnitInParty and UnitInParty("player"))
         if inGroup and C_QuestLog.SetSelectedQuest and QuestLogPushQuest then
@@ -1681,7 +1670,6 @@ end
 
 APPEARANCE_ACTIONS["share"] = function(_)
     local printFn = addon.HSPrint or print
-    local L = addon.L or {}
     printFn("|cffffcc00" .. (L["FOCUS_APPEARANCE_CANNOT_SHARE"]) .. "|r")
 end
 

--- a/modules/Focus/FocusLayout.lua
+++ b/modules/Focus/FocusLayout.lua
@@ -4,7 +4,7 @@
 ]]
 
 local addon = _G.HorizonSuite
-
+local L = addon.L
 -- ============================================================================
 -- LAYOUT ENGINE
 -- ============================================================================
@@ -380,7 +380,7 @@ local function FullLayout()
         if hideOptBtn then
             addon.optionsBtn:Hide()
         else
-            addon.SetTextWithShadow(addon.optionsLabel, addon.optionsShadow, addon.L["PRESENCE_OPTIONS"])
+            addon.SetTextWithShadow(addon.optionsLabel, addon.optionsShadow, L["PRESENCE_OPTIONS"])
             addon.optionsBtn:SetWidth(math.max(addon.optionsLabel:GetStringWidth() + 4, 44))
             addon.optionsBtn:Show()
             -- Visible on hover only: use alpha so frames stay in layout and remain clickable
@@ -395,7 +395,7 @@ local function FullLayout()
         addon.chevron:SetAlpha(1)
         addon.headerText:Show()
         addon.headerShadow:Show()
-        local headerStr = addon.ApplyTextCase(addon.L["PRESENCE_OBJECTIVES"], "headerTextCase", "upper")
+        local headerStr = addon.ApplyTextCase(L["PRESENCE_OBJECTIVES"], "headerTextCase", "upper")
         addon.SetTextWithShadow(addon.headerText, addon.headerShadow, headerStr)
         if addon.GetDB("showQuestCount", true) then addon.countText:Show(); addon.countShadow:Show() else addon.countText:Hide(); addon.countShadow:Hide() end
         addon.chevron:Show()
@@ -404,7 +404,7 @@ local function FullLayout()
         else
             addon.optionsBtn:SetAlpha(1)
             addon.optionsBtn:Show()
-            addon.SetTextWithShadow(addon.optionsLabel, addon.optionsShadow, addon.L["PRESENCE_OPTIONS"])
+            addon.SetTextWithShadow(addon.optionsLabel, addon.optionsShadow, L["PRESENCE_OPTIONS"])
             addon.optionsBtn:SetWidth(math.max(addon.optionsLabel:GetStringWidth() + 4, 44))
         end
         local showDiv = addon.GetDB("showHeaderDivider", true)

--- a/modules/Focus/FocusSectionHeaders.lua
+++ b/modules/Focus/FocusSectionHeaders.lua
@@ -4,7 +4,7 @@
 ]]
 
 local addon = _G.HorizonSuite
-
+local L = addon.L
 local sectionPool = addon.sectionPool
 local scrollFrame = addon.scrollFrame
 
@@ -46,7 +46,7 @@ local function AcquireSectionHeader(groupKey, focusedGroupKey)
     until not (fadeOutKeys and s.groupKey and fadeOutKeys[s.groupKey])
     s.groupKey = groupKey
 
-    local label = addon.L[addon.SECTION_LABELS[groupKey] or groupKey]
+    local label = L[addon.SECTION_LABELS[groupKey] or groupKey]
     label = addon.ApplyTextCase(label, "sectionHeaderTextCase", "upper")
     local color = addon.GetSectionHeaderDisplayColor(groupKey, focusedGroupKey)
     addon.SetTextWithShadow(s.text, s.shadow, label)

--- a/modules/Focus/FocusUnacceptedPopup.lua
+++ b/modules/Focus/FocusUnacceptedPopup.lua
@@ -7,7 +7,7 @@
 
 local addon = _G.HorizonSuite
 if not addon then return end
-
+local L = addon.L
 local PADDING = 12
 local ROW_HEIGHT = 22
 local POPUP_WIDTH = 900
@@ -468,7 +468,7 @@ local function CreatePopupFrame()
     refreshBtn:EnableMouse(true)
     local refreshLabel = refreshBtn:CreateFontString(nil, "OVERLAY")
     refreshLabel:SetFont("Fonts\\FRIZQT__.TTF", 11, "OUTLINE")
-    refreshLabel:SetText(addon.L["PRESENCE_REFRESH"])
+    refreshLabel:SetText(L["PRESENCE_REFRESH"])
     refreshLabel:SetPoint("CENTER", refreshBtn, "CENTER", 0, 0)
     refreshBtn:SetScript("OnClick", function()
         addon.ShowUnacceptedPopup()
@@ -500,7 +500,7 @@ local function CreatePopupFrame()
     footer:SetPoint("BOTTOMRIGHT", panel, "BOTTOMRIGHT", -PADDING, PADDING)
     footer:SetJustifyH("LEFT")
     footer:SetWordWrap(true)
-    footer:SetText(addon.L["PRESENCE_BEST_EFFORT_UNACCEPTED_QUESTS_EXPO"])
+    footer:SetText(L["PRESENCE_BEST_EFFORT_UNACCEPTED_QUESTS_EXPO"])
     panel.footerText = footer
 
     popupFrame = panel
@@ -514,7 +514,7 @@ local function PopulatePopup(rows, mapID, zoneName)
     if not popupFrame or not contentFrame then return end
 
     local count = #rows
-    popupFrame.titleText:SetText((addon.L["PRESENCE_UNACCEPTED_QUESTS_X_MAP_X"]):format(zoneName, tostring(mapID), count))
+    popupFrame.titleText:SetText(L["PRESENCE_UNACCEPTED_QUESTS_X_MAP_X"]):format(zoneName, tostring(mapID), count))
 
     local contentWidth = (scrollFrame and scrollFrame:GetWidth() and scrollFrame:GetWidth() > 0)
         and scrollFrame:GetWidth()

--- a/modules/Focus/scenarios/FocusScenarioRegistry.lua
+++ b/modules/Focus/scenarios/FocusScenarioRegistry.lua
@@ -4,13 +4,13 @@
 ]]
 
 local addon = _G.HorizonSuite
-
+local L = addon.L
 local providers = {}
 local Registry = {}
 
 --- True when the current scenario is Abundance (TWW open-world scenario).
 local function IsAbundanceScenario()
-    local abundanceLabel = (addon.L and addon.L["UI_ABUNDANCE"])
+    local abundanceLabel = L["UI_ABUNDANCE"]
     local lowerLabel = abundanceLabel:lower()
     local ok, name = pcall(C_Scenario.GetInfo)
     if ok and name and type(name) == "string" and name:lower():find(lowerLabel, 1, true) then

--- a/modules/Presence/PresenceCore.lua
+++ b/modules/Presence/PresenceCore.lua
@@ -14,7 +14,7 @@
 ]]
 local addon = _G.HorizonSuite
 if not addon then return end
-
+local L = addon.L
 
 
 addon.Presence = addon.Presence or {}
@@ -746,8 +746,8 @@ local function ApplyToastContentToLayer(layer, typeName, title, subtitle, opts, 
 
     local showDiscovery = opts.showDiscovery or (not forPreview and addon.Presence.pendingDiscovery and (typeName == "ZONE_CHANGE" or typeName == "SUBZONE_CHANGE") and (not addon.GetDB or addon.GetDB("showPresenceDiscovery", true)))
     if showDiscovery then
-        layer.discoveryText:SetText(addon.L and addon.L["PRESENCE_DISCOVERED"])
-        layer.discoveryShadow:SetText(addon.L and addon.L["PRESENCE_DISCOVERED"])
+        layer.discoveryText:SetText(L["PRESENCE_DISCOVERED"])
+        layer.discoveryShadow:SetText(L["PRESENCE_DISCOVERED"])
         local dc = getDiscoveryColor()
         layer.discoveryText:SetTextColor(dc[1], dc[2], dc[3], 1)
         layer.discoveryShadow:SetTextColor(0, 0, 0, (addon.SHADOW_A ~= nil) and addon.SHADOW_A or 0.8)
@@ -1112,8 +1112,8 @@ end
 local function ShowDiscoveryLine()
     if not curLayer then return end
     if addon.GetDB and not addon.GetDB("showPresenceDiscovery", true) then return end
-    curLayer.discoveryText:SetText(addon.L["PRESENCE_DISCOVERED"])
-    curLayer.discoveryShadow:SetText(addon.L["PRESENCE_DISCOVERED"])
+    curLayer.discoveryText:SetText(L["PRESENCE_DISCOVERED"])
+    curLayer.discoveryShadow:SetText(L["PRESENCE_DISCOVERED"])
     local dc = getDiscoveryColor()
     curLayer.discoveryText:SetTextColor(dc[1], dc[2], dc[3], 1)
     curLayer.discoveryShadow:SetTextColor(0, 0, 0, (addon.SHADOW_A ~= nil) and addon.SHADOW_A or 0.8)

--- a/modules/Presence/PresenceErrors.lua
+++ b/modules/Presence/PresenceErrors.lua
@@ -6,7 +6,7 @@
 
 local addon = _G.HorizonSuite
 if not addon or not addon.Presence then return end
-
+local L = addon.L
 -- ============================================================================
 -- Private helpers
 -- ============================================================================
@@ -14,7 +14,7 @@ if not addon or not addon.Presence then return end
 local uiErrorsHooked = false
 
 local function OnUIErrorsAddMessage(self, msg)
-    local discoveredStr = (addon.L and addon.L["PRESENCE_DISCOVERED"])
+    local discoveredStr = L["PRESENCE_DISCOVERED"]
     if msg and msg:find(discoveredStr, 1, true) then
         addon.Presence.SetPendingDiscovery()
         local phase = addon.Presence.animPhase and addon.Presence.animPhase()

--- a/modules/Vista/VistaCore.lua
+++ b/modules/Vista/VistaCore.lua
@@ -6,7 +6,7 @@
 
 local addon = _G.HorizonSuite
 if not addon then return end
-
+local L = addon.L
 addon.Vista = addon.Vista or {}
 local Vista = addon.Vista
 
@@ -1566,7 +1566,7 @@ local function CreateCraftingOrderIndicator()
 
     craftingOrderAnchor:SetScript("OnEnter", function(self)
         GameTooltip:SetOwner(self, "ANCHOR_BOTTOMLEFT")
-        GameTooltip:SetText((addon.L and addon.L["VISTA_CRAFTING_ORDER_TOOLTIP"]))
+        GameTooltip:SetText(L["VISTA_CRAFTING_ORDER_TOOLTIP"])
         local total = 0
         local rows = {}
         if C_CraftingOrders and C_CraftingOrders.GetPersonalOrdersInfo then
@@ -1584,9 +1584,9 @@ local function CreateCraftingOrderIndicator()
             end
         end
         if total > 0 then
-            local fmt = (addon.L and addon.L["VISTA_CRAFTING_ORDER_PENDING_COUNT"])
+            local fmt = L["VISTA_CRAFTING_ORDER_PENDING_COUNT"]
             GameTooltip:AddLine(fmt:format(total), 1, 1, 1)
-            local rowFmt = (addon.L and addon.L["VISTA_CRAFTING_ORDER_PROFESSION_LINE"])
+            local rowFmt = L["VISTA_CRAFTING_ORDER_PROFESSION_LINE"]
             for _, row in ipairs(rows) do
                 local name = row.name or (UNKNOWN or "Unknown")
                 GameTooltip:AddLine(rowFmt:format(name, row.count), 0.85, 0.85, 0.85)

--- a/options/OptionsPanel.lua
+++ b/options/OptionsPanel.lua
@@ -1690,7 +1690,7 @@ local function BuildCategory(tab, tabIndex, options, refreshers, optionFrames)
             for _, key in ipairs(keys) do
                 local getTbl = function() local db = getDB(opt.dbKey, nil) return db and db[key] end
                 local setKeyVal = function(v) addon.EnsureDB(); local _rdb = _G[addon.DATABASE]; if not _rdb[opt.dbKey] then _rdb[opt.dbKey] = {} end; _rdb[opt.dbKey][key] = v; if not addon._colorPickerLive then notifyMainAddon() end end
-                local row = OptionsWidgets_CreateColorSwatchRow(cardContent, currentCard.contentAnchor, addon.L[(opt.labelMap and opt.labelMap[key]) or key:gsub("^%l", string.upper)], defaultMap[key], getTbl, setKeyVal, notifyMainAddon)
+                local row = OptionsWidgets_CreateColorSwatchRow(cardContent, currentCard.contentAnchor, L[(opt.labelMap and opt.labelMap[key]) or key:gsub("^%l", string.upper)], defaultMap[key], getTbl, setKeyVal, notifyMainAddon)
                 currentCard.contentAnchor = row
                 currentCard.contentHeight = currentCard.contentHeight + 4 + 24
                 swatches[#swatches+1] = row
@@ -1814,7 +1814,7 @@ local function BuildCategory(tab, tabIndex, options, refreshers, optionFrames)
             -- + a Reset button. Fixed height, no expand/collapse.
             -- ---------------------------------------------------------------
             local function BuildCompactColorCard(parentFrame, key)
-                local labelBase = addon.L[(addon.SECTION_LABELS and addon.SECTION_LABELS[key]) or key]
+                local labelBase = L[(addon.SECTION_LABELS and addon.SECTION_LABELS[key]) or key]
                 local container = CreateFrame("Frame", nil, parentFrame)
                 container:SetHeight(COMPACT_CARD_H)
                 container.groupKey = key
@@ -1850,7 +1850,7 @@ local function BuildCategory(tab, tabIndex, options, refreshers, optionFrames)
                 local sectionColor = (addon.SECTION_COLORS and addon.SECTION_COLORS[key]) or (addon.SECTION_COLORS and addon.SECTION_COLORS.DEFAULT) or { 0.9, 0.9, 0.9 }
                 local unifiedDef = (key == "NEARBY" or key == "CURRENT" or key == "CURRENT_EVENT") and sectionColor or baseColor
 
-                local zoneLabel = (key == "SCENARIO") and ((addon.L and addon.L["UI_STAGE"])) or ((addon.L and addon.L["FOCUS_ZONE"]))
+                local zoneLabel = (key == "SCENARIO") and (L["UI_STAGE"]) or (L["FOCUS_ZONE"])
                 local catDefs = {
                     { subKey = "section",   abbr = "Sec",   full = "Section",   def = unifiedDef },
                     { subKey = "title",     abbr = "Title", full = "Title",     def = unifiedDef },
@@ -2569,7 +2569,7 @@ local function BuildCategory(tab, tabIndex, options, refreshers, optionFrames)
                 local getTbl = function() local db = getDB(opt.dbKey, nil) return db and db[key] end
                 local setKeyVal = function(v) addon.EnsureDB(); local _rdb = _G[addon.DATABASE]; if not _rdb[opt.dbKey] then _rdb[opt.dbKey] = {} end; _rdb[opt.dbKey][key] = v; if not addon._colorPickerLive then notifyMainAddon() end end
                 local def = defaultMap[key] or {0.5,0.5,0.5}
-                local row = OptionsWidgets_CreateColorSwatchRow(cardContent, currentCard.contentAnchor, addon.L[(opt.labelMap and opt.labelMap[key]) or key:gsub("^%l", string.upper)], def, getTbl, setKeyVal, notifyMainAddon)
+                local row = OptionsWidgets_CreateColorSwatchRow(cardContent, currentCard.contentAnchor, L[(opt.labelMap and opt.labelMap[key]) or key:gsub("^%l", string.upper)], def, getTbl, setKeyVal, notifyMainAddon)
                 currentCard.contentAnchor = row
                 currentCard.contentHeight = currentCard.contentHeight + 4 + 24
                 swatches[#swatches+1] = row

--- a/options/OptionsWidgets.lua
+++ b/options/OptionsWidgets.lua
@@ -2048,7 +2048,7 @@ function OptionsWidgets_CreateReorderList(parent, anchor, opt, scrollFrameRef, p
         SetSafeFont(lab, Def.FontPath, Def.LabelSize, nil)
         lab:SetJustifyH("LEFT")
         SetTextColor(lab, Def.TextColorLabel)
-        lab:SetText(addon.L[(labelMap[key]) or key:gsub("^%l", string.upper)])
+        lab:SetText(L[(labelMap[key]) or key:gsub("^%l", string.upper)])
         lab:SetPoint("LEFT", row, "LEFT", 24, 0)
         row.label = lab
         local grip = row:CreateFontString(nil, "OVERLAY")
@@ -2204,7 +2204,7 @@ function _G.OptionsWidgets_CreateBlacklistGrid(parent, labelText, opts)
             local emptyLabel = listFrame:CreateFontString(nil, "OVERLAY")
             SetSafeFont(emptyLabel, Def.FontPath, Def.SectionSize, nil)
             SetTextColor(emptyLabel, Def.TextColorSection)
-            emptyLabel:SetText(addon.L and addon.L["HIDDEN_QUESTS"])
+            emptyLabel:SetTextL["HIDDEN_QUESTS"]
             emptyLabel:SetPoint("TOPLEFT", listFrame, "TOPLEFT", 0, 0)
             local emptyRow = CreateFrame("Frame", nil, listFrame)
             emptyRow:SetHeight(20)
@@ -2233,7 +2233,7 @@ function _G.OptionsWidgets_CreateBlacklistGrid(parent, labelText, opts)
             nameLbl:SetPoint("LEFT", row, "LEFT", 0, 0)
             nameLbl:SetJustifyH("LEFT")
 
-            local unblockBtn = _G.OptionsWidgets_CreateButton(row, addon.L and addon.L["UNBLOCK"], function()
+            local unblockBtn = _G.OptionsWidgets_CreateButton(row, L["UNBLOCK"], function()
                 if addon.GetDB then
                     local bl = addon.GetDB("questBlacklist", nil)
                     if bl and type(bl) == "table" then

--- a/options/dashboard/DashboardDetailView.lua
+++ b/options/dashboard/DashboardDetailView.lua
@@ -5,7 +5,7 @@
 
 local addon = _G.HorizonSuite
 if not addon then return end
-
+local L = addon.L
 --- Build detail and subcategory scroll areas; assign f.OpenModule, f.OpenCategoryDetail, f.BuildAccordionDetail.
 --- env fields: f, addon, L, detailView, subCategoryView, contentWidth, dashScrollTopOffset, dashScrollTopOffsetModule, dashAccentRefs,
 --- GetAccentColor, MakeText, OptionCategoryKeyIsAxis, moduleLabels, DASHBOARD_CHILD_PANEL_ALPHA,
@@ -1568,7 +1568,7 @@ function addon.DashboardDetailView_Init(env)
                             _rdb[opt.dbKey][key] = v
                             if not addon._colorPickerLive and addon.OptionsData_NotifyMainAddon then addon.OptionsData_NotifyMainAddon() end
                         end
-                        local labelText = addon.L[(opt.labelMap and opt.labelMap[key]) or key:gsub("^%l", string.upper)]
+                        local labelText = L[(opt.labelMap and opt.labelMap[key]) or key:gsub("^%l", string.upper)]
                         local row = _G.OptionsWidgets_CreateColorSwatchRow(cmContainer, nil, labelText, defaultMap[key], getTbl, setKeyVal, function() if addon.OptionsData_NotifyMainAddon then addon.OptionsData_NotifyMainAddon() end end)
                         row:ClearAllPoints()
                         row:SetPoint("TOPLEFT", cmContainer, "TOPLEFT", 10, yOff)
@@ -1656,7 +1656,7 @@ function addon.DashboardDetailView_Init(env)
 
                     -- Build a compact color card for a category
                     local function BuildCompactCard(parentFrame, key)
-                        local labelBase = addon.L[(addon.SECTION_LABELS and addon.SECTION_LABELS[key]) or key]
+                        local labelBase = L[(addon.SECTION_LABELS and addon.SECTION_LABELS[key]) or key]
                         local card = CreateFrame("Frame", nil, parentFrame)
                         card:SetHeight(CARD_H)
                         card.groupKey = key
@@ -1717,7 +1717,7 @@ function addon.DashboardDetailView_Init(env)
                         local sectionColor = (addon.SECTION_COLORS and addon.SECTION_COLORS[key]) or (addon.SECTION_COLORS and addon.SECTION_COLORS.DEFAULT) or { 0.9, 0.9, 0.9 }
                         local unifiedDef = (key == "NEARBY" or key == "CURRENT" or key == "CURRENT_EVENT") and sectionColor or baseColor
 
-                        local zoneLabel = (key == "SCENARIO") and ((addon.L and addon.L["UI_STAGE"])) or ((addon.L and addon.L["FOCUS_ZONE"]))
+                        local zoneLabel = (key == "SCENARIO") and (L["UI_STAGE"]) or (L["FOCUS_ZONE"])
                         local catDefs = {
                             { subKey = "section",   abbr = L["FOCUS_SECTION"],   full = "Section",   def = unifiedDef },
                             { subKey = "title",     abbr = L["FOCUS_TITLE"],     full = "Title",     def = unifiedDef },

--- a/options/dashboard/DashboardFrame.lua
+++ b/options/dashboard/DashboardFrame.lua
@@ -2438,7 +2438,7 @@ function addon.Dashboard_BuildMainFrame()
             grabber:SetScript("OnEnter", function(self)
                 if not _dragActive then setGripAlpha(0.9) end
                 GameTooltip:SetOwner(self, "ANCHOR_LEFT")
-                GameTooltip:SetText(addon.L["DASH_RESIZE_TOOLTIP"], 1, 1, 1, 1)
+                GameTooltip:SetText(L["DASH_RESIZE_TOOLTIP"], 1, 1, 1, 1)
                 GameTooltip:Show()
             end)
 


### PR DESCRIPTION
# Intent

Prevent known locale errors from occurring.

## Reviewer Notes

Multiple localisation artefacts exist that lead to half-fixes that do not target the actual issue at hand.

Localisation is handled through a singular function that only needs to appear **once** per file.

This helps with code legibility tremendously and removes the ability to have a function fail due to improper references. 

## Developer Notes

Locale fixes should NEVER again consist of `addon.L and addon.L["TERM"]` or `addon.L and L["TERM"]` additions. It "works" but does not fix the underlying issue.

This `local L = addon.L` function is to be defined in the base `.lua` file, outside of any other function so it can be applied in all subfunctions.

There do not need to be parentheses around locale keys (`L["TERM"]`) unless required by the function it is a part of (such as `SetText()`). These may remain from the prior additional terms and should be removed if seen.

*Of note, `FocusEntryPool.lua` contains a deprecated `T` function, which author believes to be an artefact for `translate` (as in locale work).

```
local function T(key)
    return (addon.L and addon.L[key]) or key
    return (L[key]) or key
end
```

`OptionsPanel.lua` did not have two parentheses removed as author unsure if required by syntax.

```
local zoneLabel = (key == "SCENARIO") and (L["UI_STAGE"]) or (L["FOCUS_ZONE"])
```

## Reviewer Checklist
*Note, author did not test in-game.

- [ ] No crashes in-game
- [ ] Coding syntax remains appropriate
  - [ ] ALL `L[` INSTEAD OF:
    - [ ] `addon.L and addon.L[`
    - [ ] `addon.L and L[`
    - [ ] `addon.L[`
  - [ ] No parentheses around `L["TERM"]` unless required
  - [ ] `local L = addon.L` remains appropriate
    - [ ] **ONCE** per file
      - [ ] Only if `L["TERM"]` is in the file
    - [ ] Under `local addon = _G.HorizonSuite`