### PR TITLE
fix(dashboard): drop dead moduleReloadPrompt arm from optId chain

### DIFF
--- a/options/dashboard/DashboardAccordionBuild.lua
+++ b/options/dashboard/DashboardAccordionBuild.lua
@@ -416,9 +416,15 @@ function addon.DashboardAccordionBuild_Init(f, p)
                     tinsert(currentDetailCards, currentCard)
                 end
                 
-                -- Store the option identifier to track its parent card
-                local optId = opt.dbKey or (opt.type == "presencePreview" and "presencePreview") or (opt.type == "talkingHeadPreview" and "talkingHeadPreview") or (opt.type == "moduleReloadPrompt" and "_module_reload_prompt") or (moduleSubName .. "_" .. (type(opt.name)=="function" and opt.name() or opt.name or ""):gsub("%s+", "_"))
-                currentCard.optionIds[optId] = true
+                -- Store the option identifier to track its parent card (for search-jump).
+                -- moduleReloadPrompt is excluded from search results, so skip it here.
+                local optId = opt.type ~= "moduleReloadPrompt" and (
+                    opt.dbKey
+                    or (opt.type == "presencePreview" and "presencePreview")
+                    or (opt.type == "talkingHeadPreview" and "talkingHeadPreview")
+                    or (moduleSubName .. "_" .. (type(opt.name)=="function" and opt.name() or opt.name or ""):gsub("%s+", "_"))
+                )
+                if optId then currentCard.optionIds[optId] = true end
 
                 -- Per-setting "(New!)" suffix: declared via `isNew = "<version>"`.
                 -- Display-only for now; ack-on-interaction is intentionally not wired.


### PR DESCRIPTION
# Intent
Remove the dead `moduleReloadPrompt` arm from the `optId` chain in `DashboardAccordionBuild.lua` and guard the `optionIds` write.

## Reviewer Notes
`optionIds` exists solely so the search-jump feature can find which accordion card owns a given option and scroll to it. `moduleReloadPrompt` widgets are already excluded from search results (`OptionsSearch.lua:133`), so any entry written for them under that key can never be looked up — it's dead tracking.

The removed arm also used the invented string `"_module_reload_prompt"` rather than following the `"presencePreview"` / `"talkingHeadPreview"` pattern (type name as key), and it would silently collide when multiple reload prompts land in the same card — `OptionsAxis.lua` has three.

## Developer Notes
- `currentCard.optionIds` is read in `DashboardDetailView.lua:346` to locate and expand the card containing a search result. Since `OptionsSearch.lua:133` explicitly gates out `moduleReloadPrompt`, the written key `"_module_reload_prompt"` could never be a search target.
- The `moduleReloadPrompt` widget creates a plain `Frame` with no `.Refresh` method, so it was also never stored in `detailOptionFrames` — the only other consumer of `optId`. The arm had no effect on either code path.
- Fix: negate the type check at the top of the chain and guard the write with `if optId then`, so any future search-excluded type is also covered without needing another explicit arm.

## Reviewer Checklist

- [x] Open Dashboard → Axis (Modules) options — reload prompt buttons still render and trigger `ReloadUI()`
- [ ] Open any module options page with a reload prompt — same check
- [x] Use the options search on any term — card expand and scroll-to behaviour unchanged