### PR TITLE
Tooltip Anchor (Cursor): False 'Dynamic Position' Setting

### DIFF
--- a/modules/Focus/FocusInteractions.lua
+++ b/modules/Focus/FocusInteractions.lua
@@ -20,7 +20,7 @@ function addon.focus.AnchorTooltip(tooltip, owner)
     if owner.IsForbidden and owner:IsForbidden() then return end
 
     local insightOn = addon.Insight and addon.Insight.IsInsightEnabled and addon.Insight.IsInsightEnabled()
-    local inFixedMode = insightOn and addon.GetDB("insightAnchorMode", "cursor") == "fixed"
+    local inFixedMode = insightOn and addon.GetDB("insightAnchorMode", "fixed")
     local focusDynamicInFixed = addon.GetDB("insightFocusDynamicInFixed", false)
     if inFixedMode and not focusDynamicInFixed and addon.Insight.ApplyAnchor then
         addon.Insight.ApplyAnchor(tooltip, owner)


### PR DESCRIPTION
# Intent 

Disable `Cursor`-anchored tooltips from obeying `Fixed`-anchored setting: "Dynamic Position for Focus Tooltips".

## Reviewer Notes

On mouseover of an objective tracker entry, if `Tooltip Anchor` is set to `Cursor`,  the tooltip's `Cursor Side` should follow its Center or Left/Right Setting with their respective X/Y Offsets,

After a switch to `Fixed` anchor and `Dynamic Position for Focus Tooltips`, the tooltip remains in that position even when switched back to `Cursor` anchor.

Whether `Dynamic Position for Focus Tooltips` is on or off in `Fixed`, or any Offset is applied to a left/right `Cursor Side`, the  tooltip remains where the dynamically positioned tooltip would be.

## Developer Notes 

In `modules/Focus/FocusInteractions.lua`'s `function addon.focus.AnchorTooltip(tooltip, owner)`, a local **`inFixedMode`** variable equated a `Cursor` anchor directly to a `Fixed` anchor.

```
local inFixedMode = insightOn and addon.GetDB("insightAnchorMode", "cursor") == "fixed"
```

Removing the false equivalency to directly gather if a tooltip is anchored in the `fixed` setting solves this problem.

`addon.GetDB("insightAnchorMode", "cursor") == "fixed"` --> `addon.GetDB("insightAnchorMode", "fixed")`

## Reviewer Checklist 

(Test in **`/dev`** and **`fix/cursor-dynamic-position`** [this branch]).

- [ ] Go to: **Insight** > *Global Tooltips* > Position and set (if not already) `Tooltip Anchor` to `Cursor`
  - [ ] Hover over an objective tracker entry to determine baseline position for `Cursor` anchor.
- [ ] Set `Tooltip Anchor` to `Fixed`
  - [ ] Hover over an objective tracker entry to determine baseline position for `Fixed` anchor.
- [ ] Enable `Dynamic Position for Focus Tooltips`
  - [ ] Disable `Dynamic Position for Focus Tooltips`
    - [ ] Set `Cursor Anchor` to `Cursor`
    - [ ] Hover over an objective tracker entry and compare if it is in the same place as `Fixed` anchor.
  - [ ] Set `Cursor Anchor` to `Fixed` again.
    - [ ] Re-enable `Dynamic Position for Focus Tooltips`
      - [ ] Set `Cursor Anchor` to `Cursor`
      - [ ] Hover over an objective tracker entry and compare if it is in the same place as `Fixed` anchor.