### PR TITLE
v5.3.2 - Insight PvP tooltip secret-name fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ All notable changes to Horizon Suite are documented here.
 
 ---
 
+## [5.3.2] – 2026-07-18
+
+### 🐛 Fixes
+- **(Insight)** Player tooltips in battlegrounds and arenas no longer error when Midnight hides unit names from addons.
+
+---
+
 ## [5.3.1] – 2026-07-18
 
 ### 🐛 Fixes

--- a/HorizonSuite.toc
+++ b/HorizonSuite.toc
@@ -2,7 +2,7 @@
 ## Title: Horizon Suite
 ## Notes: Core addon with pluggable modules.
 ## Author: Crystilac
-## Version: 5.3.1
+## Version: 5.3.2
 ## SavedVariables: HorizonDB
 ## OptionalDeps: Auctionator, IconBrowser, Horizon-RareScanner, Horizon-SilverDragon
 ## IconTexture: Interface\AddOns\HorizonSuite\Docs\Branding\HorizonLogo.blp

--- a/core/PatchNotesData.lua
+++ b/core/PatchNotesData.lua
@@ -14,6 +14,16 @@ local addon = _G.HorizonSuite
 
 addon.PATCH_NOTES = {
 
+    ["5.3.2"] = {
+        date = "2026-07-18",
+        {
+            section = "Fixes",
+            bullets = {
+                "Insight: Player tooltips in battlegrounds and arenas no longer error when Midnight hides unit names from addons.",
+            },
+        },
+    },
+
     ["5.3.1"] = {
         date = "2026-07-18",
         {


### PR DESCRIPTION
Release v5.3.2

Patch release for Insight PvP/BG/arena player tooltip secret-name errors (#373).
