### PR TITLE
Template Key Header & Description propagated to non-enUS locales

### DIFF
--- a/locales/horizon/deDE.lua
+++ b/locales/horizon/deDE.lua
@@ -6,7 +6,11 @@ if not addon then return end
 local L = setmetatable({}, { __index = addon.L })
 addon.L = L
 addon.StandardFont = UNIT_NAME_FONT
--- L["TERM"]                                                = " "
+
+-- Template Key, feel free to copy/paste. 
+L["TERM"]                                                = " "
+-- Do not change anything except for the information inside of the quotation marks.
+-- To inactivate the key, make it a comment stub (prefaced with -- ) as this line is.
 
 -- =====================================================================
 -- Branding — Horizon Suite, module names, and third-party brand names

--- a/locales/horizon/esES.lua
+++ b/locales/horizon/esES.lua
@@ -6,7 +6,11 @@ if not addon then return end
 local L = setmetatable({}, { __index = addon.L })
 addon.L = L
 addon.StandardFont = UNIT_NAME_FONT
--- L["TERM"]                                                = " "
+
+-- Template Key, feel free to copy/paste. 
+L["TERM"]                                                = " "
+-- Do not change anything except for the information inside of the quotation marks.
+-- To inactivate the key, make it a comment stub (prefaced with -- ) as this line is.
 
 -- =====================================================================
 -- Branding — Horizon Suite, module names, and third-party brand names

--- a/locales/horizon/frFR.lua
+++ b/locales/horizon/frFR.lua
@@ -6,7 +6,11 @@ if not addon then return end
 local L = setmetatable({}, { __index = addon.L })
 addon.L = L
 addon.StandardFont = UNIT_NAME_FONT
--- L["TERM"]                                                = " "
+
+-- Template Key, feel free to copy/paste. 
+L["TERM"]                                                = " "
+-- Do not change anything except for the information inside of the quotation marks.
+-- To inactivate the key, make it a comment stub (prefaced with -- ) as this line is.
 
 -- =====================================================================
 -- Branding — Horizon Suite, module names, and third-party brand names

--- a/locales/horizon/koKR.lua
+++ b/locales/horizon/koKR.lua
@@ -6,7 +6,11 @@ if not addon then return end
 local L = setmetatable({}, { __index = addon.L })
 addon.L = L
 addon.StandardFont = UNIT_NAME_FONT
--- L["TERM"]                                                = " "
+
+-- Template Key, feel free to copy/paste. 
+L["TERM"]                                                = " "
+-- Do not change anything except for the information inside of the quotation marks.
+-- To inactivate the key, make it a comment stub (prefaced with -- ) as this line is.
 
 -- =====================================================================
 -- Branding — Horizon Suite, module names, and third-party brand names

--- a/locales/horizon/ptBR.lua
+++ b/locales/horizon/ptBR.lua
@@ -6,7 +6,11 @@ if not addon then return end
 local L = setmetatable({}, { __index = addon.L })
 addon.L = L
 addon.StandardFont = UNIT_NAME_FONT
--- L["TERM"]                                                = " "
+
+-- Template Key, feel free to copy/paste. 
+L["TERM"]                                                = " "
+-- Do not change anything except for the information inside of the quotation marks.
+-- To inactivate the key, make it a comment stub (prefaced with -- ) as this line is.
 
 -- =====================================================================
 -- Branding — Horizon Suite, module names, and third-party brand names

--- a/locales/horizon/zhCN.lua
+++ b/locales/horizon/zhCN.lua
@@ -6,7 +6,11 @@ if not addon then return end
 local L = setmetatable({}, { __index = addon.L })
 addon.L = L
 addon.StandardFont = UNIT_NAME_FONT
--- L["TERM"]                                                = " "
+
+-- Template Key, feel free to copy/paste. 
+L["TERM"]                                                = " "
+-- Do not change anything except for the information inside of the quotation marks.
+-- To inactivate the key, make it a comment stub (prefaced with -- ) as this line is.
 
 -- =====================================================================
 -- Branding — Horizon Suite, module names, and third-party brand names


### PR DESCRIPTION
# Intent

Propagate Template Locale Key to all Locales, along with intended description in the comments.

## Reviewer Notes

Template Locale Key was introduced in commit [7a674f6](https://github.com/Tacit-Labs/Horizon-Suite/commit/7a674f615e9d53b7b1e43459b690ae71ebed0c35#diff-0a5fb7612bef04c31af388370f77dbc02de9b57d89742957d488aa27a84ab0af), intended to remain only in `locales/horizon/enUS.lua`.

The key was propagated to each other locale in commit [d59c12b](d59c12bcdad34633d8a603730c075093e229f201), albeit without the proper spacing or any description in the comments.

This leads to confusion on intended purpose as the key is used nowhere in the codebase, except to serve as a reference for newer contributors when reviewing `locales/enUS.lua`.

## Developer Notes

Author believes the template locale key was likely propagated through use of the `restructure_locales.js` tool. If true, the tool likely created the key in each Horizon locale due to scanning an "active" key within the `enUS.lua` file.

Template Locale Key propagated to each non-`enUS.lua` locale despite original intent to only include it in `enUS.lua` as to prevent future occurances of the same concern.

The Template Locale Key (with surrounding context) should look as follows:
```
local L = addon.L

-- Template Key, feel free to copy/paste. 
L["TERM"]                                                = " "
-- Do not change anything except for the information inside of the quotation marks.
-- To inactivate the key, make it a comment stub (prefaced with -- ) as this line is.

-- =====================================================================
```
Yet each non-`enUS.lua` locale's Template Key looked as follows:
```
addon.StandardFont = UNIT_NAME_FONT
-- L["TERM"]                                                = " "

-- =====================================================================
```
Non-`enUS.lua` locales do have `addon.StandardFont = UNIT_NAME_FONT` in the place that `local L = addon.L` is in `enUS.lua`, to clarify that is not part of the issue.

Presuming the propagation was caused by the tool, the `L["TERM"]` keys will be commented out on the next run. Author temporarily okay with this as there will at least be contextual comments in a more suitable fashion.

## Reviewer Checklist

- [x] The full template locale key description appears and a newline appears before and after the template key description.
  - [x] deDE.lua
  - [x] esES.lua
  - [x] frFR.lua
  - [x] koKR.lua
  - [x] ptBR.lua
  - [x] zhCN.lua