### PR TITLE
fix(locale): restore two broken SetText calls introduced by #325

### DIFF
--- a/modules/Focus/FocusUnacceptedPopup.lua
+++ b/modules/Focus/FocusUnacceptedPopup.lua
@@ -514,7 +514,7 @@ local function PopulatePopup(rows, mapID, zoneName)
     if not popupFrame or not contentFrame then return end
 
     local count = #rows
-    popupFrame.titleText:SetText(L["PRESENCE_UNACCEPTED_QUESTS_X_MAP_X"]):format(zoneName, tostring(mapID), count))
+    popupFrame.titleText:SetText((L["PRESENCE_UNACCEPTED_QUESTS_X_MAP_X"]):format(zoneName, tostring(mapID), count))
 
     local contentWidth = (scrollFrame and scrollFrame:GetWidth() and scrollFrame:GetWidth() > 0)
         and scrollFrame:GetWidth()

--- a/options/OptionsWidgets.lua
+++ b/options/OptionsWidgets.lua
@@ -2204,7 +2204,7 @@ function _G.OptionsWidgets_CreateBlacklistGrid(parent, labelText, opts)
             local emptyLabel = listFrame:CreateFontString(nil, "OVERLAY")
             SetSafeFont(emptyLabel, Def.FontPath, Def.SectionSize, nil)
             SetTextColor(emptyLabel, Def.TextColorSection)
-            emptyLabel:SetTextL["HIDDEN_QUESTS"]
+            emptyLabel:SetText(L["HIDDEN_QUESTS"])
             emptyLabel:SetPoint("TOPLEFT", listFrame, "TOPLEFT", 0, 0)
             local emptyRow = CreateFrame("Frame", nil, listFrame)
             emptyRow:SetHeight(20)


### PR DESCRIPTION
# Intent
Fixes two load-time syntax errors introduced by #325.

## Reviewer Notes
PR #325 mangled two lines when removing `addon.L and` guards — in both cases the outer parentheses were dropped, causing either a syntax error or a silent logic bug.

**`options/OptionsWidgets.lua:2207`**
```lua
-- broken (#325)
emptyLabel:SetTextL["HIDDEN_QUESTS"]

-- fixed
emptyLabel:SetText(L["HIDDEN_QUESTS"])
```
Missing `(` and `)` — `SetTextL` is read as the method name, `[` is unexpected → `LUA_WARNING: function arguments expected near '['`.

**`modules/Focus/FocusUnacceptedPopup.lua:517`**
```lua
-- broken (#325)
popupFrame.titleText:SetText(L["PRESENCE_UNACCEPTED_QUESTS_X_MAP_X"]):format(zoneName, tostring(mapID), count))

-- fixed
popupFrame.titleText:SetText((L["PRESENCE_UNACCEPTED_QUESTS_X_MAP_X"]):format(zoneName, tostring(mapID), count))
```
Two issues: `:format()` was called on `SetText`'s return value (`nil`) instead of the string, and a dangling `)` caused `LUA_WARNING: unexpected symbol near ')'`.

## Developer Notes
All other files touched by #325 were scanned for the same pattern — no further instances found.

## Reviewer Checklist
- [ ] No Lua errors on `/reload`
- [ ] Blacklist grid (hidden quests list) renders the empty-state label correctly
- [ ] Unaccepted quests popup title displays zone name, map ID and count correctly