### PR TITLE
Options widget overhaul — slider redesign, Horizon colour picker + saved palette

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,8 @@ Thumbs.db
 AGENTS.md
 CLAUDE.md
 TRP3_INTEGRATION_SUMMARY.md
+# Brainstorming visual-companion mockups (local only)
+.superpowers/
 # Dev / listing assets (screenshots, GIFs, internal notes); also excluded from addon zips via .pkgmeta
 docs/
 

--- a/HorizonSuite.toc
+++ b/HorizonSuite.toc
@@ -117,6 +117,7 @@ modules/Essence/EssenceCore.lua
 modules/Essence/EssenceSlash.lua
 modules/Essence/EssenceModule.lua
 options/OptionsWidgets.lua
+options/HorizonColorPicker.lua
 options/OptionsDefaults.lua
 options/OptionsData.lua
 options/OptionsHelpers.lua

--- a/locales/horizon/enUS.lua
+++ b/locales/horizon/enUS.lua
@@ -78,6 +78,12 @@ L["SEARCH_SETTINGS"]                                    = "Search Settings..."
 L["SEARCH_FONTS"]                                             = "Search Fonts..."
 
 -- =====================================================================
+-- HorizonColorPicker.lua — Custom colour picker
+-- =====================================================================
+L["COLOR_PICKER_TITLE"]                                       = "Choose a colour"
+L["OPACITY"]                                                  = "Opacity"
+
+-- =====================================================================
 -- OptionsPanel.lua — Resize handle tooltip
 -- =====================================================================
 L["FOCUS_DRAG_RESIZE"]                                        = "Drag to Resize"

--- a/locales/horizon/enUS.lua
+++ b/locales/horizon/enUS.lua
@@ -81,6 +81,7 @@ L["SEARCH_FONTS"]                                             = "Search Fonts...
 -- HorizonColorPicker.lua — Custom colour picker
 -- =====================================================================
 L["COLOR_PICKER_TITLE"]                                       = "Choose a colour"
+L["COLOR_SAVE_CURRENT"]                                       = "Save current colour"
 L["OPACITY"]                                                  = "Opacity"
 
 -- =====================================================================

--- a/options/HorizonColorPicker.lua
+++ b/options/HorizonColorPicker.lua
@@ -9,6 +9,14 @@ local PICKER_W, PICKER_H = 340, 300
 local WHEEL_SIZE = 128
 local VALUE_W = 24
 local THUMB_TEX = "Interface\\Buttons\\UI-ColorPicker-Buttons"
+local ALPHA_TRACK_H = 10
+local ALPHA_THUMB = 14
+
+local PRESET_COMMON = {
+    { 1, 1, 1 }, { 0, 0, 0 }, { 0.85, 0.20, 0.20 }, { 0.95, 0.70, 0.10 },
+    { 0.25, 0.75, 0.30 }, { 0.25, 0.55, 0.95 }, { 0.65, 0.35, 0.95 },
+}
+local PRESET_SIZE = 20
 
 local function Round(x) return math.floor(x * 255 + 0.5) end
 
@@ -205,6 +213,89 @@ local function EnsurePicker()
     end
     f.rBox, f.gBox, f.bBox = rBox, gBox, bBox
 
+    -- Alpha row (shown only when hasAlpha).
+    local alphaRow = CreateFrame("Frame", nil, f)
+    alphaRow:SetPoint("TOPLEFT", rBox:GetParent():GetParent(), "BOTTOMLEFT", 0, -14)
+    alphaRow:SetPoint("RIGHT", f, "RIGHT", -14, 0)
+    alphaRow:SetHeight(22)
+    local alphaLbl = alphaRow:CreateFontString(nil, "OVERLAY")
+    alphaLbl:SetFont(Def.FontPath, Def.LabelSize, Def.WidgetFontFlags or "OUTLINE")
+    alphaLbl:SetPoint("TOPLEFT", alphaRow, "TOPLEFT", 0, 0); alphaLbl:SetText((L and L["OPACITY"]) or "Opacity")
+    alphaLbl:SetTextColor(Def.TextColorSection[1], Def.TextColorSection[2], Def.TextColorSection[3], 1)
+    local alphaPct = alphaRow:CreateFontString(nil, "OVERLAY")
+    alphaPct:SetFont(Def.FontPath, Def.LabelSize, Def.WidgetFontFlags or "OUTLINE")
+    alphaPct:SetPoint("TOPRIGHT", alphaRow, "TOPRIGHT", 0, 0)
+    alphaPct:SetTextColor(Def.TextColorLabel[1], Def.TextColorLabel[2], Def.TextColorLabel[3], 1)
+    local aTrack = CreateFrame("Frame", nil, alphaRow)
+    aTrack:SetPoint("BOTTOMLEFT", alphaRow, "BOTTOMLEFT", 0, 0)
+    aTrack:SetPoint("BOTTOMRIGHT", alphaRow, "BOTTOMRIGHT", 0, 0)
+    aTrack:SetHeight(ALPHA_TRACK_H)
+    local aFill = aTrack:CreateTexture(nil, "ARTWORK")
+    aFill:SetAllPoints(aTrack)
+    local aThumb = CreateFrame("Button", nil, aTrack)
+    aThumb:SetSize(ALPHA_THUMB, ALPHA_THUMB)
+    local aThumbTex = aThumb:CreateTexture(nil, "OVERLAY")
+    aThumbTex:SetAllPoints(aThumb); aThumbTex:SetColorTexture(1, 1, 1, 0.98)
+
+    local function alphaTravel() return aTrack:GetWidth() - ALPHA_THUMB end
+    local function placeAlpha()
+        aThumb:ClearAllPoints()
+        aThumb:SetPoint("CENTER", aTrack, "LEFT", ALPHA_THUMB / 2 + state.a * alphaTravel(), 0)
+        aFill:SetColorTexture(state.r, state.g, state.b, 0.85)
+        alphaPct:SetText(math.floor(state.a * 100 + 0.5) .. "%")
+    end
+    aThumb:SetScript("OnMouseDown", function()
+        aThumb:SetScript("OnUpdate", function()
+            if not IsMouseButtonDown("LeftButton") then aThumb:SetScript("OnUpdate", nil) return end
+            local scale = aTrack:GetEffectiveScale()
+            local x = (GetCursorPosition() / scale) - aTrack:GetLeft()
+            local n = math.max(0, math.min(1, (x - ALPHA_THUMB / 2) / alphaTravel()))
+            state.a = n
+            placeAlpha()
+            f.newSwatch:SetColorTexture(state.r, state.g, state.b, state.a)
+            FireChange()
+        end)
+    end)
+    f.alphaRow = alphaRow
+    f.placeAlpha = placeAlpha
+
+    -- Preset palette: class colour first, then commons.
+    local presetRow = CreateFrame("Frame", nil, f)
+    presetRow:SetPoint("TOPLEFT", alphaRow, "BOTTOMLEFT", 0, -14)
+    presetRow:SetPoint("RIGHT", f, "RIGHT", -14, 0)
+    presetRow:SetHeight(PRESET_SIZE)
+    f.presetRow = presetRow
+    f.presetButtons = {}
+    local function presetButton(i)
+        local b = f.presetButtons[i]
+        if b then return b end
+        b = CreateFrame("Button", nil, presetRow)
+        b:SetSize(PRESET_SIZE, PRESET_SIZE)
+        if i == 1 then b:SetPoint("LEFT", presetRow, "LEFT", 0, 0)
+        else b:SetPoint("LEFT", f.presetButtons[i - 1], "RIGHT", 5, 0) end
+        local tex = b:CreateTexture(nil, "ARTWORK"); tex:SetAllPoints(b); b.tex = tex
+        if addon.CreateBorder then addon.CreateBorder(b, Def.InputBorder) end
+        b:SetScript("OnClick", function()
+            local c = b._color
+            if c then f.colorSelect:SetColorRGB(c[1], c[2], c[3]) end  -- OnColorSelect refreshes + fires
+        end)
+        f.presetButtons[i] = b
+        return b
+    end
+    function f:BuildPresets()
+        local list = {}
+        local classColor = addon.GetOptionsClassColor and addon.GetOptionsClassColor()
+        if classColor then list[#list + 1] = { classColor[1], classColor[2], classColor[3] } end
+        for _, c in ipairs(PRESET_COMMON) do list[#list + 1] = c end
+        for i = 1, #list do
+            local b = presetButton(i)
+            b._color = list[i]
+            b.tex:SetColorTexture(list[i][1], list[i][2], list[i][3], 1)
+            b:Show()
+        end
+        for i = #list + 1, #f.presetButtons do f.presetButtons[i]:Hide() end
+    end
+
     f.colorSelect = cs
     function f:Refresh()
         local a = state.hasAlpha and state.a or 1
@@ -215,6 +306,7 @@ local function EnsurePicker()
         if f.rBox and not f.rBox:HasFocus() then f.rBox:SetText(Round(state.r)) end
         if f.gBox and not f.gBox:HasFocus() then f.gBox:SetText(Round(state.g)) end
         if f.bBox and not f.bBox:HasFocus() then f.bBox:SetText(Round(state.b)) end
+        if state.hasAlpha and f.placeAlpha then f.placeAlpha() end
     end
     P = f
     return P
@@ -232,6 +324,9 @@ function addon.OpenColorPicker(spec)
     f.colorSelect:SetColorRGB(state.r, state.g, state.b)
     state.suppress = false
     if f.Refresh then f:Refresh() end
+    f.alphaRow:SetShown(state.hasAlpha)
+    if state.hasAlpha and f.placeAlpha then f.placeAlpha() end
+    f:BuildPresets()
     f:ClearAllPoints(); f:SetPoint("CENTER", UIParent, "CENTER", 0, 0)
     f:Show(); f:Raise()
 end

--- a/options/HorizonColorPicker.lua
+++ b/options/HorizonColorPicker.lua
@@ -1,0 +1,145 @@
+--[[ Horizon Suite — Custom colour picker (replaces Blizzard ColorPickerFrame). ]]
+local addon = _G._HorizonSuite_Loading or _G.HorizonSuiteBeta or _G.HorizonSuite
+if not addon then return end
+
+local L = addon.L
+local Def = addon.OptionsWidgetsDef  -- design tokens exported by OptionsWidgets.lua
+
+local PICKER_W, PICKER_H = 340, 300
+local WHEEL_SIZE = 128
+local VALUE_W = 24
+local THUMB_TEX = "Interface\\Buttons\\UI-ColorPicker-Buttons"
+
+local function Round(x) return math.floor(x * 255 + 0.5) end
+
+-- Parse a hex colour string ("ff0000", "#ff0000", "f00") to r,g,b in 0-1, or nil. (Moved here from
+-- OptionsWidgets.lua; exported so anything else can reuse it.)
+local function ParseHexColor(raw)
+    if type(raw) ~= "string" then return nil end
+    local hex = raw:gsub("^#", ""):gsub("%s+", "")
+    if #hex < 3 then return nil end
+    if #hex == 3 then hex = hex:gsub("(%x)(%x)(%x)", "%1%1%2%2%3%3") end
+    hex = hex:sub(1, 6)
+    while #hex < 6 do hex = hex .. "0" end
+    local r = tonumber(hex:sub(1, 2), 16)
+    local g = tonumber(hex:sub(3, 4), 16)
+    local b = tonumber(hex:sub(5, 6), 16)
+    if not r or not g or not b then return nil end
+    return r / 255, g / 255, b / 255
+end
+addon.ParseHexColor = ParseHexColor
+
+-- Singleton state.
+local P            -- the picker frame (built lazily)
+local state = { spec = nil, r = 1, g = 1, b = 1, a = 1, hasAlpha = false, suppress = false, orig = {} }
+
+local function FireChange()
+    local s = state.spec
+    if s and s.onChange then s.onChange(state.r, state.g, state.b, state.a) end
+end
+
+local function Close(cancelled)
+    if not P then return end
+    P:Hide()
+    if cancelled then
+        local s = state.spec
+        if s and s.onCancel then s.onCancel() end
+    end
+end
+
+local function EnsurePicker()
+    if P then return P end
+
+    local f = CreateFrame("Frame", "HorizonColorPicker", UIParent, "BackdropTemplate")
+    f:SetSize(PICKER_W, PICKER_H)
+    f:SetPoint("CENTER")
+    f:SetFrameStrata("FULLSCREEN_DIALOG")
+    f:SetToplevel(true)
+    f:EnableMouse(true)
+    f:SetMovable(true)
+    f:Hide()
+    if f.SetBackdrop and addon.OptionsWidgetsSectionCardBackdrop then
+        f:SetBackdrop(addon.OptionsWidgetsSectionCardBackdrop)
+        f:SetBackdropColor(Def.SectionCardBg[1], Def.SectionCardBg[2], Def.SectionCardBg[3], Def.SectionCardBg[4] or 1)
+        f:SetBackdropBorderColor(Def.SectionCardBorder[1], Def.SectionCardBorder[2], Def.SectionCardBorder[3], 1)
+    end
+
+    -- Title bar (drag handle) + close button.
+    local titleText = f:CreateFontString(nil, "OVERLAY")
+    titleText:SetFont(Def.FontPath, Def.HeaderSize or 16, Def.WidgetFontFlags or "OUTLINE")
+    titleText:SetPoint("TOPLEFT", f, "TOPLEFT", 14, -12)
+    titleText:SetText((L and L["COLOR_PICKER_TITLE"]) or "Choose a colour")
+    titleText:SetTextColor(Def.TextColorTitleBar[1], Def.TextColorTitleBar[2], Def.TextColorTitleBar[3], 1)
+
+    local drag = CreateFrame("Frame", nil, f)
+    drag:SetPoint("TOPLEFT", 0, 0); drag:SetPoint("TOPRIGHT", f, "TOPRIGHT", -34, 0); drag:SetHeight(34)
+    drag:EnableMouse(true); drag:RegisterForDrag("LeftButton")
+    drag:SetScript("OnDragStart", function() f:StartMoving() end)
+    drag:SetScript("OnDragStop", function() f:StopMovingOrSizing() end)
+
+    local close = CreateFrame("Button", nil, f)
+    close:SetSize(20, 20); close:SetPoint("TOPRIGHT", f, "TOPRIGHT", -10, -10)
+    close:SetFrameLevel((f:GetFrameLevel() or 1) + 10)
+    local cx = close:CreateFontString(nil, "OVERLAY")
+    cx:SetFont(Def.FontPath, 16, "OUTLINE"); cx:SetPoint("CENTER"); cx:SetText("\195\151") -- ×
+    cx:SetTextColor(Def.TextColorSection[1], Def.TextColorSection[2], Def.TextColorSection[3], 1)
+    close:SetScript("OnClick", function() Close(true) end)
+
+    -- Esc closes (cancel). Registered as a special frame.
+    f:SetScript("OnKeyDown", function(_, key) if key == "ESCAPE" then Close(true) end end)
+    f:SetPropagateKeyboardInput(true)
+    tinsert(UISpecialFrames, "HorizonColorPicker")
+
+    -- ColorSelect: hue/sat wheel + value bar.
+    local cs = CreateFrame("ColorSelect", nil, f)
+    cs:SetPoint("TOPLEFT", f, "TOPLEFT", 14, -40)
+    cs:SetSize(WHEEL_SIZE + VALUE_W + 24, WHEEL_SIZE)
+
+    -- SPIKE: ColorSelect paints the wheel/value art itself; here we hand it created Texture objects.
+    -- If the wheel/value renders blank in-game, the alternative is passing a texture *path string*
+    -- to SetColorWheelTexture / SetColorValueTexture instead of a Texture object.
+    local wheel = cs:CreateTexture(nil, "OVERLAY")
+    wheel:SetSize(WHEEL_SIZE, WHEEL_SIZE)
+    wheel:SetPoint("TOPLEFT", cs, "TOPLEFT", 0, -7)
+    cs:SetColorWheelTexture(wheel)
+
+    local wheelThumb = cs:CreateTexture(nil, "OVERLAY")
+    wheelThumb:SetSize(10, 10); wheelThumb:SetTexture(THUMB_TEX)
+    cs:SetColorWheelThumbTexture(wheelThumb)
+
+    local value = cs:CreateTexture(nil, "OVERLAY")
+    value:SetSize(VALUE_W, WHEEL_SIZE)
+    value:SetPoint("TOPLEFT", wheel, "TOPRIGHT", 16, 0)
+    cs:SetColorValueTexture(value)
+
+    local valueThumb = cs:CreateTexture(nil, "OVERLAY")
+    valueThumb:SetSize(VALUE_W + 4, 10); valueThumb:SetTexture(THUMB_TEX)
+    cs:SetColorValueThumbTexture(valueThumb)
+
+    cs:SetScript("OnColorSelect", function(_, r, g, b)
+        if state.suppress then return end
+        state.r, state.g, state.b = r, g, b
+        if P and P.Refresh then P:Refresh() end
+        FireChange()
+    end)
+
+    f.colorSelect = cs
+    function f:Refresh() end  -- replaced in later tasks
+    P = f
+    return P
+end
+
+function addon.OpenColorPicker(spec)
+    local f = EnsurePicker()
+    state.spec = spec or {}
+    state.hasAlpha = spec.hasAlpha and true or false
+    state.r, state.g, state.b = spec.r or 1, spec.g or 1, spec.b or 1
+    state.a = state.hasAlpha and (spec.a or 1) or 1
+    state.orig = { r = state.r, g = state.g, b = state.b, a = state.a }
+    state.suppress = true
+    f.colorSelect:SetColorRGB(state.r, state.g, state.b)
+    state.suppress = false
+    if f.Refresh then f:Refresh() end
+    f:ClearAllPoints(); f:SetPoint("CENTER", UIParent, "CENTER", 0, 0)
+    f:Show(); f:Raise()
+end

--- a/options/HorizonColorPicker.lua
+++ b/options/HorizonColorPicker.lua
@@ -5,6 +5,13 @@ if not addon then return end
 local L = addon.L
 local Def = addon.OptionsWidgetsDef  -- design tokens exported by OptionsWidgets.lua
 
+-- Use the shared widget font setter so our text registers in the same font registry as every other
+-- options widget — it then refreshes/shadows with the global dashboard font automatically.
+-- Pass nil flags so it adopts Def.WidgetFontFlags and registers for OptionsWidgets_RefreshFonts.
+local SafeFont = addon.OptionsWidgets_SetSafeFont or function(fs, path, size, flags)
+    if fs and fs.SetFont then fs:SetFont(path, size, flags or "OUTLINE") end
+end
+
 local PICKER_W, PICKER_H = 360, 312
 local WHEEL_SIZE = 128
 local VALUE_W = 24
@@ -137,7 +144,7 @@ local function EnsurePicker()
 
     -- Title bar (drag handle) + close button.
     local titleText = f:CreateFontString(nil, "OVERLAY")
-    titleText:SetFont(Def.FontPath, Def.HeaderSize or 16, Def.WidgetFontFlags or "OUTLINE")
+    SafeFont(titleText, Def.FontPath, Def.HeaderSize or 16, nil)
     titleText:SetPoint("TOPLEFT", f, "TOPLEFT", 14, -12)
     titleText:SetText((L and L["COLOR_PICKER_TITLE"]) or "Choose a colour")
     titleText:SetTextColor(Def.TextColorTitleBar[1], Def.TextColorTitleBar[2], Def.TextColorTitleBar[3], 1)
@@ -152,7 +159,7 @@ local function EnsurePicker()
     close:SetSize(20, 20); close:SetPoint("TOPRIGHT", f, "TOPRIGHT", -10, -10)
     close:SetFrameLevel((f:GetFrameLevel() or 1) + 10)
     local cx = close:CreateFontString(nil, "OVERLAY")
-    cx:SetFont(Def.FontPath, 16, "OUTLINE"); cx:SetPoint("CENTER"); cx:SetText("\195\151") -- ×
+    SafeFont(cx, Def.FontPath, 16, nil); cx:SetPoint("CENTER"); cx:SetText("\195\151") -- ×
     cx:SetTextColor(Def.TextColorSection[1], Def.TextColorSection[2], Def.TextColorSection[3], 1)
     close:SetScript("OnClick", function() CancelClose() end)
 
@@ -237,13 +244,13 @@ local function EnsurePicker()
     hexBg:SetColorTexture(Def.InputBg[1], Def.InputBg[2], Def.InputBg[3], Def.InputBg[4])
     if addon.CreateBorder then addon.CreateBorder(hexWrap, Def.InputBorder) end
     local hexHash = hexWrap:CreateFontString(nil, "OVERLAY")
-    hexHash:SetFont(Def.FontPath, Def.LabelSize, Def.WidgetFontFlags or "OUTLINE")
+    SafeFont(hexHash, Def.FontPath, Def.LabelSize, nil)
     hexHash:SetPoint("LEFT", hexWrap, "LEFT", 6, 0); hexHash:SetText("#")
     hexHash:SetTextColor(Def.TextColorSection[1], Def.TextColorSection[2], Def.TextColorSection[3], 1)
     local hex = CreateFrame("EditBox", nil, hexWrap)
     hex:SetPoint("LEFT", hexHash, "RIGHT", 4, 0); hex:SetPoint("RIGHT", hexWrap, "RIGHT", -4, 0)
     hex:SetHeight(20); hex:SetAutoFocus(false); hex:SetMaxLetters(6)
-    hex:SetFont(Def.FontPath, Def.LabelSize, Def.WidgetFontFlags or "OUTLINE")
+    SafeFont(hex, Def.FontPath, Def.LabelSize, nil)
     hex:SetTextColor(Def.TextColorLabel[1], Def.TextColorLabel[2], Def.TextColorLabel[3], 1)
     local function commitHex(self)
         local r, g, b = ParseHexColor(self:GetText())
@@ -262,7 +269,7 @@ local function EnsurePicker()
         if anchorTo then wrap:SetPoint("LEFT", anchorTo, "RIGHT", FIELD_GAP, 0)
         else wrap:SetPoint("LEFT", hexWrap, "RIGHT", FIELD_GAP, 0) end  -- R right of hex, same line
         local lab = wrap:CreateFontString(nil, "OVERLAY")
-        lab:SetFont(Def.FontPath, Def.LabelSize, Def.WidgetFontFlags or "OUTLINE")
+        SafeFont(lab, Def.FontPath, Def.LabelSize, nil)
         lab:SetPoint("LEFT", wrap, "LEFT", 0, 0); lab:SetText(labelText)
         lab:SetTextColor(Def.TextColorSection[1], Def.TextColorSection[2], Def.TextColorSection[3], 1)
         local boxWrap = CreateFrame("Frame", nil, wrap)
@@ -274,7 +281,7 @@ local function EnsurePicker()
         local box = CreateFrame("EditBox", nil, boxWrap)
         box:SetPoint("TOPLEFT", 4, 0); box:SetPoint("BOTTOMRIGHT", -4, 0)
         box:SetAutoFocus(false); box:SetNumeric(true); box:SetMaxLetters(3); box:SetJustifyH("CENTER")
-        box:SetFont(Def.FontPath, Def.LabelSize, Def.WidgetFontFlags or "OUTLINE")
+        SafeFont(box, Def.FontPath, Def.LabelSize, nil)
         box:SetTextColor(Def.TextColorLabel[1], Def.TextColorLabel[2], Def.TextColorLabel[3], 1)
         return box
     end
@@ -301,11 +308,11 @@ local function EnsurePicker()
     alphaRow:SetPoint("RIGHT", f, "RIGHT", -14, 0)
     alphaRow:SetHeight(32)
     local alphaLbl = alphaRow:CreateFontString(nil, "OVERLAY")
-    alphaLbl:SetFont(Def.FontPath, Def.LabelSize, Def.WidgetFontFlags or "OUTLINE")
+    SafeFont(alphaLbl, Def.FontPath, Def.LabelSize, nil)
     alphaLbl:SetPoint("TOPLEFT", alphaRow, "TOPLEFT", 0, 0); alphaLbl:SetText((L and L["OPACITY"]) or "Opacity")
     alphaLbl:SetTextColor(Def.TextColorSection[1], Def.TextColorSection[2], Def.TextColorSection[3], 1)
     local alphaPct = alphaRow:CreateFontString(nil, "OVERLAY")
-    alphaPct:SetFont(Def.FontPath, Def.LabelSize, Def.WidgetFontFlags or "OUTLINE")
+    SafeFont(alphaPct, Def.FontPath, Def.LabelSize, nil)
     alphaPct:SetPoint("TOPRIGHT", alphaRow, "TOPRIGHT", 0, 0)
     alphaPct:SetTextColor(Def.TextColorLabel[1], Def.TextColorLabel[2], Def.TextColorLabel[3], 1)
     local aTrack = CreateFrame("Frame", nil, alphaRow)
@@ -360,7 +367,7 @@ local function EnsurePicker()
         if addon.CreateBorder then addon.CreateBorder(b, Def.InputBorder) end
         -- "+" glyph (shown on the add cell only).
         local plus = b:CreateFontString(nil, "OVERLAY")
-        plus:SetFont(Def.FontPath, 16, Def.WidgetFontFlags or "OUTLINE")
+        SafeFont(plus, Def.FontPath, 16, nil)
         plus:SetPoint("CENTER", b, "CENTER", 0, 0); plus:SetText("+")
         plus:SetTextColor(Def.TextColorSection[1], Def.TextColorSection[2], Def.TextColorSection[3], 1)
         plus:Hide(); b.plus = plus
@@ -372,7 +379,7 @@ local function EnsurePicker()
         local xbg = xbadge:CreateTexture(nil, "BACKGROUND"); xbg:SetAllPoints(xbadge)
         xbg:SetColorTexture(0.75, 0.22, 0.17, 1)
         local xtx = xbadge:CreateFontString(nil, "OVERLAY")
-        xtx:SetFont(Def.FontPath, 10, "OUTLINE")
+        SafeFont(xtx, Def.FontPath, 10, nil)
         xtx:SetAllPoints(xbadge)
         xtx:SetJustifyH("CENTER"); xtx:SetJustifyV("MIDDLE")
         xtx:SetText("\195\151")
@@ -441,7 +448,7 @@ local function EnsurePicker()
         if addon.CreateBorder then addon.CreateBorder(b, primary and Def.AccentColor or Def.InputBorder) end
         local hi = b:CreateTexture(nil, "HIGHLIGHT"); hi:SetAllPoints(b); hi:SetColorTexture(1, 1, 1, 0.08)
         local t = b:CreateFontString(nil, "OVERLAY")
-        t:SetFont(Def.FontPath, Def.LabelSize, Def.WidgetFontFlags or "OUTLINE"); t:SetPoint("CENTER"); t:SetText(text)
+        SafeFont(t, Def.FontPath, Def.LabelSize, nil); t:SetPoint("CENTER"); t:SetText(text)
         t:SetTextColor(Def.TextColorLabel[1], Def.TextColorLabel[2], Def.TextColorLabel[3], 1)
         return b
     end

--- a/options/HorizonColorPicker.lua
+++ b/options/HorizonColorPicker.lua
@@ -5,10 +5,9 @@ if not addon then return end
 local L = addon.L
 local Def = addon.OptionsWidgetsDef  -- design tokens exported by OptionsWidgets.lua
 
-local PICKER_W, PICKER_H = 340, 300
+local PICKER_W, PICKER_H = 360, 312
 local WHEEL_SIZE = 128
 local VALUE_W = 24
-local THUMB_TEX = "Interface\\Buttons\\UI-ColorPicker-Buttons"
 local ALPHA_TRACK_H = 10
 local ALPHA_THUMB = 14
 
@@ -16,7 +15,14 @@ local PRESET_COMMON = {
     { 1, 1, 1 }, { 0, 0, 0 }, { 0.85, 0.20, 0.20 }, { 0.95, 0.70, 0.10 },
     { 0.25, 0.75, 0.30 }, { 0.25, 0.55, 0.95 }, { 0.65, 0.35, 0.95 },
 }
-local PRESET_SIZE = 20
+local PRESET_COLS = 4
+local PRESET_GAP = 6
+-- Derived widths so the hex+RGB row and the preset grid each fill their column edge-to-edge.
+local CONTENT_W = PICKER_W - 28                                            -- usable width (14px pad each side)
+local FIELD_GAP = 8
+local FIELD_W = math.floor((CONTENT_W - 3 * FIELD_GAP) / 4)                -- hex + R + G + B fill the row
+local RIGHTCOL_W = PICKER_W - 14 - (14 + (WHEEL_SIZE + VALUE_W + 24) + 14) -- right column (compare/presets) width
+local PRESET_SIZE = math.floor((RIGHTCOL_W - (PRESET_COLS - 1) * PRESET_GAP) / PRESET_COLS)
 
 local function Round(x) return math.floor(x * 255 + 0.5) end
 
@@ -46,13 +52,17 @@ local function FireChange()
     if s and s.onChange then s.onChange(state.r, state.g, state.b, state.a) end
 end
 
-local function Close(cancelled)
+local function ConfirmClose()
     if not P then return end
+    state.confirmed = true
+    local s = state.spec
+    if s and s.onConfirm then s.onConfirm(state.r, state.g, state.b, state.a) end
     P:Hide()
-    if cancelled then
-        local s = state.spec
-        if s and s.onCancel then s.onCancel() end
-    end
+end
+
+local function CancelClose()
+    if not P then return end
+    P:Hide()   -- OnHide fires onCancel because confirmed is false
 end
 
 local function EnsurePicker()
@@ -91,10 +101,17 @@ local function EnsurePicker()
     local cx = close:CreateFontString(nil, "OVERLAY")
     cx:SetFont(Def.FontPath, 16, "OUTLINE"); cx:SetPoint("CENTER"); cx:SetText("\195\151") -- ×
     cx:SetTextColor(Def.TextColorSection[1], Def.TextColorSection[2], Def.TextColorSection[3], 1)
-    close:SetScript("OnClick", function() Close(true) end)
+    close:SetScript("OnClick", function() CancelClose() end)
+
+    -- Divider under the title bar.
+    local titleDivider = f:CreateTexture(nil, "ARTWORK")
+    titleDivider:SetHeight(1)
+    titleDivider:SetPoint("TOPLEFT", f, "TOPLEFT", 12, -34)
+    titleDivider:SetPoint("TOPRIGHT", f, "TOPRIGHT", -12, -34)
+    titleDivider:SetColorTexture(Def.SectionCardBorder[1], Def.SectionCardBorder[2], Def.SectionCardBorder[3], 0.6)
 
     -- Esc closes (cancel). Registered as a special frame.
-    f:SetScript("OnKeyDown", function(_, key) if key == "ESCAPE" then Close(true) end end)
+    f:SetScript("OnKeyDown", function(_, key) if key == "ESCAPE" then CancelClose() end end)
     f:SetPropagateKeyboardInput(true)
     tinsert(UISpecialFrames, "HorizonColorPicker")
 
@@ -110,9 +127,15 @@ local function EnsurePicker()
     wheel:SetSize(WHEEL_SIZE, WHEEL_SIZE)
     wheel:SetPoint("TOPLEFT", cs, "TOPLEFT", 0, -7)
     cs:SetColorWheelTexture(wheel)
+    -- Circular mask softens the wheel's aliased rim.
+    local wheelMask = cs:CreateMaskTexture(nil, "OVERLAY")
+    wheelMask:SetTexture("Interface\\CHARACTERFRAME\\TempPortraitAlphaMask", "CLAMPTOBLACKADDITIVE", "CLAMPTOBLACKADDITIVE")
+    wheelMask:SetAllPoints(wheel)
+    wheel:AddMaskTexture(wheelMask)
 
+    -- Clean solid markers (the Blizzard UI-ColorPicker-Buttons sprite sheet drew a stray blob).
     local wheelThumb = cs:CreateTexture(nil, "OVERLAY")
-    wheelThumb:SetSize(10, 10); wheelThumb:SetTexture(THUMB_TEX)
+    wheelThumb:SetSize(10, 10); wheelThumb:SetColorTexture(1, 1, 1, 0.95)
     cs:SetColorWheelThumbTexture(wheelThumb)
 
     local value = cs:CreateTexture(nil, "OVERLAY")
@@ -121,7 +144,7 @@ local function EnsurePicker()
     cs:SetColorValueTexture(value)
 
     local valueThumb = cs:CreateTexture(nil, "OVERLAY")
-    valueThumb:SetSize(VALUE_W + 4, 10); valueThumb:SetTexture(THUMB_TEX)
+    valueThumb:SetSize(VALUE_W + 6, 4); valueThumb:SetColorTexture(1, 1, 1, 0.95)
     cs:SetColorValueThumbTexture(valueThumb)
 
     cs:SetScript("OnColorSelect", function(_, r, g, b)
@@ -137,19 +160,20 @@ local function EnsurePicker()
     cmp:SetPoint("RIGHT", f, "RIGHT", -14, 0)
     cmp:SetHeight(26)
     local newSw = cmp:CreateTexture(nil, "ARTWORK")
-    newSw:SetPoint("TOPLEFT", cmp, "TOPLEFT", 0, 0); newSw:SetPoint("BOTTOM", cmp, "BOTTOM", 0, 0)
-    newSw:SetWidth(60)
+    newSw:SetPoint("TOPLEFT", cmp, "TOPLEFT", 0, 0)
+    newSw:SetPoint("BOTTOM", cmp, "BOTTOM", 0, 0)
+    newSw:SetPoint("RIGHT", cmp, "CENTER", 0, 0)
     local oldSw = cmp:CreateTexture(nil, "ARTWORK")
-    oldSw:SetPoint("TOPLEFT", newSw, "TOPRIGHT", 0, 0); oldSw:SetPoint("BOTTOM", cmp, "BOTTOM", 0, 0)
-    oldSw:SetWidth(60)
+    oldSw:SetPoint("TOPLEFT", newSw, "TOPRIGHT", 0, 0)
+    oldSw:SetPoint("BOTTOMRIGHT", cmp, "BOTTOMRIGHT", 0, 0)
     if addon.CreateBorder then addon.CreateBorder(cmp, Def.InputBorder) end
     f.newSwatch = newSw
     f.oldSwatch = oldSw
 
     -- Hex input.
     local hexWrap = CreateFrame("Frame", nil, f)
-    hexWrap:SetSize(96, 22)
-    hexWrap:SetPoint("TOPLEFT", cmp, "BOTTOMLEFT", 0, -8)
+    hexWrap:SetSize(FIELD_W, 22)
+    hexWrap:SetPoint("TOPLEFT", cs, "BOTTOMLEFT", 0, -16)  -- combined hex + R/G/B row below the wheel
     local hexBg = hexWrap:CreateTexture(nil, "BACKGROUND")
     hexBg:SetAllPoints(hexWrap)
     hexBg:SetColorTexture(Def.InputBg[1], Def.InputBg[2], Def.InputBg[3], Def.InputBg[4])
@@ -176,9 +200,9 @@ local function EnsurePicker()
     -- R/G/B 0-255 fields.
     local function makeNumField(labelText, anchorTo)
         local wrap = CreateFrame("Frame", nil, f)
-        wrap:SetSize(58, 22)
-        if anchorTo then wrap:SetPoint("LEFT", anchorTo, "RIGHT", 6, 0)
-        else wrap:SetPoint("TOPLEFT", hexWrap, "BOTTOMLEFT", 0, -8) end
+        wrap:SetSize(FIELD_W, 22)
+        if anchorTo then wrap:SetPoint("LEFT", anchorTo, "RIGHT", FIELD_GAP, 0)
+        else wrap:SetPoint("LEFT", hexWrap, "RIGHT", FIELD_GAP, 0) end  -- R right of hex, same line
         local lab = wrap:CreateFontString(nil, "OVERLAY")
         lab:SetFont(Def.FontPath, Def.LabelSize, Def.WidgetFontFlags or "OUTLINE")
         lab:SetPoint("LEFT", wrap, "LEFT", 0, 0); lab:SetText(labelText)
@@ -215,9 +239,9 @@ local function EnsurePicker()
 
     -- Alpha row (shown only when hasAlpha).
     local alphaRow = CreateFrame("Frame", nil, f)
-    alphaRow:SetPoint("TOPLEFT", rBox:GetParent():GetParent(), "BOTTOMLEFT", 0, -14)
+    alphaRow:SetPoint("TOPLEFT", hexWrap, "BOTTOMLEFT", 0, -16)
     alphaRow:SetPoint("RIGHT", f, "RIGHT", -14, 0)
-    alphaRow:SetHeight(22)
+    alphaRow:SetHeight(32)
     local alphaLbl = alphaRow:CreateFontString(nil, "OVERLAY")
     alphaLbl:SetFont(Def.FontPath, Def.LabelSize, Def.WidgetFontFlags or "OUTLINE")
     alphaLbl:SetPoint("TOPLEFT", alphaRow, "TOPLEFT", 0, 0); alphaLbl:SetText((L and L["OPACITY"]) or "Opacity")
@@ -259,11 +283,11 @@ local function EnsurePicker()
     f.alphaRow = alphaRow
     f.placeAlpha = placeAlpha
 
-    -- Preset palette: class colour first, then commons.
+    -- Preset palette: class colour first, then commons. Wrapping grid, tucked beside the wheel.
     local presetRow = CreateFrame("Frame", nil, f)
-    presetRow:SetPoint("TOPLEFT", alphaRow, "BOTTOMLEFT", 0, -14)
+    presetRow:SetPoint("TOPLEFT", cmp, "BOTTOMLEFT", 0, -10)
     presetRow:SetPoint("RIGHT", f, "RIGHT", -14, 0)
-    presetRow:SetHeight(PRESET_SIZE)
+    presetRow:SetHeight(PRESET_SIZE * 2 + PRESET_GAP)
     f.presetRow = presetRow
     f.presetButtons = {}
     local function presetButton(i)
@@ -271,8 +295,9 @@ local function EnsurePicker()
         if b then return b end
         b = CreateFrame("Button", nil, presetRow)
         b:SetSize(PRESET_SIZE, PRESET_SIZE)
-        if i == 1 then b:SetPoint("LEFT", presetRow, "LEFT", 0, 0)
-        else b:SetPoint("LEFT", f.presetButtons[i - 1], "RIGHT", 5, 0) end
+        local col = (i - 1) % PRESET_COLS
+        local row = math.floor((i - 1) / PRESET_COLS)
+        b:SetPoint("TOPLEFT", presetRow, "TOPLEFT", col * (PRESET_SIZE + PRESET_GAP), -row * (PRESET_SIZE + PRESET_GAP))
         local tex = b:CreateTexture(nil, "ARTWORK"); tex:SetAllPoints(b); b.tex = tex
         if addon.CreateBorder then addon.CreateBorder(b, Def.InputBorder) end
         b:SetScript("OnClick", function()
@@ -296,6 +321,48 @@ local function EnsurePicker()
         for i = #list + 1, #f.presetButtons do f.presetButtons[i]:Hide() end
     end
 
+    -- Footer buttons.
+    local function makeButton(text, primary)
+        local b = CreateFrame("Button", nil, f)
+        b:SetSize(72, 24)
+        local bg = b:CreateTexture(nil, "BACKGROUND"); bg:SetAllPoints(b)
+        if primary then bg:SetColorTexture(Def.AccentColor[1] * 0.5, Def.AccentColor[2] * 0.5, Def.AccentColor[3] * 0.6, 1)
+        else bg:SetColorTexture(Def.InputBg[1], Def.InputBg[2], Def.InputBg[3], Def.InputBg[4]) end
+        if addon.CreateBorder then addon.CreateBorder(b, primary and Def.AccentColor or Def.InputBorder) end
+        local hi = b:CreateTexture(nil, "HIGHLIGHT"); hi:SetAllPoints(b); hi:SetColorTexture(1, 1, 1, 0.08)
+        local t = b:CreateFontString(nil, "OVERLAY")
+        t:SetFont(Def.FontPath, Def.LabelSize, Def.WidgetFontFlags or "OUTLINE"); t:SetPoint("CENTER"); t:SetText(text)
+        t:SetTextColor(Def.TextColorLabel[1], Def.TextColorLabel[2], Def.TextColorLabel[3], 1)
+        return b
+    end
+
+    local okBtn = makeButton((OKAY) or "OK", true)
+    okBtn:SetPoint("BOTTOMRIGHT", f, "BOTTOMRIGHT", -14, 12)
+    okBtn:SetScript("OnClick", function() ConfirmClose() end)
+    local cancelBtn = makeButton((CANCEL) or "Cancel", false)
+    cancelBtn:SetPoint("RIGHT", okBtn, "LEFT", -8, 0)
+    cancelBtn:SetScript("OnClick", function() CancelClose() end)
+    local resetBtn = makeButton((RESET) or "Reset", false)
+    resetBtn:SetPoint("BOTTOMLEFT", f, "BOTTOMLEFT", 14, 12)
+    resetBtn:SetScript("OnClick", function()
+        local d = state.spec and state.spec.default
+        if not d then return end
+        if state.hasAlpha and type(d[4]) == "number" then
+            state.a = d[4]
+            if f.placeAlpha then f.placeAlpha() end
+        end
+        f.colorSelect:SetColorRGB(d[1], d[2], d[3])  -- OnColorSelect refreshes + fires change
+    end)
+
+    -- Fire onCancel when hidden without an explicit confirm (Cancel / ✕ / Esc). Placed after the
+    -- initial f:Hide() above so it never fires during construction.
+    f:SetScript("OnHide", function()
+        if not state.confirmed then
+            local s = state.spec
+            if s and s.onCancel then s.onCancel() end
+        end
+    end)
+
     f.colorSelect = cs
     function f:Refresh()
         local a = state.hasAlpha and state.a or 1
@@ -315,6 +382,7 @@ end
 function addon.OpenColorPicker(spec)
     local f = EnsurePicker()
     state.spec = spec or {}
+    state.confirmed = false
     state.hasAlpha = spec.hasAlpha and true or false
     state.r, state.g, state.b = spec.r or 1, spec.g or 1, spec.b or 1
     state.a = state.hasAlpha and (spec.a or 1) or 1

--- a/options/HorizonColorPicker.lua
+++ b/options/HorizonColorPicker.lua
@@ -123,8 +123,99 @@ local function EnsurePicker()
         FireChange()
     end)
 
+    -- New (live) vs Current (original) comparison.
+    local cmp = CreateFrame("Frame", nil, f)
+    cmp:SetPoint("TOPLEFT", cs, "TOPRIGHT", 14, -2)
+    cmp:SetPoint("RIGHT", f, "RIGHT", -14, 0)
+    cmp:SetHeight(26)
+    local newSw = cmp:CreateTexture(nil, "ARTWORK")
+    newSw:SetPoint("TOPLEFT", cmp, "TOPLEFT", 0, 0); newSw:SetPoint("BOTTOM", cmp, "BOTTOM", 0, 0)
+    newSw:SetWidth(60)
+    local oldSw = cmp:CreateTexture(nil, "ARTWORK")
+    oldSw:SetPoint("TOPLEFT", newSw, "TOPRIGHT", 0, 0); oldSw:SetPoint("BOTTOM", cmp, "BOTTOM", 0, 0)
+    oldSw:SetWidth(60)
+    if addon.CreateBorder then addon.CreateBorder(cmp, Def.InputBorder) end
+    f.newSwatch = newSw
+    f.oldSwatch = oldSw
+
+    -- Hex input.
+    local hexWrap = CreateFrame("Frame", nil, f)
+    hexWrap:SetSize(96, 22)
+    hexWrap:SetPoint("TOPLEFT", cmp, "BOTTOMLEFT", 0, -8)
+    local hexBg = hexWrap:CreateTexture(nil, "BACKGROUND")
+    hexBg:SetAllPoints(hexWrap)
+    hexBg:SetColorTexture(Def.InputBg[1], Def.InputBg[2], Def.InputBg[3], Def.InputBg[4])
+    if addon.CreateBorder then addon.CreateBorder(hexWrap, Def.InputBorder) end
+    local hexHash = hexWrap:CreateFontString(nil, "OVERLAY")
+    hexHash:SetFont(Def.FontPath, Def.LabelSize, Def.WidgetFontFlags or "OUTLINE")
+    hexHash:SetPoint("LEFT", hexWrap, "LEFT", 6, 0); hexHash:SetText("#")
+    hexHash:SetTextColor(Def.TextColorSection[1], Def.TextColorSection[2], Def.TextColorSection[3], 1)
+    local hex = CreateFrame("EditBox", nil, hexWrap)
+    hex:SetPoint("LEFT", hexHash, "RIGHT", 4, 0); hex:SetPoint("RIGHT", hexWrap, "RIGHT", -4, 0)
+    hex:SetHeight(20); hex:SetAutoFocus(false); hex:SetMaxLetters(6)
+    hex:SetFont(Def.FontPath, Def.LabelSize, Def.WidgetFontFlags or "OUTLINE")
+    hex:SetTextColor(Def.TextColorLabel[1], Def.TextColorLabel[2], Def.TextColorLabel[3], 1)
+    local function commitHex(self)
+        local r, g, b = ParseHexColor(self:GetText())
+        if r then f.colorSelect:SetColorRGB(r, g, b) end  -- OnColorSelect refreshes + fires change
+        self:ClearFocus()
+    end
+    hex:SetScript("OnEnterPressed", commitHex)
+    hex:SetScript("OnEditFocusLost", commitHex)
+    hex:SetScript("OnEscapePressed", function(self) self:ClearFocus(); f:Refresh() end)
+    f.hex = hex
+
+    -- R/G/B 0-255 fields.
+    local function makeNumField(labelText, anchorTo)
+        local wrap = CreateFrame("Frame", nil, f)
+        wrap:SetSize(58, 22)
+        if anchorTo then wrap:SetPoint("LEFT", anchorTo, "RIGHT", 6, 0)
+        else wrap:SetPoint("TOPLEFT", hexWrap, "BOTTOMLEFT", 0, -8) end
+        local lab = wrap:CreateFontString(nil, "OVERLAY")
+        lab:SetFont(Def.FontPath, Def.LabelSize, Def.WidgetFontFlags or "OUTLINE")
+        lab:SetPoint("LEFT", wrap, "LEFT", 0, 0); lab:SetText(labelText)
+        lab:SetTextColor(Def.TextColorSection[1], Def.TextColorSection[2], Def.TextColorSection[3], 1)
+        local boxWrap = CreateFrame("Frame", nil, wrap)
+        boxWrap:SetPoint("LEFT", lab, "RIGHT", 4, 0); boxWrap:SetPoint("RIGHT", wrap, "RIGHT", 0, 0)
+        boxWrap:SetHeight(20)
+        local bg = boxWrap:CreateTexture(nil, "BACKGROUND"); bg:SetAllPoints(boxWrap)
+        bg:SetColorTexture(Def.InputBg[1], Def.InputBg[2], Def.InputBg[3], Def.InputBg[4])
+        if addon.CreateBorder then addon.CreateBorder(boxWrap, Def.InputBorder) end
+        local box = CreateFrame("EditBox", nil, boxWrap)
+        box:SetPoint("TOPLEFT", 4, 0); box:SetPoint("BOTTOMRIGHT", -4, 0)
+        box:SetAutoFocus(false); box:SetNumeric(true); box:SetMaxLetters(3); box:SetJustifyH("CENTER")
+        box:SetFont(Def.FontPath, Def.LabelSize, Def.WidgetFontFlags or "OUTLINE")
+        box:SetTextColor(Def.TextColorLabel[1], Def.TextColorLabel[2], Def.TextColorLabel[3], 1)
+        return box
+    end
+    local rBox = makeNumField("R", nil)
+    local gBox = makeNumField("G", rBox:GetParent():GetParent())
+    local bBox = makeNumField("B", gBox:GetParent():GetParent())
+
+    local function commitRGB()
+        local r = math.min(255, math.max(0, tonumber(rBox:GetText()) or Round(state.r)))
+        local g = math.min(255, math.max(0, tonumber(gBox:GetText()) or Round(state.g)))
+        local b = math.min(255, math.max(0, tonumber(bBox:GetText()) or Round(state.b)))
+        f.colorSelect:SetColorRGB(r / 255, g / 255, b / 255)  -- OnColorSelect refreshes + fires change
+    end
+    for _, box in ipairs({ rBox, gBox, bBox }) do
+        box:SetScript("OnEnterPressed", function(self) commitRGB(); self:ClearFocus() end)
+        box:SetScript("OnEditFocusLost", function() commitRGB() end)
+        box:SetScript("OnEscapePressed", function(self) self:ClearFocus(); f:Refresh() end)
+    end
+    f.rBox, f.gBox, f.bBox = rBox, gBox, bBox
+
     f.colorSelect = cs
-    function f:Refresh() end  -- replaced in later tasks
+    function f:Refresh()
+        local a = state.hasAlpha and state.a or 1
+        f.newSwatch:SetColorTexture(state.r, state.g, state.b, a)
+        if f.hex and not f.hex:HasFocus() then
+            f.hex:SetText(string.format("%02X%02X%02X", Round(state.r), Round(state.g), Round(state.b)))
+        end
+        if f.rBox and not f.rBox:HasFocus() then f.rBox:SetText(Round(state.r)) end
+        if f.gBox and not f.gBox:HasFocus() then f.gBox:SetText(Round(state.g)) end
+        if f.bBox and not f.bBox:HasFocus() then f.bBox:SetText(Round(state.b)) end
+    end
     P = f
     return P
 end
@@ -136,6 +227,7 @@ function addon.OpenColorPicker(spec)
     state.r, state.g, state.b = spec.r or 1, spec.g or 1, spec.b or 1
     state.a = state.hasAlpha and (spec.a or 1) or 1
     state.orig = { r = state.r, g = state.g, b = state.b, a = state.a }
+    f.oldSwatch:SetColorTexture(state.r, state.g, state.b, state.a)
     state.suppress = true
     f.colorSelect:SetColorRGB(state.r, state.g, state.b)
     state.suppress = false

--- a/options/HorizonColorPicker.lua
+++ b/options/HorizonColorPicker.lua
@@ -12,6 +12,10 @@ local SafeFont = addon.OptionsWidgets_SetSafeFont or function(fs, path, size, fl
     if fs and fs.SetFont then fs:SetFont(path, size, flags or "OUTLINE") end
 end
 
+-- The × symbols (window close + remove badge) are UI chrome, not text — keep them on a guaranteed
+-- font (the game default includes the × glyph) so they render even when the user's font lacks it.
+local GLYPH_FONT = (addon.GetDefaultFontPath and addon.GetDefaultFontPath()) or "Fonts\\FRIZQT__.TTF"
+
 local PICKER_W, PICKER_H = 360, 312
 local WHEEL_SIZE = 128
 local VALUE_W = 24
@@ -115,6 +119,7 @@ end
 local function ConfirmClose()
     if not P then return end
     state.confirmed = true
+    addon._colorPickerLive = nil  -- commit: let the option's heavy refresh run now
     local s = state.spec
     if s and s.onConfirm then s.onConfirm(state.r, state.g, state.b, state.a) end
     P:Hide()
@@ -159,7 +164,7 @@ local function EnsurePicker()
     close:SetSize(20, 20); close:SetPoint("TOPRIGHT", f, "TOPRIGHT", -10, -10)
     close:SetFrameLevel((f:GetFrameLevel() or 1) + 10)
     local cx = close:CreateFontString(nil, "OVERLAY")
-    SafeFont(cx, Def.FontPath, 16, nil); cx:SetPoint("CENTER"); cx:SetText("\195\151") -- ×
+    cx:SetFont(GLYPH_FONT, 16, "OUTLINE"); cx:SetPoint("CENTER"); cx:SetText("\195\151") -- ×
     cx:SetTextColor(Def.TextColorSection[1], Def.TextColorSection[2], Def.TextColorSection[3], 1)
     close:SetScript("OnClick", function() CancelClose() end)
 
@@ -379,7 +384,7 @@ local function EnsurePicker()
         local xbg = xbadge:CreateTexture(nil, "BACKGROUND"); xbg:SetAllPoints(xbadge)
         xbg:SetColorTexture(0.75, 0.22, 0.17, 1)
         local xtx = xbadge:CreateFontString(nil, "OVERLAY")
-        SafeFont(xtx, Def.FontPath, 10, nil)
+        xtx:SetFont(GLYPH_FONT, 10, "OUTLINE")
         xtx:SetAllPoints(xbadge)
         xtx:SetJustifyH("CENTER"); xtx:SetJustifyV("MIDDLE")
         xtx:SetText("\195\151")
@@ -474,6 +479,7 @@ local function EnsurePicker()
     -- Fire onCancel when hidden without an explicit confirm (Cancel / ✕ / Esc). Placed after the
     -- initial f:Hide() above so it never fires during construction.
     f:SetScript("OnHide", function()
+        addon._colorPickerLive = nil  -- leave live mode; the cancel restore below gets a full refresh
         if not state.confirmed then
             local s = state.spec
             if s and s.onCancel then s.onCancel() end
@@ -500,6 +506,7 @@ function addon.OpenColorPicker(spec)
     local f = EnsurePicker()
     state.spec = spec or {}
     state.confirmed = false
+    addon._colorPickerLive = true  -- live mode: option setters skip the heavy refresh while dragging
     state.hasAlpha = spec.hasAlpha and true or false
     state.r, state.g, state.b = spec.r or 1, spec.g or 1, spec.b or 1
     state.a = state.hasAlpha and (spec.a or 1) or 1
@@ -512,6 +519,10 @@ function addon.OpenColorPicker(spec)
     f.alphaRow:SetShown(state.hasAlpha)
     if state.hasAlpha and f.placeAlpha then f.placeAlpha() end
     f:BuildPalette()
+    -- The picker is a singleton (built once), so unlike per-open widgets it won't have picked up a
+    -- font change since it was built. Re-apply the current dashboard font via the shared refresh so
+    -- our registered fontstrings match the rest of the options UI every time it opens.
+    if addon.OptionsWidgets_RefreshFonts then addon.OptionsWidgets_RefreshFonts() end
     f:ClearAllPoints(); f:SetPoint("CENTER", UIParent, "CENTER", 0, 0)
     f:Show(); f:Raise()
 end

--- a/options/HorizonColorPicker.lua
+++ b/options/HorizonColorPicker.lua
@@ -11,12 +11,9 @@ local VALUE_W = 24
 local ALPHA_TRACK_H = 10
 local ALPHA_THUMB = 14
 
-local PRESET_COMMON = {
-    { 1, 1, 1 }, { 0, 0, 0 }, { 0.85, 0.20, 0.20 }, { 0.95, 0.70, 0.10 },
-    { 0.25, 0.75, 0.30 }, { 0.25, 0.55, 0.95 }, { 0.65, 0.35, 0.95 },
-}
 local PRESET_COLS = 4
 local PRESET_GAP = 6
+local PALETTE_CAP = 6  -- max user-saved colours (class + 6 saved + "+" = 8 cells = 2 rows of 4)
 -- Derived widths so the hex+RGB row and the preset grid each fill their column edge-to-edge.
 local CONTENT_W = PICKER_W - 28                                            -- usable width (14px pad each side)
 local FIELD_GAP = 8
@@ -46,6 +43,62 @@ addon.ParseHexColor = ParseHexColor
 -- Singleton state.
 local P            -- the picker frame (built lazily)
 local state = { spec = nil, r = 1, g = 1, b = 1, a = 1, hasAlpha = false, suppress = false, orig = {} }
+
+-- Account-wide saved palette: an ordered list of hex strings at the SavedVariables root
+-- (HorizonDB.customPalette), independent of profiles.
+local function PaletteStore()
+    local db = _G[addon.DATABASE]
+    if not db then return nil end
+    db.customPalette = db.customPalette or {}
+    return db.customPalette
+end
+
+local function ToHex(r, g, b)
+    return string.format("%02X%02X%02X", Round(r), Round(g), Round(b))
+end
+
+-- Returns an array of { r, g, b } from the stored hex list (skipping unparseable entries).
+local function LoadPalette()
+    local store, out = PaletteStore(), {}
+    if store then
+        for _, hex in ipairs(store) do
+            local r, g, b = ParseHexColor(hex)
+            if r then out[#out + 1] = { r, g, b } end
+        end
+    end
+    return out
+end
+
+local function AddCurrentToPalette()
+    addon.EnsureDB()
+    local store = PaletteStore()
+    if not store then return end
+    if #store >= PALETTE_CAP then return end
+    local hex = ToHex(state.r, state.g, state.b)
+    for _, h in ipairs(store) do
+        if type(h) == "string" and h:upper() == hex then return end  -- dedupe
+    end
+    store[#store + 1] = hex
+    if P and P.BuildPalette then P:BuildPalette() end
+end
+
+local function RemoveFromPalette(i)
+    local store = PaletteStore()
+    if not store or not store[i] then return end
+    table.remove(store, i)
+    if P and P.BuildPalette then P:BuildPalette() end
+end
+
+-- The player's class colour (ungated — always available as a quick-pick).
+local function PlayerClassColor()
+    local _, classFile = UnitClass("player")
+    if not classFile then return nil end
+    local cc = C_ClassColor and C_ClassColor.GetClassColor and C_ClassColor.GetClassColor(classFile)
+    if cc then return cc.r, cc.g, cc.b end
+    local rc = RAID_CLASS_COLORS and RAID_CLASS_COLORS[classFile]
+    if rc then return rc.r, rc.g, rc.b end
+    return nil
+end
 
 local function FireChange()
     local s = state.spec
@@ -135,8 +188,13 @@ local function EnsurePicker()
 
     -- Clean solid markers (the Blizzard UI-ColorPicker-Buttons sprite sheet drew a stray blob).
     local wheelThumb = cs:CreateTexture(nil, "OVERLAY")
-    wheelThumb:SetSize(10, 10); wheelThumb:SetColorTexture(1, 1, 1, 0.95)
+    wheelThumb:SetSize(12, 12); wheelThumb:SetColorTexture(1, 1, 1, 0.95)
     cs:SetColorWheelThumbTexture(wheelThumb)
+    -- Circular mask makes the wheel marker a clean circle (not a solid square).
+    local wheelThumbMask = cs:CreateMaskTexture(nil, "OVERLAY")
+    wheelThumbMask:SetTexture("Interface\\CHARACTERFRAME\\TempPortraitAlphaMask", "CLAMPTOBLACKADDITIVE", "CLAMPTOBLACKADDITIVE")
+    wheelThumbMask:SetAllPoints(wheelThumb)
+    wheelThumb:AddMaskTexture(wheelThumbMask)
 
     local value = cs:CreateTexture(nil, "OVERLAY")
     value:SetSize(VALUE_W, WHEEL_SIZE)
@@ -283,42 +341,94 @@ local function EnsurePicker()
     f.alphaRow = alphaRow
     f.placeAlpha = placeAlpha
 
-    -- Preset palette: class colour first, then commons. Wrapping grid, tucked beside the wheel.
-    local presetRow = CreateFrame("Frame", nil, f)
-    presetRow:SetPoint("TOPLEFT", cmp, "BOTTOMLEFT", 0, -10)
-    presetRow:SetPoint("RIGHT", f, "RIGHT", -14, 0)
-    presetRow:SetHeight(PRESET_SIZE * 2 + PRESET_GAP)
-    f.presetRow = presetRow
-    f.presetButtons = {}
-    local function presetButton(i)
-        local b = f.presetButtons[i]
+    -- Palette grid beside the wheel: class colour (auto) + saved colours (hover-× to remove) + "+".
+    local paletteRow = CreateFrame("Frame", nil, f)
+    paletteRow:SetPoint("TOPLEFT", cmp, "BOTTOMLEFT", 0, -10)
+    paletteRow:SetPoint("RIGHT", f, "RIGHT", -14, 0)
+    paletteRow:SetHeight(PRESET_SIZE * 2 + PRESET_GAP)
+    f.paletteRow = paletteRow
+    f.paletteButtons = {}
+    local function paletteButton(i)
+        local b = f.paletteButtons[i]
         if b then return b end
-        b = CreateFrame("Button", nil, presetRow)
+        b = CreateFrame("Button", nil, paletteRow)
         b:SetSize(PRESET_SIZE, PRESET_SIZE)
         local col = (i - 1) % PRESET_COLS
         local row = math.floor((i - 1) / PRESET_COLS)
-        b:SetPoint("TOPLEFT", presetRow, "TOPLEFT", col * (PRESET_SIZE + PRESET_GAP), -row * (PRESET_SIZE + PRESET_GAP))
+        b:SetPoint("TOPLEFT", paletteRow, "TOPLEFT", col * (PRESET_SIZE + PRESET_GAP), -row * (PRESET_SIZE + PRESET_GAP))
         local tex = b:CreateTexture(nil, "ARTWORK"); tex:SetAllPoints(b); b.tex = tex
         if addon.CreateBorder then addon.CreateBorder(b, Def.InputBorder) end
+        -- "+" glyph (shown on the add cell only).
+        local plus = b:CreateFontString(nil, "OVERLAY")
+        plus:SetFont(Def.FontPath, 16, Def.WidgetFontFlags or "OUTLINE")
+        plus:SetPoint("CENTER", b, "CENTER", 0, 0); plus:SetText("+")
+        plus:SetTextColor(Def.TextColorSection[1], Def.TextColorSection[2], Def.TextColorSection[3], 1)
+        plus:Hide(); b.plus = plus
+        -- × remove badge (saved cells only); a child button inside the swatch corner.
+        local xbadge = CreateFrame("Button", nil, b)
+        xbadge:SetSize(13, 13)
+        xbadge:SetPoint("TOPRIGHT", b, "TOPRIGHT", 0, 0)
+        xbadge:SetFrameLevel(b:GetFrameLevel() + 5)
+        local xbg = xbadge:CreateTexture(nil, "BACKGROUND"); xbg:SetAllPoints(xbadge)
+        xbg:SetColorTexture(0.75, 0.22, 0.17, 1)
+        local xtx = xbadge:CreateFontString(nil, "OVERLAY")
+        xtx:SetFont(Def.FontPath, 10, "OUTLINE")
+        xtx:SetAllPoints(xbadge)
+        xtx:SetJustifyH("CENTER"); xtx:SetJustifyV("MIDDLE")
+        xtx:SetText("\195\151")
+        xtx:SetTextColor(1, 1, 1, 1)
+        xbadge:Hide(); b.xbadge = xbadge
+        local function hideBadgeIfAway()
+            if not (b:IsMouseOver() or xbadge:IsMouseOver()) then xbadge:Hide() end
+        end
+        xbadge:SetScript("OnClick", function() if b._index then RemoveFromPalette(b._index) end end)
+        xbadge:SetScript("OnLeave", hideBadgeIfAway)
         b:SetScript("OnClick", function()
-            local c = b._color
-            if c then f.colorSelect:SetColorRGB(c[1], c[2], c[3]) end  -- OnColorSelect refreshes + fires
+            if b._kind == "add" then
+                AddCurrentToPalette()
+            elseif b._color then
+                f.colorSelect:SetColorRGB(b._color[1], b._color[2], b._color[3])  -- OnColorSelect refreshes + fires
+            end
         end)
-        f.presetButtons[i] = b
+        b:SetScript("OnEnter", function()
+            if b._kind == "saved" then
+                xbadge:Show()
+            elseif b._kind == "add" then
+                GameTooltip:SetOwner(b, "ANCHOR_RIGHT")
+                GameTooltip:SetText((L and L["COLOR_SAVE_CURRENT"]) or "Save current colour", 1, 1, 1, 1, true)
+                GameTooltip:Show()
+            end
+        end)
+        b:SetScript("OnLeave", function() GameTooltip:Hide(); hideBadgeIfAway() end)
+        f.paletteButtons[i] = b
         return b
     end
-    function f:BuildPresets()
-        local list = {}
-        local classColor = addon.GetOptionsClassColor and addon.GetOptionsClassColor()
-        if classColor then list[#list + 1] = { classColor[1], classColor[2], classColor[3] } end
-        for _, c in ipairs(PRESET_COMMON) do list[#list + 1] = c end
-        for i = 1, #list do
-            local b = presetButton(i)
-            b._color = list[i]
-            b.tex:SetColorTexture(list[i][1], list[i][2], list[i][3], 1)
+    function f:BuildPalette()
+        local cells = {}
+        local cr, cg, cb = PlayerClassColor()
+        if cr then cells[#cells + 1] = { kind = "class", color = { cr, cg, cb } } end
+        local saved = LoadPalette()
+        for idx = 1, #saved do
+            cells[#cells + 1] = { kind = "saved", color = saved[idx], index = idx }
+        end
+        if #saved < PALETTE_CAP then cells[#cells + 1] = { kind = "add" } end
+        for i = 1, #cells do
+            local cell = cells[i]
+            local b = paletteButton(i)
+            b._kind = cell.kind
+            b._index = cell.index
+            b._color = cell.color
+            b.xbadge:Hide()
+            if cell.kind == "add" then
+                b.tex:SetColorTexture(Def.InputBg[1], Def.InputBg[2], Def.InputBg[3], Def.InputBg[4])
+                b.plus:Show()
+            else
+                b.tex:SetColorTexture(cell.color[1], cell.color[2], cell.color[3], 1)
+                b.plus:Hide()
+            end
             b:Show()
         end
-        for i = #list + 1, #f.presetButtons do f.presetButtons[i]:Hide() end
+        for i = #cells + 1, #f.paletteButtons do f.paletteButtons[i]:Hide() end
     end
 
     -- Footer buttons.
@@ -394,7 +504,7 @@ function addon.OpenColorPicker(spec)
     if f.Refresh then f:Refresh() end
     f.alphaRow:SetShown(state.hasAlpha)
     if state.hasAlpha and f.placeAlpha then f.placeAlpha() end
-    f:BuildPresets()
+    f:BuildPalette()
     f:ClearAllPoints(); f:SetPoint("CENTER", UIParent, "CENTER", 0, 0)
     f:Show(); f:Raise()
 end

--- a/options/OptionsWidgets.lua
+++ b/options/OptionsWidgets.lua
@@ -120,7 +120,11 @@ local function SetSafeFont(fs, path, size, flags)
     if effFlags == nil then
         effFlags = Def.WidgetFontFlags or "OUTLINE"
         -- Register so OptionsWidgets_RefreshFonts can re-apply when WidgetFontFlags changes.
-        widgetFontRegistry[#widgetFontRegistry + 1] = { fs = fs, size = size }
+        -- Guard against duplicate entries when the same FontString is re-fonted (e.g. on refresh).
+        if not fs._horizonFontRegistered then
+            fs._horizonFontRegistered = true
+            widgetFontRegistry[#widgetFontRegistry + 1] = { fs = fs, size = size }
+        end
     end
     local ok = fs:SetFont(path, size, effFlags)
     if not ok then
@@ -156,18 +160,31 @@ local function ApplyOptionTooltip(frame, tooltip)
     end)
 end
 
+-- Combine an inline description and a hover tooltip into one tooltip string (blank-line separated).
+local function JoinTooltip(desc, tip)
+    return (desc or "") .. (desc and tip and "\n\n" or "") .. (tip or "")
+end
+
+-- Row hover-highlight geometry/timing.
+local ROW_HOVER_INSET_X = 18
+local ROW_HOVER_INSET_Y = 5
+local ROW_HOVER_ALPHA   = 0.025
+local ROW_HOVER_FADE    = 0.15
+-- Vertical spacing between a row's label and its (hidden) description, and the bottom pad.
+local ROW_LABEL_DESC_GAP  = 2
+local ROW_DESC_BOTTOM_PAD = 4
+
 local function ApplyRowHoverHighlight(row)
     if not row then return end
     local hiBg = row:CreateTexture(nil, "BACKGROUND", nil, -7) -- Behind track/thumb backgrounds
-    hiBg:SetPoint("TOPLEFT", row, "TOPLEFT", -18, 5)
-    hiBg:SetPoint("BOTTOMRIGHT", row, "BOTTOMRIGHT", 18, -5)
-    hiBg:SetColorTexture(1, 1, 1, 0.025)
+    hiBg:SetPoint("TOPLEFT", row, "TOPLEFT", -ROW_HOVER_INSET_X, ROW_HOVER_INSET_Y)
+    hiBg:SetPoint("BOTTOMRIGHT", row, "BOTTOMRIGHT", ROW_HOVER_INSET_X, -ROW_HOVER_INSET_Y)
+    hiBg:SetColorTexture(1, 1, 1, ROW_HOVER_ALPHA)
     hiBg:Hide()
-    
+
     row:EnableMouse(true)
     row:HookScript("OnEnter", function()
-        -- Fade in
-        UIFrameFadeIn(row.hoverHighlightFrame or hiBg, 0.15, 0, 1)
+        UIFrameFadeIn(hiBg, ROW_HOVER_FADE, 0, 1)
         hiBg:Show()
     end)
     row:HookScript("OnLeave", function()
@@ -221,7 +238,7 @@ function _G.OptionsWidgets_CreateToggleSwitch(parent, labelText, description, ge
     SetTextColor(desc, Def.TextColorSection)
     desc:SetText("")
     desc:Hide()
-    desc:SetPoint("TOPLEFT", label, "BOTTOMLEFT", 0, -2)
+    desc:SetPoint("TOPLEFT", label, "BOTTOMLEFT", 0, -ROW_LABEL_DESC_GAP)
     desc:SetPoint("RIGHT", track, "LEFT", -12, 0)
     desc:SetWordWrap(true)
 
@@ -231,10 +248,9 @@ function _G.OptionsWidgets_CreateToggleSwitch(parent, labelText, description, ge
     local function updateRowHeight()
         local descH = desc:GetStringHeight() or 0
         local labelH = label:GetStringHeight() or 0
-        local neededH = labelH + 2 + descH + 4
+        local neededH = labelH + ROW_LABEL_DESC_GAP + descH + ROW_DESC_BOTTOM_PAD
         local h = math.max(row._baseHeight, neededH)
         row:SetHeight(h)
-        row._measuredHeight = h
     end
     -- Defer measurement to after layout
     C_Timer.After(0, updateRowHeight)
@@ -292,11 +308,11 @@ function _G.OptionsWidgets_CreateToggleSwitch(parent, labelText, description, ge
     btn:SetScript("OnClick", function()
         if disabledFn and disabledFn() == true then return end
         if row.animStart then return end  -- Debounce: ignore clicks during animation (prevents double-click reverting)
-        local next = not get()
-        set(next)
+        local newOn = not get()
+        set(newOn)
         row.animStart = GetTime()
         row.animFrom = row.thumbPos
-        row.animTo = next and 1 or 0
+        row.animTo = newOn and 1 or 0
         track:SetScript("OnUpdate", toggleOnUpdate)
     end)
 
@@ -312,7 +328,7 @@ function _G.OptionsWidgets_CreateToggleSwitch(parent, labelText, description, ge
 
     row:Refresh()
     ApplyRowHoverHighlight(row)
-    local effectiveTooltip = (description or "") .. (description and tooltip and "\n\n" or "") .. (tooltip or "")
+    local effectiveTooltip = JoinTooltip(description, tooltip)
     ApplyOptionTooltip(row, effectiveTooltip)
     return row
 end
@@ -362,10 +378,38 @@ function _G.OptionsWidgets_CreateButton(parent, labelText, onClick, opts)
     return btn
 end
 
--- Slider: slim rounded track + draggable thumb + numeric readout
-local SLIDER_TRACK_HEIGHT = 6
-local SLIDER_THUMB_SIZE = 14
-local SLIDER_TRACK_INSET = 2
+-- Slider: chunky gradient bar + square handle (same height as the bar) + numeric readout
+local SLIDER_TRACK_HEIGHT     = 14   -- chunky bar
+local SLIDER_TRACK_INSET      = 0    -- fill spans the full bar height/width
+-- Square handle, same height as the bar; grows slightly in the active (hover/drag) state.
+local SLIDER_THUMB_W          = 14
+local SLIDER_THUMB_H          = 14
+local SLIDER_THUMB_W_ACTIVE   = 16
+local SLIDER_THUMB_H_ACTIVE   = 16
+-- Soft additive glow behind the handle.
+local SLIDER_GLOW_SIZE        = 28
+local SLIDER_GLOW_ALPHA_REST  = 0.30
+local SLIDER_GLOW_ALPHA_ON    = 0.80
+-- Hover/drag "active" ease duration (seconds).
+local SLIDER_ACTIVE_DUR       = 0.12
+-- Built-in glow texture (no custom assets).
+local SLIDER_GLOW_TEXTURE     = "Interface\\Cooldown\\star4"
+
+-- Apply the slim fill gradient (dark → accent) derived from the live Def.TrackOn, so a
+-- class-colour change retints it through the normal Refresh path. Falls back to a flat
+-- fill on clients without SetGradient/CreateColor.
+local function ApplyFillGradient(tex)
+    local c = Def.TrackOn
+    local a = c[4] or 0.85
+    if tex.SetGradient and CreateColor then
+        tex:SetColorTexture(1, 1, 1, 1)
+        tex:SetGradient("HORIZONTAL",
+            CreateColor(c[1] * 0.30, c[2] * 0.30, c[3] * 0.42, a),
+            CreateColor(math.min(1, c[1] * 1.12), math.min(1, c[2] * 1.12), math.min(1, c[3] * 1.12), a))
+    else
+        tex:SetColorTexture(c[1], c[2], c[3], a)
+    end
+end
 function _G.OptionsWidgets_CreateSlider(parent, labelText, description, get, set, minVal, maxVal, disabledFn, step, tooltip)
     -- step: snapping increment (default 1 = integer). Use e.g. 0.1 for one decimal place.
     step = step or 1
@@ -420,14 +464,24 @@ function _G.OptionsWidgets_CreateSlider(parent, labelText, description, get, set
     local trackFill = track:CreateTexture(nil, "ARTWORK")
     trackFill:SetPoint("TOPLEFT", track, "TOPLEFT", SLIDER_TRACK_INSET, -SLIDER_TRACK_INSET)
     trackFill:SetPoint("BOTTOMLEFT", track, "BOTTOMLEFT", SLIDER_TRACK_INSET, SLIDER_TRACK_INSET)
-    trackFill:SetColorTexture(Def.TrackOn[1], Def.TrackOn[2], Def.TrackOn[3], Def.TrackOn[4])
+    ApplyFillGradient(trackFill)
 
     local thumb = CreateFrame("Button", nil, track)
-    thumb:SetSize(SLIDER_THUMB_SIZE, SLIDER_THUMB_SIZE)
+    thumb:SetSize(SLIDER_THUMB_W, SLIDER_THUMB_H)
     thumb:SetPoint("CENTER", track, "LEFT", 0, 0)
-    local thumbTex = thumb:CreateTexture(nil, "BACKGROUND")
+    -- Square handle, same height as the bar (no mask needed).
+    local thumbTex = thumb:CreateTexture(nil, "ARTWORK")
     thumbTex:SetAllPoints(thumb)
     thumbTex:SetColorTexture(Def.ThumbColor[1], Def.ThumbColor[2], Def.ThumbColor[3], Def.ThumbColor[4])
+
+    -- Soft additive halo behind the handle; alpha rises in the active (hover/drag) state.
+    local glow = thumb:CreateTexture(nil, "BACKGROUND")
+    glow:SetTexture(SLIDER_GLOW_TEXTURE)
+    glow:SetBlendMode("ADD")
+    glow:SetSize(SLIDER_GLOW_SIZE, SLIDER_GLOW_SIZE)
+    glow:SetPoint("CENTER", thumb, "CENTER", 0, 0)
+    glow:SetVertexColor(Def.TrackOn[1], Def.TrackOn[2], Def.TrackOn[3])
+    glow:SetAlpha(SLIDER_GLOW_ALPHA_REST)
 
     local editWrap = CreateFrame("Frame", nil, row)
     editWrap:SetSize(44, 20)
@@ -499,24 +553,56 @@ function _G.OptionsWidgets_CreateSlider(parent, labelText, description, get, set
     end
 
     local fillWidth = trackWidth - 2 * SLIDER_TRACK_INSET
-    local thumbTravel = fillWidth - SLIDER_THUMB_SIZE
+    local thumbTravel = fillWidth - SLIDER_THUMB_W
 
     -- Now assign the body — all closures above that captured the upvalue slot will see this.
     updateFromValue = function(v)
         v = math.max(minVal, math.min(maxVal, v))
         local n = valueToNorm(v)
+        local center = SLIDER_TRACK_INSET + SLIDER_THUMB_W/2 + n * thumbTravel
         thumb:ClearAllPoints()
-        thumb:SetPoint("CENTER", track, "LEFT", SLIDER_TRACK_INSET + SLIDER_THUMB_SIZE/2 + n * thumbTravel, 0)
-        trackFill:SetWidth(n * fillWidth)
+        thumb:SetPoint("CENTER", track, "LEFT", center, 0)
+        trackFill:SetWidth(center)   -- fill the bar up to the handle centre
         edit:SetText(formatValue(v))
     end
 
+    -- Active (hover/drag) feedback: ease the handle larger + glow brighter over SLIDER_ACTIVE_DUR.
+    local activeCur, activeTarget = 0, 0
+    local function applyThumbState(t)
+        local w = SLIDER_THUMB_W + (SLIDER_THUMB_W_ACTIVE - SLIDER_THUMB_W) * t
+        local h = SLIDER_THUMB_H + (SLIDER_THUMB_H_ACTIVE - SLIDER_THUMB_H) * t
+        thumb:SetSize(w, h)
+        glow:SetAlpha(SLIDER_GLOW_ALPHA_REST + (SLIDER_GLOW_ALPHA_ON - SLIDER_GLOW_ALPHA_REST) * t)
+    end
+    local function tickThumbAnim(_, elapsed)
+        local stepAmt = (SLIDER_ACTIVE_DUR > 0) and (elapsed / SLIDER_ACTIVE_DUR) or 1
+        if activeCur < activeTarget then
+            activeCur = math.min(activeTarget, activeCur + stepAmt)
+        else
+            activeCur = math.max(activeTarget, activeCur - stepAmt)
+        end
+        applyThumbState(activeCur)
+        if activeCur == activeTarget then
+            thumb:SetScript("OnUpdate", nil)
+        end
+    end
+    local function setThumbActive(on)
+        if disabledFn and disabledFn() == true then on = false end
+        local tgt = on and 1 or 0
+        if tgt == activeTarget then return end
+        activeTarget = tgt
+        thumb:SetScript("OnUpdate", tickThumbAnim)
+    end
+    applyThumbState(0)
+
     local dragging = false
+    local rowHovered = false
     local startNorm, startX
     thumb:SetScript("OnMouseDown", function(_, btn)
         if btn ~= "LeftButton" then return end
         if disabledFn and disabledFn() == true then return end
         dragging = true
+        setThumbActive(true)
         startNorm = valueToNorm(get())
         local scale = track:GetEffectiveScale()
         startX = GetCursorPosition() / scale
@@ -525,6 +611,7 @@ function _G.OptionsWidgets_CreateSlider(parent, labelText, description, get, set
             if not IsMouseButtonDown("LeftButton") then
                 thumb:GetParent():SetScript("OnUpdate", nil)
                 dragging = false
+                if not rowHovered then setThumbActive(false) end
                 -- Commit final value on release so the DB is up-to-date.
                 local finalV = snapToStep(math.max(minVal, math.min(maxVal, normToValue(startNorm))))
                 if finalV ~= lastCommittedSnapped then
@@ -536,20 +623,21 @@ function _G.OptionsWidgets_CreateSlider(parent, labelText, description, get, set
             local delta = (x - startX) / fillWidth
             local n = math.max(0, math.min(1, startNorm + delta))
             local v = normToValue(n)
-            -- Update visual every frame for smooth thumb movement.
-            updateFromValue(v)
             -- Only call set() when the snapped value changes.
             local snappedV = snapToStep(v)
             if snappedV ~= lastCommittedSnapped then
                 lastCommittedSnapped = snappedV
                 set(snappedV)
             end
+            -- Update the visual LAST so the smooth position wins over any row:Refresh()
+            -- the set() callback may trigger (which would otherwise snap the handle = lag).
+            updateFromValue(v)
             startNorm = n
             startX = x
         end)
     end)
 
-    local function applyDisabledVisual()
+    local function applyDisabledVisuals()
         local dis = disabledFn and disabledFn() == true
         local alpha = dis and 0.35 or 1
         label:SetAlpha(alpha)
@@ -557,6 +645,7 @@ function _G.OptionsWidgets_CreateSlider(parent, labelText, description, get, set
         track:SetAlpha(alpha)
         editWrap:SetAlpha(alpha)
         if dis then
+            setThumbActive(false)
             edit:EnableMouse(false)
         else
             edit:EnableMouse(true)
@@ -564,14 +653,31 @@ function _G.OptionsWidgets_CreateSlider(parent, labelText, description, get, set
     end
 
     function row:Refresh()
-        trackFill:SetColorTexture(Def.TrackOn[1], Def.TrackOn[2], Def.TrackOn[3], Def.TrackOn[4])
-        updateFromValue(get())
-        applyDisabledVisual()
+        ApplyFillGradient(trackFill)
+        glow:SetVertexColor(Def.TrackOn[1], Def.TrackOn[2], Def.TrackOn[3])
+        -- Don't reposition the handle from the DB mid-drag; the drag handler owns it.
+        if not dragging then updateFromValue(get()) end
+        applyDisabledVisuals()
     end
 
     row:Refresh()
     ApplyRowHoverHighlight(row)
-    local effectiveTooltip = (description or "") .. (description and tooltip and "\n\n" or "") .. (tooltip or "")
+    local function onHoverEnter()
+        rowHovered = true
+        setThumbActive(true)
+    end
+    local function onHoverLeave()
+        -- The handle is a mouse-enabled child, so moving onto it fires the row's OnLeave even
+        -- though the cursor is still within the row. Stay active while over either.
+        if row:IsMouseOver() or thumb:IsMouseOver() then return end
+        rowHovered = false
+        if not dragging then setThumbActive(false) end
+    end
+    row:HookScript("OnEnter", onHoverEnter)
+    row:HookScript("OnLeave", onHoverLeave)
+    thumb:HookScript("OnEnter", onHoverEnter)
+    thumb:HookScript("OnLeave", onHoverLeave)
+    local effectiveTooltip = JoinTooltip(description, tooltip)
     ApplyOptionTooltip(row, effectiveTooltip)
     return row
 end
@@ -588,6 +694,44 @@ local SECTION_CARD_BACKDROP = {
 
 -- Sentinel stored in DB for "use global font" per-element pickers (must match OptionsData FONT_USE_GLOBAL / Vista GLOBAL_SENTINEL).
 local DROPDOWN_FONT_GLOBAL_SENTINEL = "__global__"
+
+-- Monotonic counter for unique, stable dropdown ESC-catch frame names (was derived from tostring(row)).
+local dropdownCatchCounter = 0
+
+-- Dropdown popup layout.
+local DROPDOWN_SEARCH_BOX_H = 36   -- height of the search box atop searchable lists
+local DROPDOWN_ROW_H        = 22   -- list row height
+local DROPDOWN_ROW_H_FONT   = 24   -- list row height when previewing fonts (taller)
+local DROPDOWN_MAX_LIST_H   = 330  -- max popup list height before scrolling
+-- Inset the row hover highlight so it floats inside the rounded popup instead of bleeding to the edges.
+local DROPDOWN_HI_INSET_X   = 4
+local DROPDOWN_HI_INSET_Y   = 1
+
+-- Normalise dropdown option input (dense array of {name,value[,disabled]} or a name->value map)
+-- into a dense array, alpha-sorted unless preserveOrder (the "__global__" sentinel sorts first).
+local function NormalizeDropdownOptions(opts, preserveOrder)
+    if type(opts) ~= "table" then return {} end
+    local out = {}
+    for k, v in pairs(opts) do
+        if type(k) == "number" and type(v) == "table" then
+            -- Expected shape: { name, value [, disabled] } — [3] truthy = not selectable (grey label, click closes list only).
+            out[#out + 1] = v
+        elseif type(k) == "string" then
+            -- Map shape: name -> value
+            out[#out + 1] = { k, v }
+        end
+    end
+    if not preserveOrder then
+        table.sort(out, function(a, b)
+            local aVal = a and a[2]
+            local bVal = b and b[2]
+            if aVal == "__global__" then return true end
+            if bVal == "__global__" then return false end
+            return tostring(a and a[1] or "") < tostring(b and b[1] or "")
+        end)
+    end
+    return out
+end
 
 -- Custom dropdown: button + popup list (no UIDropDownMenuTemplate)
 -- When searchable is true, adds an EditBox above the list to filter options by name (e.g. font dropdown).
@@ -740,18 +884,16 @@ function _G.OptionsWidgets_CreateCustomDropdown(parent, labelText, description, 
     -- Ensure the dropdown list scrolls internally and doesn't forward wheel events to the parent panel.
     scrollFrame:EnableMouseWheel(true)
     list:EnableMouseWheel(true)
-    if not InCombatLockdown() then
-        scrollFrame:SetPropagateMouseMotion(false)
-        list:SetPropagateMouseMotion(false)
-    end
+    -- SetPropagateMouseMotion is not a protected method, so no combat guard is needed; calling it
+    -- unconditionally also covers dropdowns first built in combat (avoids hover bleed-through).
+    scrollFrame:SetPropagateMouseMotion(false)
+    list:SetPropagateMouseMotion(false)
 
     -- Row height for open list; updated in populate when fontPreviewInList (taller rows for glyph clearance).
     local listRowHeight = 22
 
-    local function consumeWheel() end
     scrollFrame:SetScript("OnMouseWheel", function(self, delta)
         if not list:IsShown() then return end
-        if self.StopMovingOrSizing then self:StopMovingOrSizing() end -- no-op consume
         local step = listRowHeight * 3
         local cur = self:GetVerticalScroll() or 0
         local childH = (scrollChild and scrollChild:GetHeight()) or 0
@@ -761,12 +903,13 @@ function _G.OptionsWidgets_CreateCustomDropdown(parent, labelText, description, 
         self:SetVerticalScroll(new)
     end)
     -- Capture mouse wheel on the outer list too, so the options panel underneath doesn't scroll.
-    list:SetScript("OnMouseWheel", function() consumeWheel() end)
+    list:SetScript("OnMouseWheel", function() end)
 
     -- Keep our own list of option buttons; GetNumChildren()/GetChildren() is unreliable.
     local optionButtons = {}
 
-    local catch = CreateFrame("Button", "HorizonSuite_DropdownCatch" .. tostring(row):gsub("table: ", ""), UIParent)
+    dropdownCatchCounter = dropdownCatchCounter + 1
+    local catch = CreateFrame("Button", "HorizonSuite_DropdownCatch" .. dropdownCatchCounter, UIParent)
     catch:SetFrameStrata("TOOLTIP")
     catch:SetAllPoints(UIParent)
     catch:Hide()
@@ -838,39 +981,15 @@ function _G.OptionsWidgets_CreateCustomDropdown(parent, labelText, description, 
         closeList()
     end
 
-    local function normalizeOptions(opts)
-        if type(opts) ~= "table" then return {} end
-        -- Rebuild into a dense array.
-        local out = {}
-        for k, v in pairs(opts) do
-            if type(k) == "number" and type(v) == "table" then
-                -- Expected shape: { name, value [, disabled] } — [3] truthy = not selectable (grey label, click closes list only).
-                out[#out + 1] = v
-            elseif type(k) == "string" then
-                -- Map shape: name -> value
-                out[#out + 1] = { k, v }
-            end
-        end
-        if not preserveOrder then
-            table.sort(out, function(a, b)
-                local aVal = a and a[2]
-                local bVal = b and b[2]
-                if aVal == "__global__" then return true end
-                if bVal == "__global__" then return false end
-                return tostring(a and a[1] or "") < tostring(b and b[1] or "")
-            end)
-        end
-        return out
-    end
 
-    local SEARCH_BOX_HEIGHT = searchable and 36 or 0
+    local SEARCH_BOX_HEIGHT = searchable and DROPDOWN_SEARCH_BOX_H or 0
 
     local function populate()
         list:SetParent(UIParent)
         list:ClearAllPoints()
         list:SetPoint("TOPLEFT", btn, "BOTTOMLEFT", 0, -2)
 
-        local fullOpts = normalizeOptions((type(options) == "function" and options()) or options or {})
+        local fullOpts = NormalizeDropdownOptions((type(options) == "function" and options()) or options or {}, preserveOrder)
         local opts = fullOpts
         if searchable and searchEdit then
             local filterText = searchEdit:GetText()
@@ -888,9 +1007,9 @@ function _G.OptionsWidgets_CreateCustomDropdown(parent, labelText, description, 
 
         local num = #opts
 
-        local rowH = fontPreviewInList and 24 or 22
+        local rowH = fontPreviewInList and DROPDOWN_ROW_H_FONT or DROPDOWN_ROW_H
         listRowHeight = rowH
-        local maxHeight = 330
+        local maxHeight = DROPDOWN_MAX_LIST_H
         local totalHeight = num * rowH
 
         list:SetWidth(btn:GetWidth())
@@ -918,7 +1037,8 @@ function _G.OptionsWidgets_CreateCustomDropdown(parent, labelText, description, 
                 b.text = tb
 
                 local hi = b:CreateTexture(nil, "BACKGROUND")
-                hi:SetAllPoints(b)
+                hi:SetPoint("TOPLEFT", b, "TOPLEFT", DROPDOWN_HI_INSET_X, -DROPDOWN_HI_INSET_Y)
+                hi:SetPoint("BOTTOMRIGHT", b, "BOTTOMRIGHT", -DROPDOWN_HI_INSET_X, DROPDOWN_HI_INSET_Y)
                 hi:SetColorTexture(1, 1, 1, 0.06)
                 hi:Hide()
                 b._dropdownHi = hi
@@ -1009,7 +1129,7 @@ function _G.OptionsWidgets_CreateCustomDropdown(parent, labelText, description, 
             if newLabel then label:SetText(newLabel) end
         end
         local val = get()
-        local opts = normalizeOptions((type(options) == "function" and options()) or options or {})
+        local opts = NormalizeDropdownOptions((type(options) == "function" and options()) or options or {}, preserveOrder)
 
         for _, opt in ipairs(opts) do
             local optVal = opt[2]
@@ -1052,9 +1172,38 @@ function _G.OptionsWidgets_CreateCustomDropdown(parent, labelText, description, 
 
     row:Refresh()
     ApplyRowHoverHighlight(row)
-    local effectiveTooltip = (description or "") .. (description and tooltip and "\n\n" or "") .. (tooltip or "")
+    local effectiveTooltip = JoinTooltip(description, tooltip)
     ApplyOptionTooltip(row, effectiveTooltip)
     return row
+end
+
+-- Live alpha from the open ColorPickerFrame (modern GetColorAlpha; legacy inverted GetOpacity).
+local function ResolvePickerAlpha()
+    return (type(ColorPickerFrame.GetColorAlpha) == "function" and ColorPickerFrame:GetColorAlpha())
+        or (type(ColorPickerFrame.GetOpacity) == "function" and (1 - ColorPickerFrame:GetOpacity()))
+        or 1
+end
+
+-- Alpha from a "previous values" table (modern .a; legacy inverted .opacity), for cancel-restore.
+local function ResolvePrevAlpha(p)
+    return (type(p.a) == "number" and p.a)
+        or (type(p.opacity) == "number" and (1 - p.opacity))
+        or 1
+end
+
+-- Parse a hex colour string ("ff0000", "#ff0000", "f00" shorthand) to r, g, b in 0-1, or nil.
+local function ParseHexColor(raw)
+    if type(raw) ~= "string" then return nil end
+    local hex = raw:gsub("^#", ""):gsub("%s+", "")
+    if #hex < 3 then return nil end
+    if #hex == 3 then hex = hex:gsub("(%x)(%x)(%x)", "%1%1%2%2%3%3") end
+    hex = hex:sub(1, 6)
+    while #hex < 6 do hex = hex .. "0" end
+    local r = tonumber(hex:sub(1, 2), 16)
+    local g = tonumber(hex:sub(3, 4), 16)
+    local b = tonumber(hex:sub(5, 6), 16)
+    if not r or not g or not b then return nil end
+    return r / 255, g / 255, b / 255
 end
 
 -- Helper: get effective color from ColorPickerFrame, preferring HexBox if user typed hex (10.2.5+).
@@ -1066,20 +1215,8 @@ local function GetColorPickerEffectiveRGB()
     if hexBox and hexBox.GetText then
         local raw = hexBox:GetText()
         if type(raw) == "string" and #raw > 0 then
-            local hex = raw:gsub("^#", ""):gsub("%s+", "")
-            if #hex >= 3 then
-                if #hex == 3 then
-                    hex = hex:gsub("(%x)(%x)(%x)", "%1%1%2%2%3%3")
-                end
-                hex = hex:sub(1, 6)
-                while #hex < 6 do hex = hex .. "0" end
-                local r = tonumber(hex:sub(1, 2), 16)
-                local g = tonumber(hex:sub(3, 4), 16)
-                local b = tonumber(hex:sub(5, 6), 16)
-                if r and g and b then
-                    return r / 255, g / 255, b / 255
-                end
-            end
+            local r, g, b = ParseHexColor(raw)
+            if r then return r, g, b end
         end
     end
     return ColorPickerFrame:GetColorRGB()
@@ -1093,16 +1230,8 @@ local function SyncHexBoxToPicker()
     if not hexBox or not hexBox.GetText then return end
     local raw = hexBox:GetText()
     if type(raw) ~= "string" or #raw < 3 then return end
-    local hex = raw:gsub("^#", ""):gsub("%s+", "")
-    if #hex < 3 then return end
-    if #hex == 3 then hex = hex:gsub("(%x)(%x)(%x)", "%1%1%2%2%3%3") end
-    hex = hex:sub(1, 6)
-    while #hex < 6 do hex = hex .. "0" end
-    local r = tonumber(hex:sub(1, 2), 16)
-    local g = tonumber(hex:sub(3, 4), 16)
-    local b = tonumber(hex:sub(5, 6), 16)
-    if not r or not g or not b then return end
-    r, g, b = r / 255, g / 255, b / 255
+    local r, g, b = ParseHexColor(raw)
+    if not r then return end
     local cp = content.ColorPicker
     local swatchCurrent = content.ColorSwatchCurrent
     if cp and cp.SetColorRGB then cp:SetColorRGB(r, g, b) end
@@ -1169,7 +1298,9 @@ function _G.OptionsWidgets_CreateColorSwatchRow(parent, anchor, labelText, defau
     addon.CreateBorder(swatch, Def.SectionCardBorder)
     swatch.tex = tex
     local def = defaultTbl and #defaultTbl >= 3 and defaultTbl or { 0.5, 0.5, 0.5 }
-    function swatch:Refresh()
+    -- Decode the current colour from getTbl(): supports {r,g,b[,a]} tables and the legacy
+    -- numeric multi-return, falling back to def. Honours hasAlpha.
+    local function readColor()
         local r, g, b, a = def[1], def[2], def[3], def[4] or 1
         if getTbl then
             local result = getTbl()
@@ -1184,6 +1315,10 @@ function _G.OptionsWidgets_CreateColorSwatchRow(parent, anchor, labelText, defau
                 end
             end
         end
+        return r, g, b, a
+    end
+    function swatch:Refresh()
+        local r, g, b, a = readColor()
         if hasAlpha then
             tex:SetColorTexture(r, g, b, a)
         else
@@ -1193,20 +1328,7 @@ function _G.OptionsWidgets_CreateColorSwatchRow(parent, anchor, labelText, defau
     swatch:SetScript("OnClick", function()
         if disabledFn and disabledFn() then return end
         if not ColorPickerFrame or not ColorPickerFrame.SetupColorPickerAndShow then return end
-        local r, g, b, a = def[1], def[2], def[3], def[4] or 1
-        if getTbl then
-            local result = getTbl()
-            if type(result) == "table" and result[1] then
-                r, g, b = result[1], result[2], result[3]
-                if hasAlpha and type(result[4]) == "number" then a = result[4] end
-            elseif type(result) == "number" then
-                local rVal, gVal, bVal, aVal = getTbl()
-                if type(rVal) == "number" and type(gVal) == "number" and type(bVal) == "number" then
-                    r, g, b = rVal, gVal, bVal
-                    if hasAlpha and type(aVal) == "number" then a = aVal end
-                end
-            end
-        end
+        local r, g, b, a = readColor()
         addon._colorPickerLive = true
         _activeColorPickerCallbacks = { setKeyVal = setKeyVal, notify = notify, tex = tex }
         ColorPickerFrame:SetupColorPickerAndShow({
@@ -1217,9 +1339,7 @@ function _G.OptionsWidgets_CreateColorSwatchRow(parent, anchor, labelText, defau
             swatchFunc = function()
                 local nr, ng, nb = GetColorPickerEffectiveRGB()
                 if hasAlpha then
-                    local na = (type(ColorPickerFrame.GetColorAlpha) == "function" and ColorPickerFrame:GetColorAlpha())
-                               or (type(ColorPickerFrame.GetOpacity) == "function" and (1 - ColorPickerFrame:GetOpacity()))
-                               or 1
+                    local na = ResolvePickerAlpha()
                     setKeyVal({ nr, ng, nb, na })
                     tex:SetColorTexture(nr, ng, nb, na)
                 else
@@ -1234,9 +1354,7 @@ function _G.OptionsWidgets_CreateColorSwatchRow(parent, anchor, labelText, defau
                 if p and type(p.r) == "number" and type(p.g) == "number" and type(p.b) == "number" then
                     if hasAlpha then
                         -- modern WoW stores alpha as pv.a; legacy stored inverted pv.opacity
-                        local oa = (type(p.a) == "number" and p.a)
-                                   or (type(p.opacity) == "number" and (1 - p.opacity))
-                                   or 1
+                        local oa = ResolvePrevAlpha(p)
                         setKeyVal({ p.r, p.g, p.b, oa })
                     else
                         setKeyVal({ p.r, p.g, p.b })
@@ -1255,9 +1373,7 @@ function _G.OptionsWidgets_CreateColorSwatchRow(parent, anchor, labelText, defau
                 _activeColorPickerCallbacks = nil
                 local nr, ng, nb = GetColorPickerEffectiveRGB()
                 if hasAlpha then
-                    local na = (type(ColorPickerFrame.GetColorAlpha) == "function" and ColorPickerFrame:GetColorAlpha())
-                               or (type(ColorPickerFrame.GetOpacity) == "function" and (1 - ColorPickerFrame:GetOpacity()))
-                               or 1
+                    local na = ResolvePickerAlpha()
                     setKeyVal({ nr, ng, nb, na })
                     tex:SetColorTexture(nr, ng, nb, na)
                 else
@@ -1308,8 +1424,7 @@ function _G.OptionsWidgets_CreateMiniSwatch(parent, labelText, defaultTbl, getTb
     local tex = swatch:CreateTexture(nil, "BACKGROUND")
     tex:SetPoint("TOPLEFT", swatch, "TOPLEFT", 1, -1)
     tex:SetPoint("BOTTOMRIGHT", swatch, "BOTTOMRIGHT", -1, 1)
-    local addon = _G.HorizonSuite
-    if addon and addon.CreateBorder then
+    if addon.CreateBorder then
         addon.CreateBorder(swatch, Def.SectionCardBorder)
     end
     swatch.tex = tex
@@ -1451,9 +1566,7 @@ function _G.OptionsWidgets_CreateColorSwatch(parent, labelText, description, get
                 if not pickerReady then return end
                 local nr, ng, nb = GetColorPickerEffectiveRGB()
                 if hasAlpha then
-                    local na = (type(ColorPickerFrame.GetColorAlpha) == "function" and ColorPickerFrame:GetColorAlpha())
-                               or (type(ColorPickerFrame.GetOpacity) == "function" and (1 - ColorPickerFrame:GetOpacity()))
-                               or 1
+                    local na = ResolvePickerAlpha()
                     set(nr, ng, nb, na)
                     tex:SetColorTexture(nr, ng, nb, na)
                 else
@@ -1468,9 +1581,7 @@ function _G.OptionsWidgets_CreateColorSwatch(parent, labelText, description, get
                 if pv and type(pv.r) == "number" and type(pv.g) == "number" and type(pv.b) == "number" then
                     if hasAlpha then
                         -- modern WoW stores alpha as pv.a; legacy stored inverted pv.opacity
-                        local oa = (type(pv.a) == "number" and pv.a)
-                                   or (type(pv.opacity) == "number" and (1 - pv.opacity))
-                                   or 1
+                        local oa = ResolvePrevAlpha(pv)
                         set(pv.r, pv.g, pv.b, oa)
                     else
                         set(pv.r, pv.g, pv.b, 1)
@@ -1483,9 +1594,7 @@ function _G.OptionsWidgets_CreateColorSwatch(parent, labelText, description, get
                 _activeColorPickerCallbacks = nil
                 local nr, ng, nb = GetColorPickerEffectiveRGB()
                 if hasAlpha then
-                    local na = (type(ColorPickerFrame.GetColorAlpha) == "function" and ColorPickerFrame:GetColorAlpha())
-                               or (type(ColorPickerFrame.GetOpacity) == "function" and (1 - ColorPickerFrame:GetOpacity()))
-                               or 1
+                    local na = ResolvePickerAlpha()
                     set(nr, ng, nb, na)
                 else
                     set(nr, ng, nb, 1)
@@ -1493,18 +1602,7 @@ function _G.OptionsWidgets_CreateColorSwatch(parent, labelText, description, get
                 swatch:Refresh()
             end,
         }
-        if ColorPickerFrame.SetupColorPickerAndShow then
-            ColorPickerFrame:SetupColorPickerAndShow(info)
-        else
-            -- Legacy WoW support
-            ColorPickerFrame.func = info.swatchFunc
-            ColorPickerFrame.cancelFunc = info.cancelFunc
-            ColorPickerFrame.opacityFunc = info.swatchFunc
-            ColorPickerFrame.hasOpacity = info.hasOpacity
-            ColorPickerFrame.opacity = info.opacity
-            ColorPickerFrame:SetColorRGB(info.r, info.g, info.b)
-            ColorPickerFrame:Show()
-        end
+        ColorPickerFrame:SetupColorPickerAndShow(info)
         EnsureHexBoxHooked()
         C_Timer.After(0, function() pickerReady = true end)
     end)
@@ -1515,7 +1613,7 @@ function _G.OptionsWidgets_CreateColorSwatch(parent, labelText, description, get
 
     row:Refresh()
     ApplyRowHoverHighlight(row)
-    local effectiveTooltip = (description or "") .. (description and tooltip and "\n\n" or "") .. (tooltip or "")
+    local effectiveTooltip = JoinTooltip(description, tooltip)
     ApplyOptionTooltip(row, effectiveTooltip)
     return row
 end
@@ -1524,7 +1622,6 @@ end
 -- onTextChanged(text) called on input.
 local SEARCH_ICON_LEFT = 28
 local SEARCH_CLEAR_SIZE = 20
-local SEARCH_CARD_INSET = 4
 local SEARCH_BAR_BACKDROP = {
     bgFile   = "Interface\\ChatFrame\\ChatFrameBackground",
     edgeFile = "Interface\\Tooltips\\UI-Tooltip-Border",
@@ -1533,7 +1630,7 @@ local SEARCH_BAR_BACKDROP = {
     edgeSize = 12,
     insets   = { left = 3, right = 3, top = 3, bottom = 3 },
 }
-function OptionsWidgets_CreateSearchInput(parent, onTextChanged, placeholder)
+function _G.OptionsWidgets_CreateSearchInput(parent, onTextChanged, placeholder)
     local row = CreateFrame("Frame", nil, parent)
     row:SetAllPoints(parent)
     local editWrapper = CreateFrame("Frame", nil, row, "BackdropTemplate")
@@ -1797,6 +1894,9 @@ end
 local REORDER_ROW_GAP = 4
 local REORDER_ROW_HEIGHT = 24
 local REORDER_AUTOSCROLL_MARGIN = 40
+local REORDER_HEADER_PAD = 14   -- gap below the card header before the first row
+local REORDER_RESET_GAP = 6     -- gap above the reset-to-default button
+local REORDER_RESET_H = 22      -- reset button height
 local REORDER_AUTOSCROLL_STEP = 10
 
 --- Create a drag-to-reorder list widget (e.g. for Focus category order). Rows show labelMap[key]; opt.get/set provide order array.
@@ -1807,7 +1907,7 @@ local REORDER_AUTOSCROLL_STEP = 10
 -- @param panelRef table Options panel for scroll region
 -- @param notifyMainAddonFn function Called when order changes (e.g. to refresh tracker)
 -- @return table Container frame
-function OptionsWidgets_CreateReorderList(parent, anchor, opt, scrollFrameRef, panelRef, notifyMainAddonFn)
+function _G.OptionsWidgets_CreateReorderList(parent, anchor, opt, scrollFrameRef, panelRef, notifyMainAddonFn)
     local keys = opt.get and opt.get() or {}
     if type(keys) == "function" then keys = keys() end
     if type(keys) ~= "table" then keys = {} end
@@ -1975,14 +2075,15 @@ function OptionsWidgets_CreateReorderList(parent, anchor, opt, scrollFrameRef, p
         state.set(orderedKeys)
         repositionRows(orderedKeys)
         if notifyMainAddonFn then
-                notifyMainAddonFn()
+            notifyMainAddonFn()
         end
     end
 
-
     local function onReorderUpdate()
-    if not state.active or not IsMouseButtonDown("LeftButton") then
-        applyReorderAndCleanup() return end
+        if not state.active or not IsMouseButtonDown("LeftButton") then
+            applyReorderAndCleanup()
+            return
+        end
 
         local ghost = ensureGhost()
         local line = ensureInsertionLine()
@@ -2083,7 +2184,7 @@ function OptionsWidgets_CreateReorderList(parent, anchor, opt, scrollFrameRef, p
     resetBtn:SetPoint("TOPLEFT", prevAnchor, "BOTTOMLEFT", 0, -6)
 
     local presetH = presetRow and (8 + 56) or 0
-    local totalH = Def.CardPadding + 14 + presetH + (#keys * (REORDER_ROW_HEIGHT + REORDER_ROW_GAP)) + 6 + 22 + Def.CardPadding
+    local totalH = Def.CardPadding + REORDER_HEADER_PAD + presetH + (#keys * (REORDER_ROW_HEIGHT + REORDER_ROW_GAP)) + REORDER_RESET_GAP + REORDER_RESET_H + Def.CardPadding
     container:SetHeight(totalH)
     container.searchText = ((opt.name or "order") .. " " .. (opt.desc or "") .. " " .. (opt.tooltip or "")):lower()
     function container:Refresh()
@@ -2193,80 +2294,96 @@ function _G.OptionsWidgets_CreateBlacklistGrid(parent, labelText, opts)
     listFrame:SetPoint("RIGHT", container, "RIGHT", 0, 0)
     listFrame:SetHeight(1)
 
-    local rowWidgets = {}
+    -- Pooled rows: WoW never GCs CreateFrame objects, so creating fresh rows on every Rebuild()
+    -- (fired on each unblock click and on dashboard refresh sweeps) would leak unboundedly.
+    -- Rows are reused; each row's unblock button reads row._questID, re-pointed every Rebuild.
+    local BLACKLIST_ROW_H    = 24
+    local BLACKLIST_ROW_STEP = 28
+    local BLACKLIST_EMPTY_H  = 20
+    local rowPool = {}
+    local emptyRow
 
-    local function Rebuild()
-        for _, rw in ipairs(rowWidgets) do rw:Hide() end
-        wipe(rowWidgets)
+    local Rebuild   -- forward declaration (doUnblock calls it)
+
+    local function doUnblock(questID)
+        if addon.GetDB then
+            local bl = addon.GetDB("questBlacklist", nil)
+            if bl and type(bl) == "table" then
+                bl[questID] = nil
+                if next(bl) == nil then bl = nil end
+                if addon.SetDB then addon.SetDB("questBlacklist", bl) end
+            end
+        end
+        Rebuild()
+        if addon.OptionsData_NotifyMainAddon then addon.OptionsData_NotifyMainAddon() end
+    end
+
+    local function acquireRow(i)
+        local row = rowPool[i]
+        if row then return row end
+        row = CreateFrame("Frame", nil, listFrame)
+        row:SetHeight(BLACKLIST_ROW_H)
+        local nameLbl = row:CreateFontString(nil, "OVERLAY")
+        SetSafeFont(nameLbl, Def.FontPath, Def.LabelSize, nil)
+        SetTextColor(nameLbl, Def.TextColorLabel)
+        nameLbl:SetPoint("LEFT", row, "LEFT", 0, 0)
+        nameLbl:SetJustifyH("LEFT")
+        row.nameLbl = nameLbl
+        local unblockBtn = _G.OptionsWidgets_CreateButton(row, L["UNBLOCK"], function()
+            doUnblock(row._questID)
+        end, { width = 70, height = 20 })
+        unblockBtn:SetPoint("RIGHT", row, "RIGHT", -4, 0)
+        rowPool[i] = row
+        return row
+    end
+
+    function Rebuild()
+        for _, row in ipairs(rowPool) do row:Hide() end
+        if emptyRow then emptyRow:Hide() end
 
         local blacklist = addon.GetDB and addon.GetDB("questBlacklist", nil) or nil
-        if not blacklist or type(blacklist) ~= "table" then
-            local emptyLabel = listFrame:CreateFontString(nil, "OVERLAY")
-            SetSafeFont(emptyLabel, Def.FontPath, Def.SectionSize, nil)
-            SetTextColor(emptyLabel, Def.TextColorSection)
-            emptyLabel:SetText(L["HIDDEN_QUESTS"])
-            emptyLabel:SetPoint("TOPLEFT", listFrame, "TOPLEFT", 0, 0)
-            local emptyRow = CreateFrame("Frame", nil, listFrame)
-            emptyRow:SetHeight(20)
-            emptyRow:SetPoint("TOPLEFT", listFrame, "TOPLEFT", 0, 0)
-            emptyRow:SetPoint("RIGHT", listFrame, "RIGHT", 0, 0)
-            rowWidgets[1] = emptyRow
-            listFrame:SetHeight(20)
-            container:SetHeight(BLACKLIST_HEADER_H + 20)
+        if not blacklist or type(blacklist) ~= "table" or next(blacklist) == nil then
+            if not emptyRow then
+                emptyRow = CreateFrame("Frame", nil, listFrame)
+                emptyRow:SetHeight(BLACKLIST_EMPTY_H)
+                emptyRow:SetPoint("TOPLEFT", listFrame, "TOPLEFT", 0, 0)
+                emptyRow:SetPoint("RIGHT", listFrame, "RIGHT", 0, 0)
+                local emptyLabel = emptyRow:CreateFontString(nil, "OVERLAY")
+                SetSafeFont(emptyLabel, Def.FontPath, Def.SectionSize, nil)
+                SetTextColor(emptyLabel, Def.TextColorSection)
+                emptyLabel:SetText(L["HIDDEN_QUESTS"])
+                emptyLabel:SetPoint("TOPLEFT", emptyRow, "TOPLEFT", 0, 0)
+            end
+            emptyRow:Show()
+            listFrame:SetHeight(BLACKLIST_EMPTY_H)
+            container:SetHeight(BLACKLIST_HEADER_H + BLACKLIST_EMPTY_H)
             return
         end
 
+        local i = 0
         local yOff = 0
-        local count = 0
         for questID, questName in pairs(blacklist) do
-            count = count + 1
-            local row = CreateFrame("Frame", nil, listFrame)
-            row:SetHeight(24)
+            i = i + 1
+            local row = acquireRow(i)
+            row._questID = questID
+            local displayName = (type(questName) == "string" and questName ~= "" and questName ~= "true") and questName or ("Quest #" .. tostring(questID))
+            row.nameLbl:SetText(displayName)
+            row:ClearAllPoints()
             row:SetPoint("TOPLEFT", listFrame, "TOPLEFT", 0, yOff)
             row:SetPoint("RIGHT", listFrame, "RIGHT", 0, 0)
-
-            local nameLbl = row:CreateFontString(nil, "OVERLAY")
-            SetSafeFont(nameLbl, Def.FontPath, Def.LabelSize, nil)
-            SetTextColor(nameLbl, Def.TextColorLabel)
-            local displayName = (type(questName) == "string" and questName ~= "" and questName ~= "true") and questName or ("Quest #" .. tostring(questID))
-            nameLbl:SetText(displayName)
-            nameLbl:SetPoint("LEFT", row, "LEFT", 0, 0)
-            nameLbl:SetJustifyH("LEFT")
-
-            local unblockBtn = _G.OptionsWidgets_CreateButton(row, L["UNBLOCK"], function()
-                if addon.GetDB then
-                    local bl = addon.GetDB("questBlacklist", nil)
-                    if bl and type(bl) == "table" then
-                        bl[questID] = nil
-                        local hasAny = false
-                        for _ in pairs(bl) do hasAny = true; break end
-                        if not hasAny then bl = nil end
-                        if addon.SetDB then addon.SetDB("questBlacklist", bl) end
-                    end
-                end
-                Rebuild()
-                if addon.OptionsData_NotifyMainAddon then addon.OptionsData_NotifyMainAddon() end
-            end, { width = 70, height = 20 })
-            unblockBtn:SetPoint("RIGHT", row, "RIGHT", -4, 0)
-
-            rowWidgets[#rowWidgets + 1] = row
-            yOff = yOff - 28
+            row:Show()
+            yOff = yOff - BLACKLIST_ROW_STEP
         end
 
-        if count == 0 then
-            listFrame:SetHeight(20)
-            container:SetHeight(BLACKLIST_HEADER_H + 20)
-        else
-            listFrame:SetHeight(-yOff)
-            container:SetHeight(BLACKLIST_HEADER_H + (-yOff))
-        end
+        listFrame:SetHeight(-yOff)
+        container:SetHeight(BLACKLIST_HEADER_H + (-yOff))
     end
 
     function container:Refresh()
         Rebuild()
     end
     Rebuild()
-    local effectiveTooltip = (opts.desc or "") .. (opts.desc and opts.tooltip and "\n\n" or "") .. (opts.tooltip or "")
+    local effectiveTooltip = JoinTooltip(opts.desc, opts.tooltip)
     ApplyOptionTooltip(container, effectiveTooltip)
     return container
 end

--- a/options/OptionsWidgets.lua
+++ b/options/OptionsWidgets.lua
@@ -45,9 +45,6 @@ if addon.StandardFont then
     Def.FontPath = addon.StandardFont
 end
 
-local _activeColorPickerCallbacks = nil  -- { setKeyVal, notify, tex } when our picker is open
-local _hexBoxHooked = false
-
 function _G.OptionsWidgets_SetDef(overrides)
     if not overrides then return end
     for k, v in pairs(overrides) do Def[k] = v end
@@ -1184,104 +1181,6 @@ function _G.OptionsWidgets_CreateCustomDropdown(parent, labelText, description, 
     return row
 end
 
--- Live alpha from the open ColorPickerFrame (modern GetColorAlpha; legacy inverted GetOpacity).
-local function ResolvePickerAlpha()
-    return (type(ColorPickerFrame.GetColorAlpha) == "function" and ColorPickerFrame:GetColorAlpha())
-        or (type(ColorPickerFrame.GetOpacity) == "function" and (1 - ColorPickerFrame:GetOpacity()))
-        or 1
-end
-
--- Alpha from a "previous values" table (modern .a; legacy inverted .opacity), for cancel-restore.
-local function ResolvePrevAlpha(p)
-    return (type(p.a) == "number" and p.a)
-        or (type(p.opacity) == "number" and (1 - p.opacity))
-        or 1
-end
-
--- Parse a hex colour string ("ff0000", "#ff0000", "f00" shorthand) to r, g, b in 0-1, or nil.
-local function ParseHexColor(raw)
-    if type(raw) ~= "string" then return nil end
-    local hex = raw:gsub("^#", ""):gsub("%s+", "")
-    if #hex < 3 then return nil end
-    if #hex == 3 then hex = hex:gsub("(%x)(%x)(%x)", "%1%1%2%2%3%3") end
-    hex = hex:sub(1, 6)
-    while #hex < 6 do hex = hex .. "0" end
-    local r = tonumber(hex:sub(1, 2), 16)
-    local g = tonumber(hex:sub(3, 4), 16)
-    local b = tonumber(hex:sub(5, 6), 16)
-    if not r or not g or not b then return nil end
-    return r / 255, g / 255, b / 255
-end
-
--- Helper: get effective color from ColorPickerFrame, preferring HexBox if user typed hex (10.2.5+).
--- Returns r, g, b in 0-1 range. HexBox may contain "ff0000", "#ff0000", or "f00" (3-char shorthand).
-local function GetColorPickerEffectiveRGB()
-    if not ColorPickerFrame then return 0.5, 0.5, 0.5 end
-    local content = ColorPickerFrame.Content
-    local hexBox = content and content.HexBox
-    if hexBox and hexBox.GetText then
-        local raw = hexBox:GetText()
-        if type(raw) == "string" and #raw > 0 then
-            local r, g, b = ParseHexColor(raw)
-            if r then return r, g, b end
-        end
-    end
-    return ColorPickerFrame:GetColorRGB()
-end
-
--- Sync hex box to picker visual and apply color (live update when user types). Only runs when our picker is open.
-local function SyncHexBoxToPicker()
-    if not ColorPickerFrame:IsVisible() or not _activeColorPickerCallbacks then return end
-    local content = ColorPickerFrame.Content
-    local hexBox = content and content.HexBox
-    if not hexBox or not hexBox.GetText then return end
-    local raw = hexBox:GetText()
-    if type(raw) ~= "string" or #raw < 3 then return end
-    local r, g, b = ParseHexColor(raw)
-    if not r then return end
-    local cp = content.ColorPicker
-    local swatchCurrent = content.ColorSwatchCurrent
-    if cp and cp.SetColorRGB then cp:SetColorRGB(r, g, b) end
-    if swatchCurrent and swatchCurrent.SetColorTexture then swatchCurrent:SetColorTexture(r, g, b) end
-    local cb = _activeColorPickerCallbacks
-    if cb then
-        cb.setKeyVal({ r, g, b })
-        local texA = (cb.getAlpha and cb.getAlpha()) or 1
-        if cb.tex then cb.tex:SetColorTexture(r, g, b, texA) end
-        -- No notify during live hex typing; finishedFunc/cancelFunc will notify.
-    end
-end
-
-local function EnsureHexBoxHooked()
-    if _hexBoxHooked then return end
-    local content = ColorPickerFrame and ColorPickerFrame.Content
-    local hexBox = content and content.HexBox
-    if not hexBox or not hexBox.SetScript then return end
-    hexBox:SetScript("OnTextChanged", function()
-        SyncHexBoxToPicker()
-    end)
-    -- Hide the "hex" label inside the box (it obstructs the UI)
-    local function hideHexLabel()
-        for i = 1, select("#", hexBox:GetRegions()) do
-            local r = select(i, hexBox:GetRegions())
-            if r and r.GetText and r.Hide then
-                local t = r:GetText()
-                if t and t:lower():find("hex") then
-                    r:Hide()
-                    return
-                end
-            end
-        end
-        local hash = hexBox.Hash
-        if hash and hash.GetText and hash.Hide then
-            local ok, t = pcall(function() return hash:GetText() end)
-            if ok and t and t:lower():find("hex") then hash:Hide() end
-        end
-    end
-    hideHexLabel()
-    _hexBoxHooked = true
-end
-
 -- Color swatch row: label + clickable swatch (for colorMatrix/colorGroup in options panel).
 -- defaultTbl: {r,g,b} or nil (nil => {0.5,0.5,0.5}). getTbl() returns current color or nil. setKeyVal({r,g,b}), notify() on change.
 -- disabledFn: optional function() return boolean end; when true, greys out and disables the swatch.
@@ -1334,63 +1233,26 @@ function _G.OptionsWidgets_CreateColorSwatchRow(parent, anchor, labelText, defau
     end
     swatch:SetScript("OnClick", function()
         if disabledFn and disabledFn() then return end
-        if not ColorPickerFrame or not ColorPickerFrame.SetupColorPickerAndShow then return end
         local r, g, b, a = readColor()
-        addon._colorPickerLive = true
-        _activeColorPickerCallbacks = { setKeyVal = setKeyVal, notify = notify, tex = tex }
-        ColorPickerFrame:SetupColorPickerAndShow({
-            r = r, g = g, b = b,
-            a = hasAlpha and a or nil,
-            opacity = hasAlpha and a or nil,
-            hasOpacity = hasAlpha == true,
-            swatchFunc = function()
-                local nr, ng, nb = GetColorPickerEffectiveRGB()
-                if hasAlpha then
-                    local na = ResolvePickerAlpha()
-                    setKeyVal({ nr, ng, nb, na })
-                    tex:SetColorTexture(nr, ng, nb, na)
-                else
-                    setKeyVal({ nr, ng, nb })
-                    tex:SetColorTexture(nr, ng, nb, 1)
-                end
+        addon.OpenColorPicker({
+            r = r, g = g, b = b, a = a, hasAlpha = hasAlpha,
+            default = { def[1], def[2], def[3], def[4] },
+            onChange = function(nr, ng, nb, na)
+                -- Live drag: setKeyVal self-skips the heavy notify while _colorPickerLive is set.
+                setKeyVal(hasAlpha and { nr, ng, nb, na } or { nr, ng, nb })
+                if tex then tex:SetColorTexture(nr, ng, nb, hasAlpha and na or 1) end
             end,
-            cancelFunc = function()
-                addon._colorPickerLive = nil
-                _activeColorPickerCallbacks = nil
-                local p = ColorPickerFrame.previousValues
-                if p and type(p.r) == "number" and type(p.g) == "number" and type(p.b) == "number" then
-                    if hasAlpha then
-                        -- modern WoW stores alpha as pv.a; legacy stored inverted pv.opacity
-                        local oa = ResolvePrevAlpha(p)
-                        setKeyVal({ p.r, p.g, p.b, oa })
-                    else
-                        setKeyVal({ p.r, p.g, p.b })
-                    end
-                elseif getTbl then
-                    local res = getTbl()
-                    if type(res) == "table" and res[1] then
-                        setKeyVal(res)
-                    end
-                end
-                swatch:Refresh()
+            onConfirm = function(nr, ng, nb, na)
+                setKeyVal(hasAlpha and { nr, ng, nb, na } or { nr, ng, nb })
+                if tex then tex:SetColorTexture(nr, ng, nb, hasAlpha and na or 1) end
                 if notify then notify() end
             end,
-            finishedFunc = function()
-                addon._colorPickerLive = nil
-                _activeColorPickerCallbacks = nil
-                local nr, ng, nb = GetColorPickerEffectiveRGB()
-                if hasAlpha then
-                    local na = ResolvePickerAlpha()
-                    setKeyVal({ nr, ng, nb, na })
-                    tex:SetColorTexture(nr, ng, nb, na)
-                else
-                    setKeyVal({ nr, ng, nb })
-                    tex:SetColorTexture(nr, ng, nb, 1)
-                end
+            onCancel = function()
+                setKeyVal(hasAlpha and { r, g, b, a } or { r, g, b })
+                if tex then tex:SetColorTexture(r, g, b, hasAlpha and a or 1) end
                 if notify then notify() end
             end,
         })
-        EnsureHexBoxHooked()
     end)
     row.Refresh = function()
         swatch:Refresh()
@@ -1450,43 +1312,27 @@ function _G.OptionsWidgets_CreateMiniSwatch(parent, labelText, defaultTbl, getTb
     end
 
     swatch:SetScript("OnClick", function()
-        if not ColorPickerFrame or not ColorPickerFrame.SetupColorPickerAndShow then return end
-        local r, g, b = def[1], def[2], def[3]
-        if getTbl then
-            local result = getTbl()
-            if type(result) == "table" and result[1] then
-                r, g, b = result[1], result[2], result[3]
-            end
-        end
-        addon._colorPickerLive = true
-        _activeColorPickerCallbacks = { setKeyVal = setKeyVal, notify = notify, tex = tex }
-        ColorPickerFrame:SetupColorPickerAndShow({
-            r = r, g = g, b = b,
-            swatchFunc = function()
-                local nr, ng, nb = GetColorPickerEffectiveRGB()
+        local cur = getTbl and getTbl() or def
+        local r, g, b = cur[1] or def[1], cur[2] or def[2], cur[3] or def[3]
+        addon.OpenColorPicker({
+            r = r, g = g, b = b, hasAlpha = false,
+            default = { def[1], def[2], def[3] },
+            onChange = function(nr, ng, nb)
+                -- Live drag: setKeyVal self-skips the heavy notify while _colorPickerLive is set.
                 setKeyVal({ nr, ng, nb })
-                tex:SetColorTexture(nr, ng, nb, 1)
+                if tex then tex:SetColorTexture(nr, ng, nb, 1) end
             end,
-            cancelFunc = function()
-                addon._colorPickerLive = nil
-                _activeColorPickerCallbacks = nil
-                local p = ColorPickerFrame.previousValues
-                if p and type(p.r) == "number" then
-                    setKeyVal({ p.r, p.g, p.b })
-                end
-                swatch:Refresh()
+            onConfirm = function(nr, ng, nb)
+                setKeyVal({ nr, ng, nb })
+                if tex then tex:SetColorTexture(nr, ng, nb, 1) end
                 if notify then notify() end
             end,
-            finishedFunc = function()
-                addon._colorPickerLive = nil
-                _activeColorPickerCallbacks = nil
-                local nr, ng, nb = GetColorPickerEffectiveRGB()
-                setKeyVal({ nr, ng, nb })
-                tex:SetColorTexture(nr, ng, nb, 1)
+            onCancel = function()
+                setKeyVal({ r, g, b })
+                if tex then tex:SetColorTexture(r, g, b, 1) end
                 if notify then notify() end
             end,
         })
-        EnsureHexBoxHooked()
     end)
 
     frame.Refresh = function() swatch:Refresh() end
@@ -1543,75 +1389,23 @@ function _G.OptionsWidgets_CreateColorSwatch(parent, labelText, description, get
     swatch:SetScript("OnClick", function()
         if type(get) ~= "function" or type(set) ~= "function" then return end
         local r, g, b, a = get()
-        addon._colorPickerLive = true
-        -- Guard: swatchFunc may fire during SetupColorPickerAndShow before the
-        -- opacity slider is initialised.  Defer readiness by one frame so init
-        -- callbacks cannot overwrite the saved alpha with a stale value.
-        local pickerReady = false
-        _activeColorPickerCallbacks = {
-            setKeyVal = function(tbl)
-                -- SyncHexBoxToPicker always passes {r,g,b} with no alpha.
-                -- Preserve current alpha from get() so hex-box sync never clobbers it.
-                if type(tbl) == "table" then
-                    local _, _, _, currentA = get()
-                    set(tbl[1] or 1, tbl[2] or 1, tbl[3] or 1, currentA)
-                end
-            end,
-            getAlpha = hasAlpha and function()
-                local _, _, _, ca = get()
-                return ca or 1
-            end or nil,
-            notify = nil,
-            tex = tex,
-        }
-        local info = {
-            r = r or 1, g = g or 1, b = b or 1,
-            a = hasAlpha and (a or 1) or nil,
-            opacity = hasAlpha and (a or 1) or nil,
-            hasOpacity = hasAlpha == true,
-            swatchFunc = function()
-                if not pickerReady then return end
-                local nr, ng, nb = GetColorPickerEffectiveRGB()
-                if hasAlpha then
-                    local na = ResolvePickerAlpha()
-                    set(nr, ng, nb, na)
-                    tex:SetColorTexture(nr, ng, nb, na)
-                else
-                    set(nr, ng, nb, 1)
-                    tex:SetColorTexture(nr, ng, nb, 1)
-                end
-            end,
-            cancelFunc = function()
-                addon._colorPickerLive = nil
-                _activeColorPickerCallbacks = nil
-                local pv = ColorPickerFrame.previousValues
-                if pv and type(pv.r) == "number" and type(pv.g) == "number" and type(pv.b) == "number" then
-                    if hasAlpha then
-                        -- modern WoW stores alpha as pv.a; legacy stored inverted pv.opacity
-                        local oa = ResolvePrevAlpha(pv)
-                        set(pv.r, pv.g, pv.b, oa)
-                    else
-                        set(pv.r, pv.g, pv.b, 1)
-                    end
-                end
+        r, g, b, a = r or 1, g or 1, b or 1, a or 1
+        addon.OpenColorPicker({
+            r = r, g = g, b = b, a = a, hasAlpha = hasAlpha,
+            default = { r, g, b, a },
+            onChange = function(nr, ng, nb, na)
+                if hasAlpha then set(nr, ng, nb, na) else set(nr, ng, nb, 1) end
                 swatch:Refresh()
             end,
-            finishedFunc = function()
-                addon._colorPickerLive = nil
-                _activeColorPickerCallbacks = nil
-                local nr, ng, nb = GetColorPickerEffectiveRGB()
-                if hasAlpha then
-                    local na = ResolvePickerAlpha()
-                    set(nr, ng, nb, na)
-                else
-                    set(nr, ng, nb, 1)
-                end
+            onConfirm = function(nr, ng, nb, na)
+                if hasAlpha then set(nr, ng, nb, na) else set(nr, ng, nb, 1) end
                 swatch:Refresh()
             end,
-        }
-        ColorPickerFrame:SetupColorPickerAndShow(info)
-        EnsureHexBoxHooked()
-        C_Timer.After(0, function() pickerReady = true end)
+            onCancel = function()
+                if hasAlpha then set(r, g, b, a) else set(r, g, b, 1) end
+                swatch:Refresh()
+            end,
+        })
     end)
 
     function row:Refresh()

--- a/options/OptionsWidgets.lua
+++ b/options/OptionsWidgets.lua
@@ -706,6 +706,8 @@ local DROPDOWN_MAX_LIST_H   = 330  -- max popup list height before scrolling
 -- Inset the row hover highlight so it floats inside the rounded popup instead of bleeding to the edges.
 local DROPDOWN_HI_INSET_X   = 4
 local DROPDOWN_HI_INSET_Y   = 1
+-- Top/bottom breathing room inside the rounded popup so the first/last row clears the corners.
+local DROPDOWN_LIST_PAD     = 5
 
 -- Normalise dropdown option input (dense array of {name,value[,disabled]} or a name->value map)
 -- into a dense array, alpha-sorted unless preserveOrder (the "__global__" sentinel sorts first).
@@ -873,7 +875,9 @@ function _G.OptionsWidgets_CreateCustomDropdown(parent, labelText, description, 
         scrollFrame:SetPoint("TOPLEFT", searchEdit, "BOTTOMLEFT", 0, -4)
         scrollFrame:SetPoint("BOTTOMRIGHT", list, "BOTTOMRIGHT", -4, 4)
     else
-        scrollFrame:SetAllPoints(list)
+        -- Pad top/bottom so the first/last row (and its highlight) clears the rounded corners.
+        scrollFrame:SetPoint("TOPLEFT", list, "TOPLEFT", 0, -DROPDOWN_LIST_PAD)
+        scrollFrame:SetPoint("BOTTOMRIGHT", list, "BOTTOMRIGHT", 0, DROPDOWN_LIST_PAD)
     end
 
     local scrollChild = CreateFrame("Frame", nil, scrollFrame)
@@ -1013,7 +1017,8 @@ function _G.OptionsWidgets_CreateCustomDropdown(parent, labelText, description, 
         local totalHeight = num * rowH
 
         list:SetWidth(btn:GetWidth())
-        list:SetHeight(SEARCH_BOX_HEIGHT + math.min(totalHeight, maxHeight))
+        local listVPad = searchable and 0 or (2 * DROPDOWN_LIST_PAD)
+        list:SetHeight(SEARCH_BOX_HEIGHT + math.min(totalHeight, maxHeight) + listVPad)
         scrollChild:SetWidth(btn:GetWidth())
         scrollChild:SetHeight(math.max(totalHeight, 1))
         scrollFrame:SetVerticalScroll(0)

--- a/options/OptionsWidgets.lua
+++ b/options/OptionsWidgets.lua
@@ -140,6 +140,8 @@ local function SetSafeFont(fs, path, size, flags)
     end
     return ok
 end
+-- Exported so other options UI (e.g. HorizonColorPicker) reuses the same font registry + refresh + shadow.
+addon.OptionsWidgets_SetSafeFont = SetSafeFont
 
 local easeOut = addon.easeOut or function(t) return 1 - (1 - t) * (1 - t) end
 local TOGGLE_ANIM_DUR = 0.15


### PR DESCRIPTION
# Intent

Replace Blizzard's grey `ColorPickerFrame` with a Horizon-styled colour picker across every colour control, and overhaul the options widget layer (slider redesign, widget-library cleanup, dropdown fix, account-wide saved palette).

## Reviewer Notes

Every colour swatch in the Options panel and the Dashboard now opens a dark, Horizon-styled colour picker instead of Blizzard's grey one. It has a hue/saturation wheel + brightness bar, hex and R/G/B entry, an opacity slider, current-vs-new compare, and a swatch palette: your class colour (always available) plus a personal **saved-colours** list that's shared across all your characters — click `+` to save the current colour, hover a saved swatch and click the `×` to remove it.

Alongside that, the options **sliders** got a visual refresh (a chunky gradient bar with a square handle and hover/drag feedback), dropdown popups had a highlight-clipping fix, and a frame leak in the hidden-quests list was fixed.

## Developer Notes

- **New `options/HorizonColorPicker.lua`** — a lazy singleton built on WoW's `ColorSelect`; single entry point `addon.OpenColorPicker(spec)`. Built-in textures only (no custom assets); circular masks smooth the wheel rim + markers.
- **Saved palette** stored account-wide at `HorizonDB.customPalette` (hex-string list), independent of profiles; class colour is shown ungated.
- **`OptionsWidgets.lua`** — the three swatch builders (`CreateColorSwatch`/`Row`/`MiniSwatch`) now route through `OpenColorPicker`; the Blizzard glue (`GetColorPickerEffectiveRGB`, `SyncHexBoxToPicker`, `EnsureHexBoxHooked`, `ResolvePickerAlpha/PrevAlpha`, `_activeColorPickerCallbacks`, …) is deleted; `ParseHexColor` now lives in the picker.
- **Perf:** the picker drives `addon._colorPickerLive` so the existing option setters defer the heavy refresh during drag (runs once on OK/Cancel) — fixes drag lag.
- **Fonts:** picker text routes through the shared `SetSafeFont` registry so it tracks the dashboard font via `OptionsWidgets_RefreshFonts`; the `×` glyphs use a guaranteed font so they render with fonts lacking that character.
- **Cleanup:** slider redesign, DRY helpers (`JoinTooltip`, `readColor`, picker-alpha helpers), named constants, and a `BlacklistGrid.Rebuild` row-pooling fix (was creating—never reusing—frames every refresh; unblock now reads `row._questID`).
- `luacheck` clean (0/0) on all changed Lua. Design specs/plans live under `docs/` which is gitignored, so they're not in this PR.

## Reviewer Checklist

- [ ] Open colour swatches in the Options panel **and** the Dashboard → the Horizon picker opens (not Blizzard's grey one)
- [ ] Wheel / value / hex / R-G-B / alpha all stay in sync; **OK** applies, **Cancel/Esc/✕** restore the original, **Reset** → the option's default
- [ ] Dragging the wheel/value is **smooth** (no lag) on a real option
- [ ] Saved palette: `+` saves current colour, click applies, hover-`×` removes; persists across `/reload` and appears on a second character (account-wide); `+` hides at the cap
- [ ] Picker text matches the **dashboard font**; the close `×` and remove `×` render correctly with a non-default font
- [ ] Sliders across modules: gradient bar + square handle, hover/drag feedback, numeric box round-trips, class-colour retint
- [ ] Hidden-quests list (BlacklistGrid): unblock removes the **correct** quest; repeated refreshes don't grow the frame count
- [ ] No Lua errors opening/closing pickers and panels
