### PR TITLE
refactor: module state init consistency + DB key naming convention foundation

### DIFF
--- a/HorizonSuite.toc
+++ b/HorizonSuite.toc
@@ -38,6 +38,7 @@ core/migrations/20260507_mplus_always_show_reset.lua
 core/migrations/20260527_cache_augment_rename.lua
 core/migrations/20260527_2_cleanup_legacy_flags.lua
 core/migrations/20260617_db_key_convention_cleanup.lua
+core/migrations/20260617_2_legacy_cleanup.lua
 modules/Focus/FocusLayoutState.lua
 core/Core.lua
 core/UrlCopyDialog.lua

--- a/HorizonSuite.toc
+++ b/HorizonSuite.toc
@@ -37,6 +37,7 @@ core/migrations/20260410_focus_click_profile.lua
 core/migrations/20260507_mplus_always_show_reset.lua
 core/migrations/20260527_cache_augment_rename.lua
 core/migrations/20260527_2_cleanup_legacy_flags.lua
+modules/Focus/FocusLayoutState.lua
 core/Core.lua
 core/UrlCopyDialog.lua
 core/ProfileIO.lua

--- a/HorizonSuite.toc
+++ b/HorizonSuite.toc
@@ -37,6 +37,7 @@ core/migrations/20260410_focus_click_profile.lua
 core/migrations/20260507_mplus_always_show_reset.lua
 core/migrations/20260527_cache_augment_rename.lua
 core/migrations/20260527_2_cleanup_legacy_flags.lua
+core/migrations/20260617_db_key_convention_cleanup.lua
 modules/Focus/FocusLayoutState.lua
 core/Core.lua
 core/UrlCopyDialog.lua

--- a/Utilities.lua
+++ b/Utilities.lua
@@ -200,7 +200,7 @@ function addon.GetTimerTextColor(remaining, duration, category, useTimerColor)
     if usePct then
         r, g, b = addon.GetTimerColorByRemainingPct(remaining, duration)
     else
-        r, g, b = addon.GetTimerColorByRemaining(remaining, duration)
+        r, g, b = addon.GetTimerColorByRemaining(remaining)
     end
     return (r or 1), (g or 0.35), (b or 0.35)
 end
@@ -208,9 +208,8 @@ end
 -- Timer color based on absolute time remaining. Used when timerColorByRemaining is on (world quests, etc.).
 -- Green when >=12h left, yellow when <12h, red when <3h.
 -- @param remaining number Seconds remaining
--- @param duration number Total duration in seconds (unused; kept for API compatibility)
 -- @return number r, number g, number b
-function addon.GetTimerColorByRemaining(remaining, duration)
+function addon.GetTimerColorByRemaining(remaining)
     if not remaining or type(remaining) ~= "number" or remaining < 0 then
         local c = addon.TIMER_URGENCY_COLORS and addon.TIMER_URGENCY_COLORS.critical or { 1, 0.35, 0.35 }
         return normalizeTimerColor(c)

--- a/core/Config.lua
+++ b/core/Config.lua
@@ -176,14 +176,35 @@ addon.QUEST_COLORS = {
     ADVENTURE  = { 0.90, 0.80, 0.50 },  -- artifact gold (WoW e6cc80; distinct from CAMPAIGN)
 }
 
+-- ============================================================================
+-- CORE-OWNED DB KEYS
+-- ============================================================================
+-- DB key convention: per-module settings are prefixed <module><Setting> in
+-- camelCase (e.g. focusShowWorldQuests, augmentMaxVisible). The keys below are
+-- the exceptions — legitimately global/core-owned, not tied to one module:
+--   - Every key in addon.AXIS_DEFAULTS (options/modules/defaults/OptionsDefaultsAxis.lua):
+--     dashboard chrome/theme, classColor<Module> tinting, <module>UIScale,
+--     globalUIScale, perModuleScaling, minimapButton*, sidebarCollapseMode,
+--     moduleNameDisplay, autoShowPatchNotesOnLogin, useGlobalFont.
+--   - rsColor / sdColor (below) — RareScanner / SilverDragon integration accent colors.
+-- fontPath is NOT in this list and is NOT a convention violation to fix later —
+-- it is an intentionally-kept legacy root-level compatibility key documented in
+-- options/OptionsData.lua, doubling as the cross-module "Global Font" fallback
+-- sentinel for Augment/Vista/Presence/Insight.
+-- This is not an exhaustive registry of all DB keys — per-module keys live in
+-- their own *_DEFAULTS table (FOCUS_DEFAULTS, AUGMENT_DEFAULTS, etc.) and are
+-- the source of truth for who owns a given key. See options/OptionsData.lua
+-- for the convention rule.
+-- ============================================================================
+
 -- Returns the effective quest color for a category, checking DB overrides first.
 -- RS and SD support user-defined colors stored as {r,g,b} tables in the DB.
 function addon.GetQuestColor(cat)
     if cat == "RARESCANNER" then
-        local c = addon.GetDB("rs_color")
+        local c = addon.GetDB("rsColor")
         if type(c) == "table" and c[1] then return c end
     elseif cat == "SILVERDRAGON" then
-        local c = addon.GetDB("sd_color")
+        local c = addon.GetDB("sdColor")
         if type(c) == "table" and c[1] then return c end
     end
     return addon.QUEST_COLORS and addon.QUEST_COLORS[cat]

--- a/core/Core.lua
+++ b/core/Core.lua
@@ -1398,15 +1398,9 @@ scrollChild:SetWidth(addon.GetPanelWidth())
 scrollChild:SetHeight(1)
 scrollChild:SetPoint("TOPLEFT", scrollFrame, "TOPLEFT", 0, 0)
 
-addon.focus = addon.focus or {}
-addon.focus.layout = addon.focus.layout or {
-    scrollOffset = 0,
-    targetHeight = addon.MIN_HEIGHT,
-    currentHeight = addon.MIN_HEIGHT,
-    sectionIdx = 0,
-}
+-- addon.focus.layout is initialised by modules/Focus/FocusLayoutState.lua (loads earlier).
+-- Reset scrollOffset unconditionally: the scrollFrame/scrollChild above were just (re)created.
 addon.focus.layout.scrollOffset = 0
-addon.focus.layout.scrollBottomOffset = addon.focus.layout.scrollBottomOffset or 0
 
 local function ApplyScrollOffset(offset)
     scrollChild:SetPoint("TOPLEFT", scrollFrame, "TOPLEFT", 0, offset)
@@ -1710,9 +1704,8 @@ HS:SetScript("OnDragStop", function(self)
     SavePanelPosition()
 end)
 
--- Hover fade: track mouse over for show-on-mouseover mode
-addon.focus = addon.focus or {}
-addon.focus.hoverFade = addon.focus.hoverFade or { mouseOver = false, fadeState = nil, fadeTime = 0 }
+-- Hover fade: track mouse over for show-on-mouseover mode.
+-- addon.focus.hoverFade is initialised by modules/Focus/FocusLayoutState.lua (loads earlier).
 HS:SetScript("OnEnter", function()
     addon.focus.hoverFade.mouseOver = true
     if addon.GetDB("showOnMouseoverOnly", false) and addon.EnsureFocusUpdateRunning then

--- a/core/migrations/20260617_2_legacy_cleanup.lua
+++ b/core/migrations/20260617_2_legacy_cleanup.lua
@@ -1,0 +1,34 @@
+-- Horizon Suite — Migration 20260617_2
+-- CRITICAL: NEVER RENAME OR MODIFY THIS FILE IN ANY FUNCTIONAL WAY
+-- Introduced: Unreleased (2026-06-17) — §5.2 dead/legacy code cleanup
+-- Two unrelated one-shot fixes bundled together (same pattern as 20260527_2):
+--
+-- 1. insightBgOpacity: very old saves stored this as a literal 0-100 value;
+--    current code always writes/reads 0-1. A runtime guard in
+--    modules/Insight/InsightShared.lua divided by 100 when the stored value
+--    was > 1. This migration does that normalisation once so the runtime
+--    guard can be deleted.
+--
+-- 2. vistaShowDefaultMinimapButtons: dead key, no longer read or written by
+--    any current code (was a routing-table entry with no backing default or
+--    consumer). Removed from existing profiles to stop it polluting saves.
+
+local addon = _G.HorizonSuite
+if not addon or not addon.RegisterMigration then return end
+
+addon.RegisterMigration({
+    id = "20260617_2",
+
+    run = function(db)
+        db.profiles = db.profiles or {}
+        for _, prof in pairs(db.profiles) do
+            if type(prof) == "table" then
+                local a = tonumber(prof.insightBgOpacity)
+                if a and a > 1 then
+                    prof.insightBgOpacity = a / 100
+                end
+                prof.vistaShowDefaultMinimapButtons = nil
+            end
+        end
+    end,
+})

--- a/core/migrations/20260617_db_key_convention_cleanup.lua
+++ b/core/migrations/20260617_db_key_convention_cleanup.lua
@@ -1,0 +1,49 @@
+-- Horizon Suite — Migration 20260617
+-- CRITICAL: NEVER RENAME OR MODIFY THIS FILE IN ANY FUNCTIONAL WAY
+-- Introduced: Unreleased (2026-06-17) — DB key naming convention foundation pass
+-- A handful of keys violated the <module><Key> camelCase convention (no module
+-- prefix, or snake_case). This is a targeted cleanup, not a full audit — see
+-- core/Config.lua's core-owned key registry and options/OptionsData.lua's
+-- convention comment for what is and isn't in scope.
+--
+-- Old keys       →  New keys (all stored per-profile)
+--   showWorldQuests →  focusShowWorldQuests   (Focus-owned, was missing its prefix)
+--   rs_color        →  rsColor                (RareScanner integration colour, snake_case)
+--   sd_color        →  sdColor                (SilverDragon integration colour, snake_case)
+--
+-- fontPath is intentionally NOT renamed here — it is a separate legacy
+-- root-level compatibility key (see options/OptionsData.lua) and a cross-module
+-- "Global Font" fallback sentinel; renaming it is out of scope for this pass.
+
+local addon = _G.HorizonSuite
+if not addon or not addon.RegisterMigration then return end
+
+addon.RegisterMigration({
+    id = "20260617",
+
+    run = function(db)
+        db.profiles = db.profiles or {}
+        for _, prof in pairs(db.profiles) do
+            if type(prof) == "table" then
+                if prof.showWorldQuests ~= nil then
+                    if prof.focusShowWorldQuests == nil then
+                        prof.focusShowWorldQuests = prof.showWorldQuests
+                    end
+                    prof.showWorldQuests = nil
+                end
+                if prof.rs_color ~= nil then
+                    if prof.rsColor == nil then
+                        prof.rsColor = prof.rs_color
+                    end
+                    prof.rs_color = nil
+                end
+                if prof.sd_color ~= nil then
+                    if prof.sdColor == nil then
+                        prof.sdColor = prof.sd_color
+                    end
+                    prof.sd_color = nil
+                end
+            end
+        end
+    end,
+})

--- a/modules/Augment/LootFrame/AugmentCore.lua
+++ b/modules/Augment/LootFrame/AugmentCore.lua
@@ -7,7 +7,7 @@ local addon = _G.HorizonSuite
 if not addon or not addon.Augment then return end
 local L = addon.L
 local Augment = addon.Augment
-local state = addon.augment
+local state = addon.Augment.state
 
 -- ============================================================================
 -- MODULE-LEVEL HELPERS

--- a/modules/Augment/LootFrame/AugmentEvents.lua
+++ b/modules/Augment/LootFrame/AugmentEvents.lua
@@ -7,7 +7,7 @@ local addon = _G.HorizonSuite
 if not addon or not addon.Augment then return end
 
 local Y = addon.Augment
-local y = addon.augment
+local y = addon.Augment.state
 
 local eventFrame
 local eventsRegistered = false

--- a/modules/Augment/LootFrame/AugmentParsing.lua
+++ b/modules/Augment/LootFrame/AugmentParsing.lua
@@ -7,7 +7,7 @@ local addon = _G.HorizonSuite
 if not addon or not addon.Augment then return end
 
 local Y = addon.Augment
-local y = addon.augment
+local y = addon.Augment.state
 
 -- Pattern tables (filled by InitPatterns)
 local selfLootPats   = {}

--- a/modules/Augment/LootFrame/AugmentSlash.lua
+++ b/modules/Augment/LootFrame/AugmentSlash.lua
@@ -7,7 +7,7 @@ local addon = _G.HorizonSuite
 if not addon or not addon.Augment or not addon.RegisterSlashHandler then return end
 
 local Y = addon.Augment
-local y = addon.augment
+local y = addon.Augment.state
 
 local HSPrint = addon.HSPrint or function(msg) print("|cFF00CCFFHorizon Suite:|r " .. tostring(msg or "")) end
 

--- a/modules/Augment/LootFrame/AugmentState.lua
+++ b/modules/Augment/LootFrame/AugmentState.lua
@@ -7,10 +7,10 @@ local addon = _G.HorizonSuite
 if not addon then return end
 
 addon.Augment = addon.Augment or {}
-addon.augment = addon.augment or {}
+addon.Augment.state = addon.Augment.state or {}
 
 local Y = addon.Augment
-local y = addon.augment
+local y = addon.Augment.state
 
 -- ============================================================================
 -- CONSTANTS
@@ -121,7 +121,7 @@ Y.REP_ICON        = "Interface\\Icons\\Achievement_Reputation_01"
 Y.UNKNOWN_ICON    = "Interface\\Icons\\INV_Misc_QuestionMark"
 
 -- ============================================================================
--- RUNTIME STATE (addon.augment)
+-- RUNTIME STATE (addon.Augment.state)
 -- ============================================================================
 
 y.pool           = y.pool or {}

--- a/modules/Focus/FocusColors.lua
+++ b/modules/Focus/FocusColors.lua
@@ -116,10 +116,10 @@ local function GetTitleColor(category)
     -- Scanner integrations store their color under a dedicated DB key separate from
     -- the color matrix, so check it first before falling through to the matrix.
     if category == "SILVERDRAGON" then
-        local c = addon.GetDB and addon.GetDB("sd_color")
+        local c = addon.GetDB and addon.GetDB("sdColor")
         if type(c) == "table" and c[1] then return c end
     elseif category == "RARESCANNER" then
-        local c = addon.GetDB and addon.GetDB("rs_color")
+        local c = addon.GetDB and addon.GetDB("rsColor")
         if type(c) == "table" and c[1] then return c end
     end
 

--- a/modules/Focus/FocusColors.lua
+++ b/modules/Focus/FocusColors.lua
@@ -129,13 +129,6 @@ local function GetTitleColor(category)
         return SanitizeColor(cm.categories[key].title, addon.QUEST_COLORS[category] or addon.QUEST_COLORS.DEFAULT)
     end
 
-    -- Legacy per-category questColors support (for safety if migration didn't run yet).
-    local db = addon.GetDB and addon.GetDB("questColors", nil)
-    if db then
-        if db[category] then return SanitizeColor(db[category], addon.QUEST_COLORS[category] or addon.QUEST_COLORS.DEFAULT) end
-        if category == "CALLING" and db.WORLD then return SanitizeColor(db.WORLD, addon.QUEST_COLORS.WORLD or addon.QUEST_COLORS.DEFAULT) end
-    end
-
     return addon.QUEST_COLORS[category] or addon.QUEST_COLORS.DEFAULT
 end
 

--- a/modules/Focus/FocusEvents.lua
+++ b/modules/Focus/FocusEvents.lua
@@ -458,7 +458,7 @@ local function OnQuestAccepted(questID)
             C_QuestLog.AddQuestWatch(questID)
         end
     end
-    if isWQ and not addon.GetDB("showWorldQuests", true) then
+    if isWQ and not addon.GetDB("focusShowWorldQuests", true) then
         addon.focus.nearbyQuestCacheDirty = true
     end
 

--- a/modules/Focus/FocusLayoutState.lua
+++ b/modules/Focus/FocusLayoutState.lua
@@ -1,0 +1,27 @@
+--[[
+    Horizon Suite - Focus - Layout State
+    Owns the initial shape of addon.focus.layout and addon.focus.hoverFade. Loaded
+    before core/Core.lua and modules/Focus/FocusState.lua so neither file needs to
+    independently create or preserve these sub-tables.
+]]
+
+local addon = _G.HorizonSuite
+
+addon.focus = addon.focus or {}
+
+addon.focus.layout = addon.focus.layout or {
+    scrollOffset = 0,
+    targetHeight = addon.MIN_HEIGHT,
+    currentHeight = addon.MIN_HEIGHT,
+    sectionIdx = 0,
+    -- Distance from the bottom of the scroll content (maxScr - scrollOffset). Used in
+    -- grow-up mode to keep the viewport pinned to the bottom (Objectives header) so
+    -- the highest-priority section stays visible across layouts. 0 = pinned to bottom.
+    scrollBottomOffset = 0,
+}
+
+addon.focus.hoverFade = addon.focus.hoverFade or {
+    mouseOver = false,
+    fadeState = nil,  -- "in" | "out" | nil
+    fadeTime  = 0,
+}

--- a/modules/Focus/FocusState.lua
+++ b/modules/Focus/FocusState.lua
@@ -5,7 +5,8 @@
 
 local addon = _G.HorizonSuite
 
--- Merge into existing addon.focus if Core created layout early; otherwise create fresh.
+-- Full-table reassignment below; carry layout/hoverFade through from FocusLayoutState.lua
+-- (loaded earlier), which owns their initial shape.
 local existing = addon.focus
 addon.focus = {
     enabled         = false,
@@ -52,22 +53,9 @@ addon.focus = {
         fadeInFromAlpha = nil,
     },
 
-    hoverFade = {
-        mouseOver = false,
-        fadeState = nil,  -- "in" | "out" | nil
-        fadeTime  = 0,
-    },
+    hoverFade = existing.hoverFade,
 
-    layout = (existing and existing.layout) or {
-        targetHeight  = addon.MIN_HEIGHT,
-        currentHeight = addon.MIN_HEIGHT,
-        sectionIdx    = 0,
-        scrollOffset  = 0,
-        -- Distance from the bottom of the scroll content (maxScr - scrollOffset). Used in
-        -- grow-up mode to keep the viewport pinned to the bottom (Objectives header) so
-        -- the highest-priority section stays visible across layouts. 0 = pinned to bottom.
-        scrollBottomOffset = 0,
-    },
+    layout = existing.layout,
 
     promotion = {
         prevWorld  = {},

--- a/modules/Focus/providers/FocusWorldQuests.lua
+++ b/modules/Focus/providers/FocusWorldQuests.lua
@@ -142,7 +142,7 @@ local function GetNearbyQuestIDs()
         return nearbySet, taskQuestOnlySet
     end
 
-    local showWQ = addon.GetDB("showWorldQuests", true)
+    local showWQ = addon.GetDB("focusShowWorldQuests", true)
     -- Track which mapIDs have already been queried via GetTaskQuestsForMap so the quest-hub
     -- fallback below cannot re-query a map already handled in the main loop.
     local queriedTaskMaps = {}

--- a/modules/Focus/rendering/FocusAggregator.lua
+++ b/modules/Focus/rendering/FocusAggregator.lua
@@ -648,7 +648,7 @@ local function ReadTrackedQuests()
     if addon.CollectWorldQuests then
         wqEntries = addon.CollectWorldQuests(ctx) or {}
     end
-    local showWorldQuests = addon.GetDB("showWorldQuests", true)
+    local showWorldQuests = addon.GetDB("focusShowWorldQuests", true)
     for _, e in ipairs(wqEntries) do
         local opts = e.opts or {}
         local isBlacklisted = (usePermanent and permanentBlacklist[e.questID]) or (not usePermanent and recentlyUntrackedWQ and recentlyUntrackedWQ[e.questID])

--- a/modules/Insight/InsightCore.lua
+++ b/modules/Insight/InsightCore.lua
@@ -856,18 +856,6 @@ function Insight.HideEmbeddedPreview()
     if globalItemMock   then globalItemMock:Hide()   end
 end
 
--- @deprecated The right-side pullout is gone; previews are embedded at the top
--- of Insight options pages. Kept as no-ops for any external callers.
-function Insight.TogglePreviewPullout() end
-function Insight.ClosePullout() end
-
--- @deprecated Prefer addon.DashboardPreview.InitDashboard; kept for callers.
-function Insight.EnsurePreviewTab(dashFrame)
-    if addon.DashboardPreview and addon.DashboardPreview.InitDashboard then
-        addon.DashboardPreview.InitDashboard(dashFrame)
-    end
-end
-
 -- ============================================================================
 -- TRP3 SUPPRESSOR
 -- ============================================================================

--- a/modules/Insight/InsightShared.lua
+++ b/modules/Insight/InsightShared.lua
@@ -394,7 +394,6 @@ function Insight.GetBackdropColor(tooltipType)
         end
     end
     local a = tonumber(addon.GetDB("insightBgOpacity", Insight.PANEL_BG[4])) or Insight.PANEL_BG[4]
-    if a > 1 then a = a / 100 end -- legacy: stored as 0-100
     return r, g, b, a
 end
 

--- a/options/OptionsData.lua
+++ b/options/OptionsData.lua
@@ -11,12 +11,28 @@ if not _G[addon.DATABASE] then _G[addon.DATABASE] = {} end
 local L = addon.L
 
 -- ---------------------------------------------------------------------------
+-- DB key naming convention: per-module settings are prefixed <module><Setting>
+-- in camelCase (e.g. focusShowWorldQuests, augmentMaxVisible). Global/core-owned
+-- keys (dashboard chrome, UI scale, minimap button, integration accent colors)
+-- are the documented exception — see the registry comment in core/Config.lua.
+-- Source of truth for "who owns this key": check the per-module *_DEFAULTS
+-- table first (FOCUS_DEFAULTS, AUGMENT_DEFAULTS, etc.), then AXIS_DEFAULTS.
+-- This is a foundation pass, not a full audit: most existing keys have not
+-- been checked against this rule yet. Outliers corrected so far (via migration
+-- core/migrations/20260617_db_key_convention_cleanup.lua): showWorldQuests ->
+-- focusShowWorldQuests, rs_color -> rsColor, sd_color -> sdColor. New keys
+-- going forward should follow the convention from the start.
+-- ---------------------------------------------------------------------------
+
+-- ---------------------------------------------------------------------------
 -- Migration: early global-font implementation used fontPath as the override key.
 -- If useGlobalFont is true but globalOverrideFontPath was never written, the saved
 -- fontPath is the old override value.  Copy it to the dedicated key.
--- fontPath is intentionally kept: it serves as the per-module "Global Font" sentinel
--- fallback (Augment, Vista, Presence, Insight all fall through to fontPath when their
--- own per-module key is "__global__" and the override is off).
+-- fontPath is intentionally kept (NOT a convention violation to fix later): it
+-- serves as the per-module "Global Font" sentinel fallback (Augment, Vista,
+-- Presence, Insight all fall through to fontPath when their own per-module key
+-- is "__global__" and the override is off), and this block is a legacy
+-- root-level compatibility shim predating the profile system.
 -- ---------------------------------------------------------------------------
 do
     local db = _G[addon.DATABASE]
@@ -46,7 +62,7 @@ end
 
 function OptionsData_SetDB(key, value)
     addon.SetDB(key, value)
-    if key == "showWorldQuests" and addon.focus and addon.focus.collapse then
+    if key == "focusShowWorldQuests" and addon.focus and addon.focus.collapse then
         if value == false then
             addon.focus.collapse.pendingWQCollapse = true
         elseif value == true then
@@ -55,7 +71,7 @@ function OptionsData_SetDB(key, value)
     end
     -- When the "Show in-zone world quests" toggle is flipped on, invalidate the nearby
     -- WQ scan augment so the next FullLayout immediately re-scans for the current zone.
-    if key == "showWorldQuests" and value == true and addon.focus then
+    if key == "focusShowWorldQuests" and value == true and addon.focus then
         addon.focus.nearbyQuestAugmentDirty = true
         addon.focus.nearbyQuestAugment = nil
         addon.focus.nearbyTaskQuestAugment = nil

--- a/options/modules/OptionsFocus.lua
+++ b/options/modules/OptionsFocus.lua
@@ -676,7 +676,7 @@ local categories = {
         moduleKey = "focus",
         options = {
             Section(L["FOCUS_WORLD_QUESTS"]),
-            Toggle(L["ZONE_WORLD_QUESTS"], L["AUTO_ADD_WQS_YOUR_CURRENT_ZONE"], "showWorldQuests", D.showWorldQuests, { tooltip = L["TRACKED_NEARBY_WQS_APPEAR_BLIZZARD_DEFAULT"] }),
+            Toggle(L["ZONE_WORLD_QUESTS"], L["AUTO_ADD_WQS_YOUR_CURRENT_ZONE"], "focusShowWorldQuests", D.focusShowWorldQuests, { tooltip = L["TRACKED_NEARBY_WQS_APPEAR_BLIZZARD_DEFAULT"] }),
             Section(L["FOCUS_RARE_BOSSES"]),
             Toggle(L["FOCUS_RARE_BOSSES"], L["UI_RARE_BOSS_VIGNETTES_LIST"], "showRareBosses", D.showRareBosses),
             Toggle(L["UI_RARE_LOOT"], L["UI_TREASURE_ITEM_VIGNETTES_RARE_LOOT"], "showRareLoot", D.showRareLoot),

--- a/options/modules/OptionsFocusIntegrations.lua
+++ b/options/modules/OptionsFocusIntegrations.lua
@@ -464,19 +464,19 @@ addon.OptionCategories[#addon.OptionCategories + 1] = {
         Color(
             L["FOCUS_INTEGRATION_RARE_COLOR"],
             L["FOCUS_INTEGRATION_RARE_COLOR_DESC"],
-            "rs_color",
+            "rsColor",
             { 0.20, 0.85, 0.75 },
             {
-                id          = "rs_color",
+                id          = "rsColor",
                 disabled    = RSDisabled,
                 visibleWhen = RSSubVisible,
                 get         = function()
-                    local c = addon.GetDB("rs_color")
+                    local c = addon.GetDB("rsColor")
                     if type(c) == "table" and c[1] then return c[1], c[2], c[3] end
                     return 0.20, 0.85, 0.75
                 end,
                 set         = function(r, g, b)
-                    setDB("rs_color", { r, g, b })
+                    setDB("rsColor", { r, g, b })
                     if addon.ScheduleRefresh then addon.ScheduleRefresh() end
                 end,
             }
@@ -784,19 +784,19 @@ addon.OptionCategories[#addon.OptionCategories + 1] = {
         Color(
             L["FOCUS_INTEGRATION_RARE_COLOR"],
             L["FOCUS_INTEGRATION_RARE_COLOR_DESC"],
-            "sd_color",
+            "sdColor",
             { 0.78, 0.87, 1.00 },
             {
-                id          = "sd_color",
+                id          = "sdColor",
                 disabled    = SDDisabled,
                 visibleWhen = SDSubVisible,
                 get         = function()
-                    local c = addon.GetDB("sd_color")
+                    local c = addon.GetDB("sdColor")
                     if type(c) == "table" and c[1] then return c[1], c[2], c[3] end
                     return 0.78, 0.87, 1.00
                 end,
                 set         = function(r, g, b)
-                    setDB("sd_color", { r, g, b })
+                    setDB("sdColor", { r, g, b })
                     if addon.ScheduleRefresh then addon.ScheduleRefresh() end
                 end,
             }

--- a/options/modules/defaults/OptionsDefaultsFocus.lua
+++ b/options/modules/defaults/OptionsDefaultsFocus.lua
@@ -225,7 +225,7 @@ addon.FOCUS_DEFAULTS = {
     showScenarioHeaderCurrenciesInTitle = true,
     cinematicScenarioBar      = true,
     -- Content types
-    showWorldQuests           = true,
+    focusShowWorldQuests      = true,
     showRareBosses            = true,
     showRareLoot              = false,
     rareNavArrowSize          = 14,

--- a/options/modules/defaults/OptionsDefaultsVista.lua
+++ b/options/modules/defaults/OptionsDefaultsVista.lua
@@ -21,7 +21,6 @@ addon.VISTA_KEYS = {
     vistaTimeUseLocal = true, vistaTime24Hour = true,
     vistaZoneDisplayMode = true,
     vistaZoneVerticalPos = true, vistaCoordVerticalPos = true, vistaTimeVerticalPos = true, vistaPerfVerticalPos = true, vistaDiffVerticalPos = true,
-    vistaShowDefaultMinimapButtons = true,  -- legacy key kept for compatibility
     vistaLock = true,
     vistaPoint = true, vistaRelPoint = true, vistaX = true, vistaY = true,
     vistaDrawerBtnX = true, vistaDrawerBtnY = true,


### PR DESCRIPTION
# Intent
Make module runtime-state initialisation consistent, and lay the foundation for a DB key naming convention.

## Reviewer Notes
- Augment had two top-level state tables (`addon.Augment` PascalCase API, `addon.augment` lowercase runtime state) with no documented distinction. The lowercase one is now `addon.Augment.state`.
- Focus had a fragile load-order dependency: `core/Core.lua` pre-populated `addon.focus.layout`/`hoverFade` before `FocusState.lua` loaded and overwrote `addon.focus` wholesale, manually preserving only `.layout`. A new `FocusLayoutState.lua` now owns both sub-tables' init, removing the cross-file coupling.
- §5.6 is a foundation pass, not a full audit of the ~300 existing DB keys: documents the `<module><Setting>` camelCase convention and the legitimately-global exceptions, and renames the three clear outliers (`showWorldQuests` → `focusShowWorldQuests`, `rs_color` → `rsColor`, `sd_color` → `sdColor`) via a migration. `fontPath` is intentionally left alone (documented legacy compatibility key).
- No behavior changes are intended — structural/naming only.

## Developer Notes
- `modules/Augment/LootFrame/{AugmentState,AugmentCore,AugmentParsing,AugmentEvents,AugmentSlash}.lua`: renamed the lowercase table reference; no other Augment mini-module touched `addon.augment`.
- `modules/Focus/FocusLayoutState.lua` (new): single guarded init for `addon.focus.layout`/`hoverFade`, loaded before `core/Core.lua` and `modules/Focus/FocusState.lua` (both updated to stop duplicating/preserving it themselves).
- `core/migrations/20260617_db_key_convention_cleanup.lua` (new): copy-then-clear rename for the three outlier keys, following the existing `20260301_classcolor_key_rename.lua` template.
- `core/Config.lua` / `options/OptionsData.lua`: added the convention rule and core-owned key registry as comments.

## Reviewer Checklist
- [x] Augment loot toasts still fire correctly (state collapse didn't break pool/animation).
- [x] Focus tracker scroll/resize still behaves normally (layout state extraction).
- [x] On an existing profile, confirm "In-Zone World Quests" toggle and RareScanner/SilverDragon colors keep their saved values after the migration runs.