### PR TITLE
fix(insight): tooltip stuck in cursor mode when pcall returns nil

### DIFF
--- a/modules/Insight/InsightCore.lua
+++ b/modules/Insight/InsightCore.lua
@@ -1112,6 +1112,27 @@ eventFrame:SetScript("OnEvent", function(self, event, guid)
 end)
 
 -- ============================================================================
+-- STUCK-TOOLTIP FALLBACK POLL
+-- Catches cases where UPDATE_MOUSEOVER_UNIT never fires (e.g. fixed anchor,
+-- UI reload edge cases). Throttled to POLL_INTERVAL seconds; exits cheaply
+-- each frame when the tooltip is not an insight unit tooltip.
+-- ============================================================================
+
+local POLL_INTERVAL = 0.25
+local pollAccum     = 0
+local pollFrame     = CreateFrame("Frame")
+pollFrame:SetScript("OnUpdate", function(_, elapsed)
+    pollAccum = pollAccum + elapsed
+    if pollAccum < POLL_INTERVAL then return end
+    pollAccum = 0
+    if not Insight.IsInsightEnabled() then return end
+    if not TooltipPlainShown(GameTooltip) then return end
+    if not GameTooltip._insightUnitTooltip then return end
+    if SafeUnitExistsKnown("mouseover") == true then return end
+    GameTooltip:Hide()
+end)
+
+-- ============================================================================
 -- SLASH COMMANDS
 -- ============================================================================
 

--- a/modules/Insight/InsightCore.lua
+++ b/modules/Insight/InsightCore.lua
@@ -1058,13 +1058,10 @@ eventFrame:SetScript("OnEvent", function(self, event, guid)
     end
     if event == "UPDATE_MOUSEOVER_UNIT" then
         if not Insight.IsInsightEnabled() then return end
-        if SafeUnitExistsKnown("mouseover") == false
+        if SafeUnitExistsKnown("mouseover") ~= true
             and TooltipPlainShown(GameTooltip)
             and GameTooltip._insightUnitTooltip then
             C_Timer.After(0, function()
-                -- Use == true (not ~= false) so a nil return from SafeUnitExistsKnown
-                -- (pcall failed due to taint) is treated as "unit gone" rather than
-                -- "unit present" — preventing the tooltip from getting stuck in cursor mode.
                 if SafeUnitExistsKnown("mouseover") == true then return end
                 if not TooltipPlainShown(GameTooltip) then return end
                 if not GameTooltip._insightUnitTooltip then return end

--- a/modules/Insight/InsightCore.lua
+++ b/modules/Insight/InsightCore.lua
@@ -1062,7 +1062,10 @@ eventFrame:SetScript("OnEvent", function(self, event, guid)
             and TooltipPlainShown(GameTooltip)
             and GameTooltip._insightUnitTooltip then
             C_Timer.After(0, function()
-                if SafeUnitExistsKnown("mouseover") ~= false then return end
+                -- Use == true (not ~= false) so a nil return from SafeUnitExistsKnown
+                -- (pcall failed due to taint) is treated as "unit gone" rather than
+                -- "unit present" — preventing the tooltip from getting stuck in cursor mode.
+                if SafeUnitExistsKnown("mouseover") == true then return end
                 if not TooltipPlainShown(GameTooltip) then return end
                 if not GameTooltip._insightUnitTooltip then return end
                 GameTooltip:Hide()
@@ -1091,7 +1094,7 @@ eventFrame:SetScript("OnEvent", function(self, event, guid)
                     if not Insight.IsInsightEnabled() then return end
                     if not TooltipPlainShown(GameTooltip) then return end
                     if not GameTooltip._insightUnitTooltip then return end
-                    if SafeUnitExistsKnown("mouseover") ~= false then return end
+                    if SafeUnitExistsKnown("mouseover") == true then return end
                     GameTooltip:Hide()
                 end)
             end


### PR DESCRIPTION
# Intent
fix(insight): tooltip stuck on screen (cursor and fixed anchor modes)

Closes #


## Summary

Two layers now protect against the stuck tooltip:

**1. Event-driven (instant)** — `UPDATE_MOUSEOVER_UNIT` fires when the game notices the mouseover unit changed. The handler checks if the unit is gone and hides the tooltip on the next frame. This is the fast path and works most of the time.

**2. Fallback poll (every 0.25s)** — A frame running in the background re-checks every quarter-second regardless of whether the event fired. If the tooltip is still showing but the mouseover unit is gone, it hides it. This catches the cases where the event never fires or was missed.

The original bug was that both layers could be fooled by WoW taint returning `nil` instead of `true`/`false` from `SafeUnitExistsKnown`. Both now treat `nil` as "unit gone" rather than "unit present", so taint no longer leaves the tooltip stuck.


## Developer Notes

`SafeUnitExistsKnown` wraps `UnitExists` in a pcall and returns `true`, `false`, or `nil` (pcall failed).

Three fixes applied:
- **Outer** `UPDATE_MOUSEOVER_UNIT` guard: `== false` → `~= true` so `nil` (taint) also schedules the deferred hide instead of silently skipping it
- **Inner** timer guard: `~= false` → `== true` so `nil` errs toward hiding rather than staying
- **Fallback poll frame**: throttled `OnUpdate` at 0.25s interval as a backstop when the event doesn't fire at all (visible in fixed anchor mode)


## Reviewer Checklist

- [x] Hover over a world NPC or nameplate with anchor set to **Cursor** — tooltip hides cleanly when cursor leaves
- [ ] Same test with anchor set to **Fixed** — tooltip hides cleanly when cursor leaves
- [x] Rapid hover/leave across several units — no stuck tooltips
- [x] Hover a player long enough to trigger inspect, move away before inspect completes — tooltip does not stay up