### PR TITLE
refactor: remove dead/legacy code

### DIFF
--- a/HorizonSuite.toc
+++ b/HorizonSuite.toc
@@ -38,6 +38,7 @@ core/migrations/20260507_mplus_always_show_reset.lua
 core/migrations/20260527_cache_augment_rename.lua
 core/migrations/20260527_2_cleanup_legacy_flags.lua
 core/migrations/20260617_db_key_convention_cleanup.lua
+core/migrations/20260617_2_legacy_cleanup.lua
 modules/Focus/FocusLayoutState.lua
 core/Core.lua
 core/UrlCopyDialog.lua

--- a/Utilities.lua
+++ b/Utilities.lua
@@ -200,7 +200,7 @@ function addon.GetTimerTextColor(remaining, duration, category, useTimerColor)
     if usePct then
         r, g, b = addon.GetTimerColorByRemainingPct(remaining, duration)
     else
-        r, g, b = addon.GetTimerColorByRemaining(remaining, duration)
+        r, g, b = addon.GetTimerColorByRemaining(remaining)
     end
     return (r or 1), (g or 0.35), (b or 0.35)
 end
@@ -208,9 +208,8 @@ end
 -- Timer color based on absolute time remaining. Used when timerColorByRemaining is on (world quests, etc.).
 -- Green when >=12h left, yellow when <12h, red when <3h.
 -- @param remaining number Seconds remaining
--- @param duration number Total duration in seconds (unused; kept for API compatibility)
 -- @return number r, number g, number b
-function addon.GetTimerColorByRemaining(remaining, duration)
+function addon.GetTimerColorByRemaining(remaining)
     if not remaining or type(remaining) ~= "number" or remaining < 0 then
         local c = addon.TIMER_URGENCY_COLORS and addon.TIMER_URGENCY_COLORS.critical or { 1, 0.35, 0.35 }
         return normalizeTimerColor(c)

--- a/core/migrations/20260617_2_legacy_cleanup.lua
+++ b/core/migrations/20260617_2_legacy_cleanup.lua
@@ -1,0 +1,34 @@
+-- Horizon Suite — Migration 20260617_2
+-- CRITICAL: NEVER RENAME OR MODIFY THIS FILE IN ANY FUNCTIONAL WAY
+-- Introduced: Unreleased (2026-06-17) — §5.2 dead/legacy code cleanup
+-- Two unrelated one-shot fixes bundled together (same pattern as 20260527_2):
+--
+-- 1. insightBgOpacity: very old saves stored this as a literal 0-100 value;
+--    current code always writes/reads 0-1. A runtime guard in
+--    modules/Insight/InsightShared.lua divided by 100 when the stored value
+--    was > 1. This migration does that normalisation once so the runtime
+--    guard can be deleted.
+--
+-- 2. vistaShowDefaultMinimapButtons: dead key, no longer read or written by
+--    any current code (was a routing-table entry with no backing default or
+--    consumer). Removed from existing profiles to stop it polluting saves.
+
+local addon = _G.HorizonSuite
+if not addon or not addon.RegisterMigration then return end
+
+addon.RegisterMigration({
+    id = "20260617_2",
+
+    run = function(db)
+        db.profiles = db.profiles or {}
+        for _, prof in pairs(db.profiles) do
+            if type(prof) == "table" then
+                local a = tonumber(prof.insightBgOpacity)
+                if a and a > 1 then
+                    prof.insightBgOpacity = a / 100
+                end
+                prof.vistaShowDefaultMinimapButtons = nil
+            end
+        end
+    end,
+})

--- a/modules/Focus/FocusColors.lua
+++ b/modules/Focus/FocusColors.lua
@@ -129,13 +129,6 @@ local function GetTitleColor(category)
         return SanitizeColor(cm.categories[key].title, addon.QUEST_COLORS[category] or addon.QUEST_COLORS.DEFAULT)
     end
 
-    -- Legacy per-category questColors support (for safety if migration didn't run yet).
-    local db = addon.GetDB and addon.GetDB("questColors", nil)
-    if db then
-        if db[category] then return SanitizeColor(db[category], addon.QUEST_COLORS[category] or addon.QUEST_COLORS.DEFAULT) end
-        if category == "CALLING" and db.WORLD then return SanitizeColor(db.WORLD, addon.QUEST_COLORS.WORLD or addon.QUEST_COLORS.DEFAULT) end
-    end
-
     return addon.QUEST_COLORS[category] or addon.QUEST_COLORS.DEFAULT
 end
 

--- a/modules/Insight/InsightCore.lua
+++ b/modules/Insight/InsightCore.lua
@@ -856,18 +856,6 @@ function Insight.HideEmbeddedPreview()
     if globalItemMock   then globalItemMock:Hide()   end
 end
 
--- @deprecated The right-side pullout is gone; previews are embedded at the top
--- of Insight options pages. Kept as no-ops for any external callers.
-function Insight.TogglePreviewPullout() end
-function Insight.ClosePullout() end
-
--- @deprecated Prefer addon.DashboardPreview.InitDashboard; kept for callers.
-function Insight.EnsurePreviewTab(dashFrame)
-    if addon.DashboardPreview and addon.DashboardPreview.InitDashboard then
-        addon.DashboardPreview.InitDashboard(dashFrame)
-    end
-end
-
 -- ============================================================================
 -- TRP3 SUPPRESSOR
 -- ============================================================================

--- a/modules/Insight/InsightShared.lua
+++ b/modules/Insight/InsightShared.lua
@@ -394,7 +394,6 @@ function Insight.GetBackdropColor(tooltipType)
         end
     end
     local a = tonumber(addon.GetDB("insightBgOpacity", Insight.PANEL_BG[4])) or Insight.PANEL_BG[4]
-    if a > 1 then a = a / 100 end -- legacy: stored as 0-100
     return r, g, b, a
 end
 

--- a/options/modules/defaults/OptionsDefaultsVista.lua
+++ b/options/modules/defaults/OptionsDefaultsVista.lua
@@ -21,7 +21,6 @@ addon.VISTA_KEYS = {
     vistaTimeUseLocal = true, vistaTime24Hour = true,
     vistaZoneDisplayMode = true,
     vistaZoneVerticalPos = true, vistaCoordVerticalPos = true, vistaTimeVerticalPos = true, vistaPerfVerticalPos = true, vistaDiffVerticalPos = true,
-    vistaShowDefaultMinimapButtons = true,  -- legacy key kept for compatibility
     vistaLock = true,
     vistaPoint = true, vistaRelPoint = true, vistaX = true, vistaY = true,
     vistaDrawerBtnX = true, vistaDrawerBtnY = true,


### PR DESCRIPTION
# Intent
Remove code explicitly marked deprecated/legacy in its own comments but never removed.

## Reviewer Notes
- `InsightCore.lua`: three no-op/deprecated stubs (`TogglePreviewPullout`, `ClosePullout`, `EnsurePreviewTab`) deleted — confirmed zero call sites anywhere in the repo.
- `InsightShared.lua`: removed a runtime guard that divided `insightBgOpacity` by 100 if it was stored as a legacy 0-100 value. No migration ever existed for this, so a new one-shot migration normalises any old value before the guard is deleted (otherwise old saves would break).
- `FocusColors.lua`: removed a "for safety if migration didn't run yet" fallback to the legacy `questColors` DB key. Verified this is genuinely unreachable: `GetColorMatrix()` always runs `EnsureColorMatrix()` first, which already folds any legacy `questColors`/`sectionColors` data into `colorMatrix` before the fallback's own lookup would ever run.
- `OptionsDefaultsVista.lua`: removed `vistaShowDefaultMinimapButtons`, a routing-table entry with no backing default value and no reader/writer anywhere in the codebase. Cleaned out of existing profiles via the same migration.
- `Utilities.lua`: `GetTimerColorByRemaining`'s `duration` parameter was never used in the function body; removed from the signature and its one call site.
- No behavior changes are intended — all five are probably dead/unreachable, or (opacity, minimap key) safely migrated first.

## Developer Notes
- New `core/migrations/20260617_2_legacy_cleanup.lua` bundles the two changes that touch persisted DB state (opacity normalisation + dead key removal), following the same multi-fix-per-file pattern as `20260527_2_cleanup_legacy_flags.lua`.
- This is not a full sweep of every "legacy"/"deprecated" comment in the codebase — it's just six items.

## Reviewer Checklist
- [ ] On a profile with an old (pre-normalisation) `insightBgOpacity`, confirm tooltip background opacity still renders correctly after the migration runs.