### PR TITLE
fix(insight): TRP3 tooltip integration without GameTooltip taint

### DIFF
--- a/modules/Insight/InsightCore.lua
+++ b/modules/Insight/InsightCore.lua
@@ -201,31 +201,6 @@ local function HookGameTooltipLifecycle()
         end
     end)
     GameTooltip:HookScript("OnHide", function(self)
-        -- TRP3 hides GameTooltip while presenting its own frame. Keep Insight
-        -- ownership so InstallTRP3Suppressor can Show() again with content intact.
-        -- Use hook-owned plain booleans only (IsShown can be secret on Midnight).
-        -- Also treat "still over a player" as TRP3-steal: Hide can run inside
-        -- TRP3 Show before TRP3's OnShow sets _trp3FrameShown.
-        if Insight._trp3ExpectGameTooltip
-            and Insight.IsInsightEnabled()
-            and addon.GetDB("insightTRP3Enabled", true)
-        then
-            if Insight._trp3FrameShown or Insight._suppressTRP3Hide then
-                return
-            end
-            local stillOverPlayer = false
-            if SafeUnitExistsKnown("mouseover") == true then
-                pcall(function()
-                    if UnitIsPlayer("mouseover") then
-                        stillOverPlayer = true
-                    end
-                end)
-            end
-            if stillOverPlayer then
-                return
-            end
-        end
-        Insight._trp3ExpectGameTooltip = false
         self._insightPlainShown = false
         self._insightUnitTooltipInstance = nil
         self._insightItemQuality = nil
@@ -416,12 +391,6 @@ local function ProcessUnitTooltip(tooltip)
         end
     end)
     tooltip._insightTooltipType = isPlayer and "player" or "npc"
-    -- Arm TRP3 restore: TRP3 may Hide GameTooltip before our Show post-hook runs.
-    if isPlayer and addon.GetDB("insightTRP3Enabled", true) then
-        Insight._trp3ExpectGameTooltip = true
-    else
-        Insight._trp3ExpectGameTooltip = false
-    end
 
     StripHealthAndPowerText(tooltip)
 
@@ -891,66 +860,91 @@ end
 -- TRP3 SUPPRESSOR
 -- ============================================================================
 
--- Hook TRP3_CharacterTooltip:Show() so that when Insight is active, TRP3's
--- own frame is suppressed and Insight's enriched GameTooltip stays visible.
--- Called once when "totalRP3" finishes loading (or at Init if already loaded).
---
--- CRITICAL: Do not replace GameTooltip.Hide with an addon closure. A permanent
--- wrapper taints every Blizzard Hide() call — Edit Mode's RefreshHudTooltip
--- calls GameTooltip_Hide() then RefreshEncounterEvents, which compares secret
--- numbers and throws LUA_WARNING (execution tainted by HorizonSuite).
---
--- Restore path (post-5.3.1): TRP3 Hide() runs OnHide which used to clear
--- _insightUnitTooltip before the Hide post-hook could re-Show. Snapshot via
--- _trp3ExpectGameTooltip (set in ProcessUnitTooltip) + _trp3FrameShown
--- (OnShow/OnHide on TRP3's frame) so OnHide skips cleanup while TRP3 steals,
--- then Show GameTooltip again after suppressing TRP3's frame.
-local function RestoreInsightGameTooltipAfterTRP3()
-    if not Insight._trp3ExpectGameTooltip then return end
-    if not Insight.IsInsightEnabled() then return end
-    if addon.GetDB and addon.GetDB("insightTRP3Enabled", true) == false then return end
-    GameTooltip._insightPlainShown = true
-    GameTooltip._insightUnitTooltip = true
-    GameTooltip:Show()
+-- TRP3's own tooltip config key controlling whether it hides the default
+-- GameTooltip (RegisterTooltip.lua → registerConfigKey("tooltip_char_HideOriginal", true)).
+local TRP3_HIDE_ORIGINAL_KEY = "tooltip_char_HideOriginal"
+
+local function TRP3ConfigReady()
+    return TRP3_API and TRP3_API.configuration
+        and TRP3_API.configuration.getValue
+        and TRP3_API.configuration.setValue
 end
 
+-- pcall: TRP3 getValue/setValue assert if the key is not registered yet
+-- (config registers during TRP3's module init, which may lag ADDON_LOADED).
+local function GetTRP3HideOriginal()
+    if not TRP3ConfigReady() then return nil end
+    local ok, value = pcall(TRP3_API.configuration.getValue, TRP3_HIDE_ORIGINAL_KEY)
+    if ok then return value end
+    return nil
+end
+
+local function SetTRP3HideOriginal(value)
+    if not TRP3ConfigReady() then return false end
+    return pcall(TRP3_API.configuration.setValue, TRP3_HIDE_ORIGINAL_KEY, value)
+end
+
+-- Align TRP3's "Hide the original tooltip" setting with our integration state.
+--
+-- We do NOT intercept GameTooltip:Hide(): assigning GameTooltip.Hide taints it
+-- for the session and makes Edit Mode (RefreshEncounterEvents) throw
+-- secret-number LUA_WARNINGs. Instead, when the integration is on we turn TRP3's
+-- own hide-original option off so TRP3 never calls GameTooltip:Hide(), and we
+-- suppress TRP3's own frame in the Show hook. The user's original value is
+-- captured once and restored when the integration is turned off / disabled.
+--- @param forceOff boolean|nil When true, restore TRP3's setting regardless of
+---   Insight state (used by Disable, which runs before the module flag flips).
+function Insight.ApplyTRP3Integration(forceOff)
+    if not Insight._trp3HookInstalled then return end
+
+    local integrationOn = not forceOff
+        and Insight.IsInsightEnabled()
+        and (not addon.GetDB or addon.GetDB("insightTRP3Enabled", true) ~= false)
+
+    if integrationOn then
+        if Insight._trp3SavedHideOriginal == nil then
+            local current = GetTRP3HideOriginal()
+            -- Only remember a genuine user value; treat our own false as unset.
+            if current ~= nil then
+                Insight._trp3SavedHideOriginal = current
+            end
+        end
+        SetTRP3HideOriginal(false)
+    elseif Insight._trp3SavedHideOriginal ~= nil then
+        SetTRP3HideOriginal(Insight._trp3SavedHideOriginal)
+        Insight._trp3SavedHideOriginal = nil
+    end
+end
+
+-- Hook TRP3_CharacterTooltip:Show() so that when Insight is active, TRP3's own
+-- frame is suppressed and Insight's enriched GameTooltip stays visible.
+-- Called once when "totalRP3" finishes loading (or at Init if already loaded).
 function Insight.InstallTRP3Suppressor()
     local trp3Tooltip = _G["TRP3_CharacterTooltip"]
     if not trp3Tooltip or Insight._trp3HookInstalled then return end
     Insight._trp3HookInstalled = true
 
-    -- Plain booleans for OnHide guard (do not read IsShown from tainted paths).
-    trp3Tooltip:HookScript("OnShow", function()
-        Insight._trp3FrameShown = true
-    end)
-    trp3Tooltip:HookScript("OnHide", function()
-        Insight._trp3FrameShown = false
-    end)
-
-    -- If TRP3 hides GameTooltip after/during its Show, re-show Insight content.
-    -- hooksecurefunc isolates taint from Blizzard callers (unlike replacing Hide).
-    hooksecurefunc(GameTooltip, "Hide", function(self)
-        if not Insight._suppressTRP3Hide then return end
-        if not Insight.IsInsightEnabled() then return end
-        Insight._suppressTRP3Hide = false
-        RestoreInsightGameTooltipAfterTRP3()
-    end)
-
     hooksecurefunc(trp3Tooltip, "Show", function(self)
         if not Insight.IsInsightEnabled() then return end
         if addon.GetDB and addon.GetDB("insightTRP3Enabled", true) == false then return end
-        -- Suppress TRP3's frame; our GameTooltip already carries TRP3 RP data.
+        -- Suppress TRP3's own frame; Insight's GameTooltip carries the RP data.
+        -- TRP3's hide-original option is forced off (see ApplyTRP3Integration),
+        -- so TRP3 does not hide GameTooltip and no tainting override is needed.
         self:Hide()
-        -- TRP3 often hides GameTooltip inside its Show() before this post-hook;
-        -- restore from the ProcessUnitTooltip snapshot (ownership flags may
-        -- already have been cleared if OnHide ran without the frame-shown guard).
-        RestoreInsightGameTooltipAfterTRP3()
-        -- Also catch a Hide() that runs just after Show returns.
-        Insight._suppressTRP3Hide = true
-        C_Timer.After(0, function()
-            Insight._suppressTRP3Hide = false
-        end)
     end)
+
+    -- TRP3's config registers during its module init, which can lag this hook;
+    -- retry a few times until the key exists, then align the setting.
+    local attempts = 0
+    local function tryApply()
+        attempts = attempts + 1
+        if GetTRP3HideOriginal() ~= nil then
+            Insight.ApplyTRP3Integration()
+        elseif attempts < 10 then
+            C_Timer.After(0.5, tryApply)
+        end
+    end
+    tryApply()
 end
 
 -- ============================================================================
@@ -986,6 +980,8 @@ function Insight.ApplyInsightOptions()
     if Insight.RefreshEmbeddedPreview then
         Insight.RefreshEmbeddedPreview()
     end
+    -- Re-align TRP3's hide-original setting when the Total RP toggle changes.
+    Insight.ApplyTRP3Integration()
     HideStyledTooltipsIfCombatSuppressionActive()
 end
 
@@ -1057,9 +1053,9 @@ end
 
 function Insight.Disable()
     addon.Log.debug("insight", "Disable")
-    Insight._trp3ExpectGameTooltip = false
-    Insight._trp3FrameShown = false
-    Insight._suppressTRP3Hide = false
+    -- Restore TRP3's original hide-original setting. Force off: OnDisable runs
+    -- before the module-enabled flag flips, so IsInsightEnabled() is still true.
+    Insight.ApplyTRP3Integration(true)
     HideAnchorFrame()
     for _, tt in ipairs(tooltipsToStyle) do
         if tt then

--- a/modules/Insight/InsightCore.lua
+++ b/modules/Insight/InsightCore.lua
@@ -201,6 +201,31 @@ local function HookGameTooltipLifecycle()
         end
     end)
     GameTooltip:HookScript("OnHide", function(self)
+        -- TRP3 hides GameTooltip while presenting its own frame. Keep Insight
+        -- ownership so InstallTRP3Suppressor can Show() again with content intact.
+        -- Use hook-owned plain booleans only (IsShown can be secret on Midnight).
+        -- Also treat "still over a player" as TRP3-steal: Hide can run inside
+        -- TRP3 Show before TRP3's OnShow sets _trp3FrameShown.
+        if Insight._trp3ExpectGameTooltip
+            and Insight.IsInsightEnabled()
+            and addon.GetDB("insightTRP3Enabled", true)
+        then
+            if Insight._trp3FrameShown or Insight._suppressTRP3Hide then
+                return
+            end
+            local stillOverPlayer = false
+            if SafeUnitExistsKnown("mouseover") == true then
+                pcall(function()
+                    if UnitIsPlayer("mouseover") then
+                        stillOverPlayer = true
+                    end
+                end)
+            end
+            if stillOverPlayer then
+                return
+            end
+        end
+        Insight._trp3ExpectGameTooltip = false
         self._insightPlainShown = false
         self._insightUnitTooltipInstance = nil
         self._insightItemQuality = nil
@@ -391,6 +416,12 @@ local function ProcessUnitTooltip(tooltip)
         end
     end)
     tooltip._insightTooltipType = isPlayer and "player" or "npc"
+    -- Arm TRP3 restore: TRP3 may Hide GameTooltip before our Show post-hook runs.
+    if isPlayer and addon.GetDB("insightTRP3Enabled", true) then
+        Insight._trp3ExpectGameTooltip = true
+    else
+        Insight._trp3ExpectGameTooltip = false
+    end
 
     StripHealthAndPowerText(tooltip)
 
@@ -868,10 +899,33 @@ end
 -- wrapper taints every Blizzard Hide() call — Edit Mode's RefreshHudTooltip
 -- calls GameTooltip_Hide() then RefreshEncounterEvents, which compares secret
 -- numbers and throws LUA_WARNING (execution tainted by HorizonSuite).
+--
+-- Restore path (post-5.3.1): TRP3 Hide() runs OnHide which used to clear
+-- _insightUnitTooltip before the Hide post-hook could re-Show. Snapshot via
+-- _trp3ExpectGameTooltip (set in ProcessUnitTooltip) + _trp3FrameShown
+-- (OnShow/OnHide on TRP3's frame) so OnHide skips cleanup while TRP3 steals,
+-- then Show GameTooltip again after suppressing TRP3's frame.
+local function RestoreInsightGameTooltipAfterTRP3()
+    if not Insight._trp3ExpectGameTooltip then return end
+    if not Insight.IsInsightEnabled() then return end
+    if addon.GetDB and addon.GetDB("insightTRP3Enabled", true) == false then return end
+    GameTooltip._insightPlainShown = true
+    GameTooltip._insightUnitTooltip = true
+    GameTooltip:Show()
+end
+
 function Insight.InstallTRP3Suppressor()
     local trp3Tooltip = _G["TRP3_CharacterTooltip"]
     if not trp3Tooltip or Insight._trp3HookInstalled then return end
     Insight._trp3HookInstalled = true
+
+    -- Plain booleans for OnHide guard (do not read IsShown from tainted paths).
+    trp3Tooltip:HookScript("OnShow", function()
+        Insight._trp3FrameShown = true
+    end)
+    trp3Tooltip:HookScript("OnHide", function()
+        Insight._trp3FrameShown = false
+    end)
 
     -- If TRP3 hides GameTooltip after/during its Show, re-show Insight content.
     -- hooksecurefunc isolates taint from Blizzard callers (unlike replacing Hide).
@@ -879,9 +933,7 @@ function Insight.InstallTRP3Suppressor()
         if not Insight._suppressTRP3Hide then return end
         if not Insight.IsInsightEnabled() then return end
         Insight._suppressTRP3Hide = false
-        if self._insightPlainShown == true or self._insightUnitTooltip then
-            self:Show()
-        end
+        RestoreInsightGameTooltipAfterTRP3()
     end)
 
     hooksecurefunc(trp3Tooltip, "Show", function(self)
@@ -890,10 +942,9 @@ function Insight.InstallTRP3Suppressor()
         -- Suppress TRP3's frame; our GameTooltip already carries TRP3 RP data.
         self:Hide()
         -- TRP3 often hides GameTooltip inside its Show() before this post-hook;
-        -- restore immediately if we still own the unit/Insight tooltip.
-        if GameTooltip._insightPlainShown == true or GameTooltip._insightUnitTooltip then
-            GameTooltip:Show()
-        end
+        -- restore from the ProcessUnitTooltip snapshot (ownership flags may
+        -- already have been cleared if OnHide ran without the frame-shown guard).
+        RestoreInsightGameTooltipAfterTRP3()
         -- Also catch a Hide() that runs just after Show returns.
         Insight._suppressTRP3Hide = true
         C_Timer.After(0, function()
@@ -1006,6 +1057,9 @@ end
 
 function Insight.Disable()
     addon.Log.debug("insight", "Disable")
+    Insight._trp3ExpectGameTooltip = false
+    Insight._trp3FrameShown = false
+    Insight._suppressTRP3Hide = false
     HideAnchorFrame()
     for _, tt in ipairs(tooltipsToStyle) do
         if tt then


### PR DESCRIPTION
# Intent

Fix the Total RP 3 integration in Insight so RP character info shows inside Horizon's tooltip **without** tainting `GameTooltip` and triggering Edit Mode secret-value warnings.

## Reviewer Notes

Previously, when Insight's "Total RP" toggle was on, Horizon replaced Blizzard's `GameTooltip.Hide` function to stop TRP3 from clearing the tooltip. That override tainted the tooltip for the whole session, which made Blizzard's Edit Mode throw `RefreshEncounterEvents` warnings blaming HorizonSuite. Turning the toggle off (5.3.1+) avoided the taint but then TRP3 users showed no tooltip at all.

This change stops fighting over the tooltip. Instead, while the integration is on, Horizon flips TRP3's own "Hide the original tooltip" setting off so TRP3 never hides `GameTooltip` in the first place. Horizon still suppresses TRP3's own separate character frame, and its enriched `GameTooltip` carries the RP data. The user's original TRP3 setting is captured once and restored when the toggle is turned off or Insight is disabled.

## Developer Notes

- Removed the `GameTooltip.Hide` override (source of the session taint) from `InstallTRP3Suppressor`.
- Added `Insight.ApplyTRP3Integration(forceOff)`: aligns TRP3's `tooltip_char_HideOriginal` config key with the integration state. Saves the user's value once, forces `false` while on, restores on off/disable. Reads/writes wrapped in `pcall` (TRP3 asserts on unregistered keys).
- `InstallTRP3Suppressor` keeps `hooksecurefunc(TRP3_CharacterTooltip, "Show", ...)` to hide TRP3's own frame (its frame, not secure — no taint), and retries applying the config until TRP3's key registers.
- Wired `ApplyTRP3Integration()` into `ApplyInsightOptions` (live toggle) and `ApplyTRP3Integration(true)` into `Disable` — force flag needed because `OnDisable` runs before the module-enabled flag flips (`HorizonSuite.lua:105-106`), so `IsInsightEnabled()` is still true there.

## Reviewer Checklist

- [ ] With TRP3 loaded and Insight's Total RP toggle **on**, hovering a TRP3 user shows their RP info inside Horizon's tooltip.
- [ ] Toggling Total RP **off** in Horizon restores normal TRP3 tooltip behavior (TRP3's own frame reappears).
- [ ] Entering **Edit Mode** produces no HorizonSuite secret-number `LUA_WARNING`s.
- [ ] Self-hover on your own character with TRP3 active shows RP info in Horizon's tooltip.
- [ ] Disabling the Insight module restores TRP3's original "Hide the original tooltip" setting.
