### PR TITLE
chore(toc): register bridge addons as optional deps

### DIFF
--- a/HorizonSuite.toc
+++ b/HorizonSuite.toc
@@ -4,7 +4,7 @@
 ## Author: Crystilac
 ## Version: 5.1.0
 ## SavedVariables: HorizonDB
-## OptionalDeps: Auctionator, IconBrowser
+## OptionalDeps: Auctionator, IconBrowser, Horizon-RareScanner, Horizon-SilverDragon
 ## IconTexture: Interface\AddOns\HorizonSuite\Docs\Branding\HorizonLogo.blp
 ## X-Curse-Project-ID: 1457844
 ## X-Wago-ID: jK8gY56y


### PR DESCRIPTION
# Intent
Register `Horizon-RareScanner` and `Horizon-SilverDragon` as optional dependencies in `HorizonSuite.toc`.


## Reviewer Notes
Adds the two new bridge addons to the `OptionalDeps` field so WoW knows to load them before Horizon Suite when they are installed. Horizon Suite continues to work normally when neither bridge addon is present.


## Developer Notes
WoW uses `OptionalDeps` to control load order without making presence mandatory. Both bridge addon repos already declare `Dependencies: HorizonSuite` on their side, so this completes the bidirectional declaration. The addon names (`Horizon-RareScanner`, `Horizon-SilverDragon`) match their respective `.toc` filenames.


## Reviewer Checklist

- [x] Confirm Horizon Suite loads without errors when both bridge addons are absent
- [x] Confirm Horizon Suite loads without errors when one or both bridge addons are present